### PR TITLE
core: migrate Kilocode workflows to Opencode commands

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -29,6 +29,7 @@ import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
 import { ModesMigrator } from "../kilocode/modes-migrator" // kilocode_change
+import { WorkflowsMigrator } from "../kilocode/workflows-migrator" // kilocode_change
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -48,9 +49,48 @@ export namespace Config {
   export const state = Instance.state(async () => {
     const auth = await Auth.all()
 
-    // Load remote/well-known config first as the base layer (lowest precedence)
-    // This allows organizations to provide default configs that users can override
+    // kilocode_change start - Load Kilocode configs first (lowest precedence)
+    // This ensures Opencode native configs always take precedence over legacy Kilocode configs
     let result: Info = {}
+
+    // Load Kilocode custom modes (legacy fallback)
+    try {
+      const kilocodeMigration = await ModesMigrator.migrate({
+        projectDir: Instance.directory,
+      })
+      if (Object.keys(kilocodeMigration.agents).length > 0) {
+        result = mergeConfigConcatArrays(result, { agent: kilocodeMigration.agents })
+        log.debug("loaded kilocode custom modes", {
+          count: Object.keys(kilocodeMigration.agents).length,
+          modes: Object.keys(kilocodeMigration.agents),
+        })
+      }
+      for (const skipped of kilocodeMigration.skipped) {
+        log.debug("skipped kilocode mode", { slug: skipped.slug, reason: skipped.reason })
+      }
+    } catch (err) {
+      log.warn("failed to load kilocode modes", { error: err })
+    }
+
+    // Load Kilocode workflows as commands (legacy fallback)
+    try {
+      const workflowsMigration = await WorkflowsMigrator.migrate({
+        projectDir: Instance.directory,
+      })
+      if (Object.keys(workflowsMigration.commands).length > 0) {
+        result = mergeConfigConcatArrays(result, { command: workflowsMigration.commands })
+        log.debug("loaded kilocode workflows as commands", {
+          count: Object.keys(workflowsMigration.commands).length,
+          commands: Object.keys(workflowsMigration.commands),
+        })
+      }
+    } catch (err) {
+      log.warn("failed to load kilocode workflows", { error: err })
+    }
+    // kilocode_change end
+
+    // Load remote/well-known config (overrides Kilocode legacy configs)
+    // This allows organizations to provide default configs that users can override
     for (const [key, value] of Object.entries(auth)) {
       if (value.type === "wellknown") {
         process.env[value.key] = value.token
@@ -95,26 +135,6 @@ export namespace Config {
       result = mergeConfigConcatArrays(result, JSON.parse(Flag.OPENCODE_CONFIG_CONTENT))
       log.debug("loaded custom config from OPENCODE_CONFIG_CONTENT")
     }
-
-    // kilocode_change start - Load Kilocode custom modes
-    try {
-      const kilocodeMigration = await ModesMigrator.migrate({
-        projectDir: Instance.directory,
-      })
-      if (Object.keys(kilocodeMigration.agents).length > 0) {
-        result = mergeConfigConcatArrays(result, { agent: kilocodeMigration.agents })
-        log.debug("loaded kilocode custom modes", {
-          count: Object.keys(kilocodeMigration.agents).length,
-          modes: Object.keys(kilocodeMigration.agents),
-        })
-      }
-      for (const skipped of kilocodeMigration.skipped) {
-        log.debug("skipped kilocode mode", { slug: skipped.slug, reason: skipped.reason })
-      }
-    } catch (err) {
-      log.warn("failed to load kilocode modes", { error: err })
-    }
-    // kilocode_change end
 
     result.agent = result.agent || {}
     result.mode = result.mode || {}

--- a/packages/opencode/src/kilocode/index.ts
+++ b/packages/opencode/src/kilocode/index.ts
@@ -1,2 +1,3 @@
 export { ModesMigrator } from "./modes-migrator"
+export { WorkflowsMigrator } from "./workflows-migrator"
 export { KilocodeConfigInjector } from "./config-injector"

--- a/packages/opencode/src/kilocode/workflows-migrator.ts
+++ b/packages/opencode/src/kilocode/workflows-migrator.ts
@@ -1,0 +1,143 @@
+// kilocode_change - new file
+
+import * as fs from "fs/promises"
+import * as path from "path"
+import os from "os"
+import type { Config } from "../config/config"
+
+export namespace WorkflowsMigrator {
+  const KILOCODE_WORKFLOWS_DIR = ".kilocode/workflows"
+  const GLOBAL_WORKFLOWS_DIR = path.join(os.homedir(), ".kilocode", "workflows")
+
+  // Get platform-specific VSCode global storage path (same as modes-migrator)
+  function getVSCodeGlobalStoragePath(): string {
+    const home = os.homedir()
+    switch (process.platform) {
+      case "darwin":
+        return path.join(home, "Library", "Application Support", "Code", "User", "globalStorage", "kilocode.kilo-code")
+      case "win32":
+        return path.join(process.env.APPDATA || path.join(home, "AppData", "Roaming"), "Code", "User", "globalStorage", "kilocode.kilo-code")
+      default: // linux
+        return path.join(home, ".config", "Code", "User", "globalStorage", "kilocode.kilo-code")
+    }
+  }
+
+  export interface KilocodeWorkflow {
+    name: string
+    path: string
+    content: string
+    source: "global" | "project"
+  }
+
+  export interface MigrationResult {
+    commands: Record<string, Config.Command>
+    warnings: string[]
+  }
+
+  async function directoryExists(dirPath: string): Promise<boolean> {
+    const stat = await fs.stat(dirPath).catch(() => null)
+    return stat?.isDirectory() ?? false
+  }
+
+  async function findWorkflowFiles(dir: string): Promise<string[]> {
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    return entries.filter((e) => e.isFile() && e.name.endsWith(".md")).map((e) => path.join(dir, e.name))
+  }
+
+  export function extractNameFromFilename(filename: string): string {
+    return path.basename(filename, ".md")
+  }
+
+  export function extractDescription(content: string): string | undefined {
+    const lines = content.split("\n")
+    let foundTitle = false
+
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (trimmed.startsWith("#")) {
+        foundTitle = true
+        continue
+      }
+      if (foundTitle && trimmed.length > 0) {
+        return trimmed.slice(0, 200)
+      }
+    }
+    return undefined
+  }
+
+  async function loadWorkflowsFromDir(dir: string, source: "global" | "project"): Promise<KilocodeWorkflow[]> {
+    if (!(await directoryExists(dir))) return []
+    const files = await findWorkflowFiles(dir)
+    const workflows: KilocodeWorkflow[] = []
+    for (const file of files) {
+      const content = await fs.readFile(file, "utf-8")
+      workflows.push({
+        name: extractNameFromFilename(file),
+        path: file,
+        content: content.trim(),
+        source,
+      })
+    }
+    return workflows
+  }
+
+  export async function discoverWorkflows(projectDir: string, skipGlobalPaths?: boolean): Promise<KilocodeWorkflow[]> {
+    const workflows: KilocodeWorkflow[] = []
+
+    if (!skipGlobalPaths) {
+      // 1. VSCode extension global storage (primary location for global workflows)
+      const vscodeWorkflowsDir = path.join(getVSCodeGlobalStoragePath(), "workflows")
+      workflows.push(...(await loadWorkflowsFromDir(vscodeWorkflowsDir, "global")))
+
+      // 2. Home directory ~/.kilocode/workflows (fallback/alternative location)
+      workflows.push(...(await loadWorkflowsFromDir(GLOBAL_WORKFLOWS_DIR, "global")))
+    }
+
+    // 3. Project workflows (.kilocode/workflows/)
+    const projectWorkflowsDir = path.join(projectDir, KILOCODE_WORKFLOWS_DIR)
+    workflows.push(...(await loadWorkflowsFromDir(projectWorkflowsDir, "project")))
+
+    return workflows
+  }
+
+  export function convertToCommand(workflow: KilocodeWorkflow): Config.Command {
+    return {
+      template: workflow.content,
+      description: extractDescription(workflow.content) ?? `Workflow: ${workflow.name}`,
+    }
+  }
+
+  export async function migrate(options: {
+    projectDir: string
+    /** Skip reading from global paths. Used for testing. */
+    skipGlobalPaths?: boolean
+  }): Promise<MigrationResult> {
+    const warnings: string[] = []
+    const commands: Record<string, Config.Command> = {}
+
+    const workflows = await discoverWorkflows(options.projectDir, options.skipGlobalPaths)
+
+    // Deduplicate by name (project takes precedence over global)
+    const workflowsByName = new Map<string, KilocodeWorkflow>()
+
+    // Add global first
+    for (const workflow of workflows.filter((w) => w.source === "global")) {
+      workflowsByName.set(workflow.name, workflow)
+    }
+
+    // Project overwrites global
+    for (const workflow of workflows.filter((w) => w.source === "project")) {
+      if (workflowsByName.has(workflow.name)) {
+        warnings.push(`Project workflow '${workflow.name}' overrides global workflow`)
+      }
+      workflowsByName.set(workflow.name, workflow)
+    }
+
+    // Convert to commands
+    for (const [name, workflow] of workflowsByName) {
+      commands[name] = convertToCommand(workflow)
+    }
+
+    return { commands, warnings }
+  }
+}

--- a/packages/opencode/test/kilocode/config-injector.test.ts
+++ b/packages/opencode/test/kilocode/config-injector.test.ts
@@ -59,6 +59,54 @@ describe("KilocodeConfigInjector", () => {
       expect(result.warnings[0]).toContain("code")
       expect(result.warnings[0]).toContain("skipped")
     })
+
+    test("includes workflows as commands in config", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const workflowsDir = path.join(dir, ".kilocode", "workflows")
+          await Bun.write(
+            path.join(workflowsDir, "code-review.md"),
+            "# Code Review\n\nPerform a code review.\n\n## Steps\n\n1. Review",
+          )
+        },
+      })
+
+      const result = await KilocodeConfigInjector.buildConfig({ projectDir: tmp.path, skipGlobalPaths: true })
+      const config = JSON.parse(result.configJson)
+
+      expect(config.command).toBeDefined()
+      expect(config.command["code-review"]).toBeDefined()
+      expect(config.command["code-review"].template).toContain("# Code Review")
+      expect(config.command["code-review"].description).toBe("Perform a code review.")
+    })
+
+    test("includes both modes and workflows in config", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          // Add a custom mode
+          await Bun.write(
+            path.join(dir, ".kilocodemodes"),
+            `customModes:
+  - slug: translate
+    name: Translate
+    roleDefinition: You are a translator
+    groups:
+      - read`,
+          )
+          // Add a workflow
+          const workflowsDir = path.join(dir, ".kilocode", "workflows")
+          await Bun.write(path.join(workflowsDir, "deploy.md"), "# Deploy\n\nDeploy the app.")
+        },
+      })
+
+      const result = await KilocodeConfigInjector.buildConfig({ projectDir: tmp.path, skipGlobalPaths: true })
+      const config = JSON.parse(result.configJson)
+
+      expect(config.agent).toBeDefined()
+      expect(config.agent.translate).toBeDefined()
+      expect(config.command).toBeDefined()
+      expect(config.command["deploy"]).toBeDefined()
+    })
   })
 
   describe("getEnvVars", () => {

--- a/packages/opencode/test/kilocode/workflows-migrator.test.ts
+++ b/packages/opencode/test/kilocode/workflows-migrator.test.ts
@@ -1,0 +1,197 @@
+import { test, expect, describe } from "bun:test"
+import { WorkflowsMigrator } from "../../src/kilocode/workflows-migrator"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+describe("WorkflowsMigrator", () => {
+  describe("extractNameFromFilename", () => {
+    test("extracts name from simple filename", () => {
+      expect(WorkflowsMigrator.extractNameFromFilename("code-review.md")).toBe("code-review")
+    })
+
+    test("extracts name from path", () => {
+      expect(WorkflowsMigrator.extractNameFromFilename("/path/to/my-workflow.md")).toBe("my-workflow")
+    })
+
+    test("handles filename without extension", () => {
+      expect(WorkflowsMigrator.extractNameFromFilename("workflow")).toBe("workflow")
+    })
+  })
+
+  describe("extractDescription", () => {
+    test("extracts description from first paragraph after title", () => {
+      const content = `# My Workflow
+
+This is the description of the workflow.
+
+## Steps
+
+1. Do something`
+
+      expect(WorkflowsMigrator.extractDescription(content)).toBe("This is the description of the workflow.")
+    })
+
+    test("returns undefined when no description found", () => {
+      const content = `# My Workflow`
+      expect(WorkflowsMigrator.extractDescription(content)).toBeUndefined()
+    })
+
+    test("limits description to 200 characters", () => {
+      const longDescription = "A".repeat(300)
+      const content = `# Title
+
+${longDescription}`
+
+      const result = WorkflowsMigrator.extractDescription(content)
+      expect(result?.length).toBe(200)
+    })
+
+    test("skips empty lines after title", () => {
+      const content = `# Title
+
+
+Actual description here.`
+
+      expect(WorkflowsMigrator.extractDescription(content)).toBe("Actual description here.")
+    })
+  })
+
+  describe("discoverWorkflows", () => {
+    test("discovers project workflows", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const workflowsDir = path.join(dir, ".kilocode", "workflows")
+          await Bun.write(path.join(workflowsDir, "test-workflow.md"), "# Test\n\nDescription")
+        },
+      })
+
+      const workflows = await WorkflowsMigrator.discoverWorkflows(tmp.path, true)
+
+      expect(workflows).toHaveLength(1)
+      expect(workflows[0].name).toBe("test-workflow")
+      expect(workflows[0].source).toBe("project")
+    })
+
+    test("returns empty array when no workflows directory exists", async () => {
+      await using tmp = await tmpdir()
+
+      const workflows = await WorkflowsMigrator.discoverWorkflows(tmp.path, true)
+
+      expect(workflows).toHaveLength(0)
+    })
+
+    test("only discovers .md files", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const workflowsDir = path.join(dir, ".kilocode", "workflows")
+          await Bun.write(path.join(workflowsDir, "workflow.md"), "# Workflow")
+          await Bun.write(path.join(workflowsDir, "readme.txt"), "Not a workflow")
+          await Bun.write(path.join(workflowsDir, "config.json"), "{}")
+        },
+      })
+
+      const workflows = await WorkflowsMigrator.discoverWorkflows(tmp.path, true)
+
+      expect(workflows).toHaveLength(1)
+      expect(workflows[0].name).toBe("workflow")
+    })
+  })
+
+  describe("convertToCommand", () => {
+    test("converts workflow to command format", () => {
+      const workflow: WorkflowsMigrator.KilocodeWorkflow = {
+        name: "code-review",
+        path: "/path/to/code-review.md",
+        content: "# Code Review\n\nReview the code changes.\n\n## Steps\n\n1. Check",
+        source: "project",
+      }
+
+      const command = WorkflowsMigrator.convertToCommand(workflow)
+
+      expect(command.template).toBe(workflow.content)
+      expect(command.description).toBe("Review the code changes.")
+    })
+
+    test("uses fallback description when none found", () => {
+      const workflow: WorkflowsMigrator.KilocodeWorkflow = {
+        name: "simple",
+        path: "/path/to/simple.md",
+        content: "# Simple",
+        source: "project",
+      }
+
+      const command = WorkflowsMigrator.convertToCommand(workflow)
+
+      expect(command.description).toBe("Workflow: simple")
+    })
+  })
+
+  describe("migrate", () => {
+    test("migrates project workflows to commands", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const workflowsDir = path.join(dir, ".kilocode", "workflows")
+          await Bun.write(
+            path.join(workflowsDir, "code-review.md"),
+            "# Code Review\n\nPerform a code review.\n\n## Steps\n\n1. Review",
+          )
+        },
+      })
+
+      const result = await WorkflowsMigrator.migrate({ projectDir: tmp.path, skipGlobalPaths: true })
+
+      expect(Object.keys(result.commands)).toHaveLength(1)
+      expect(result.commands["code-review"]).toBeDefined()
+      expect(result.commands["code-review"].template).toContain("# Code Review")
+      expect(result.commands["code-review"].description).toBe("Perform a code review.")
+    })
+
+    test("returns empty commands when no workflows exist", async () => {
+      await using tmp = await tmpdir()
+
+      const result = await WorkflowsMigrator.migrate({ projectDir: tmp.path, skipGlobalPaths: true })
+
+      expect(Object.keys(result.commands)).toHaveLength(0)
+      expect(result.warnings).toHaveLength(0)
+    })
+
+    test("migrates multiple workflows", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const workflowsDir = path.join(dir, ".kilocode", "workflows")
+          await Bun.write(path.join(workflowsDir, "review.md"), "# Review\n\nReview code")
+          await Bun.write(path.join(workflowsDir, "deploy.md"), "# Deploy\n\nDeploy app")
+        },
+      })
+
+      const result = await WorkflowsMigrator.migrate({ projectDir: tmp.path, skipGlobalPaths: true })
+
+      expect(Object.keys(result.commands)).toHaveLength(2)
+      expect(result.commands["review"]).toBeDefined()
+      expect(result.commands["deploy"]).toBeDefined()
+    })
+
+    test("project workflows override global workflows with same name", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          // Create a "global" directory to simulate global workflows
+          const globalDir = path.join(dir, "global-workflows")
+          await Bun.write(path.join(globalDir, "shared.md"), "# Shared\n\nGlobal version")
+
+          // Create project workflows
+          const projectDir = path.join(dir, ".kilocode", "workflows")
+          await Bun.write(path.join(projectDir, "shared.md"), "# Shared\n\nProject version")
+
+          return globalDir
+        },
+      })
+
+      // Note: We can't easily test global workflow override without mocking the home directory
+      // This test verifies the deduplication logic works for project workflows
+      const result = await WorkflowsMigrator.migrate({ projectDir: tmp.path, skipGlobalPaths: true })
+
+      expect(Object.keys(result.commands)).toHaveLength(1)
+      expect(result.commands["shared"].template).toContain("Project version")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This PR implements Phase 3 of the Kilocode to Opencode config migration - Workflows Migration. It automatically discovers Kilocode workflow files and converts them to Opencode slash commands at runtime.

## Changes

- Add `WorkflowsMigrator` to discover and convert Kilocode workflows
- Load workflows from VSCode global storage, `~/.kilocode/workflows/`, and `.kilocode/workflows/`
- Convert workflows to Opencode Command format with template and description
- Load Kilocode configs first (lowest precedence) so Opencode configs always win
- Update config-injector for VSCode extension env var injection
- Add 16 unit tests for workflows-migrator
- Add 2 integration tests for config-injector

## Workflow Discovery Locations

Workflows are discovered from (in order):
1. VSCode extension storage (platform-specific)
2. `~/.kilocode/workflows/` (global)
3. `.kilocode/workflows/` (project)

## Config Loading Order (lowest to highest precedence)

1. Kilocode legacy configs (modes + workflows)
2. Remote/well-known config
3. Global user config
4. Custom config path
5. Project config (opencode.json)
6. OPENCODE_CONFIG_CONTENT env var

## Testing

- 16 unit tests for workflows-migrator covering all public functions
- 2 integration tests for config-injector
- Manual testing with real workflow files

## Related

- Phase 1 (Modes) - ✅ MERGED
- Phase 2 (Rules) - 📋 Planned
- Phase 4 (MCP) - 📋 Planned