### PR TITLE
chore: disable OpenCode-specific GitHub Actions for kilo-cli fork

### DIFF
--- a/.github/workflows/daily-issues-recap.yml
+++ b/.github/workflows/daily-issues-recap.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   daily-recap:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode Discord integration)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/daily-pr-recap.yml
+++ b/.github/workflows/daily-pr-recap.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   pr-recap:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode Discord integration)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   deploy:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode infrastructure deployment)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -10,7 +10,9 @@ env:
 
 jobs:
   update-docs:
-    if: github.repository == 'sst/opencode'
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode docs automation)
+    if: false
+    # kilocode_change end - original: if: github.repository == 'sst/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   check-duplicates:
+    # kilocode_change start - disabled for kilo-cli fork (requires OpenCode API key and install)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -6,17 +6,21 @@ on:
 
 jobs:
   check-duplicates:
-    if: |
-      github.event.pull_request.user.login != 'actions-user' &&
-      github.event.pull_request.user.login != 'opencode' &&
-      github.event.pull_request.user.login != 'rekram1-node' &&
-      github.event.pull_request.user.login != 'thdxr' &&
-      github.event.pull_request.user.login != 'kommander' &&
-      github.event.pull_request.user.login != 'jayair' &&
-      github.event.pull_request.user.login != 'fwang' &&
-      github.event.pull_request.user.login != 'adamdotdevin' &&
-      github.event.pull_request.user.login != 'iamdavidhill' &&
-      github.event.pull_request.user.login != 'opencode-agent[bot]'
+    # kilocode_change start - disabled for kilo-cli fork (requires OpenCode API key and install)
+    if: false
+    # kilocode_change end
+    # Original condition with OpenCode maintainer allowlist:
+    # if: |
+    #   github.event.pull_request.user.login != 'actions-user' &&
+    #   github.event.pull_request.user.login != 'opencode' &&
+    #   github.event.pull_request.user.login != 'rekram1-node' &&
+    #   github.event.pull_request.user.login != 'thdxr' &&
+    #   github.event.pull_request.user.login != 'kommander' &&
+    #   github.event.pull_request.user.login != 'jayair' &&
+    #   github.event.pull_request.user.login != 'fwang' &&
+    #   github.event.pull_request.user.login != 'adamdotdevin' &&
+    #   github.event.pull_request.user.login != 'iamdavidhill' &&
+    #   github.event.pull_request.user.login != 'opencode-agent[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   notify:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode Discord notifications)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Send nicely-formatted embed to Discord

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,11 +8,15 @@ on:
 
 jobs:
   opencode:
-    if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode bot commands)
+    if: false
+    # kilocode_change end
+    # Original condition:
+    # if: |
+    #   contains(github.event.comment.body, ' /oc') ||
+    #   startsWith(github.event.comment.body, '/oc') ||
+    #   contains(github.event.comment.body, ' /opencode') ||
+    #   startsWith(github.event.comment.body, '/opencode')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -6,17 +6,21 @@ on:
 
 jobs:
   check-standards:
-    if: |
-      github.event.pull_request.user.login != 'actions-user' &&
-      github.event.pull_request.user.login != 'opencode' &&
-      github.event.pull_request.user.login != 'rekram1-node' &&
-      github.event.pull_request.user.login != 'thdxr' &&
-      github.event.pull_request.user.login != 'kommander' &&
-      github.event.pull_request.user.login != 'jayair' &&
-      github.event.pull_request.user.login != 'fwang' &&
-      github.event.pull_request.user.login != 'adamdotdevin' &&
-      github.event.pull_request.user.login != 'iamdavidhill' &&
-      github.event.pull_request.user.login != 'opencode-agent[bot]'
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode maintainer allowlist)
+    if: false
+    # kilocode_change end
+    # Original condition with OpenCode maintainer allowlist:
+    # if: |
+    #   github.event.pull_request.user.login != 'actions-user' &&
+    #   github.event.pull_request.user.login != 'opencode' &&
+    #   github.event.pull_request.user.login != 'rekram1-node' &&
+    #   github.event.pull_request.user.login != 'thdxr' &&
+    #   github.event.pull_request.user.login != 'kommander' &&
+    #   github.event.pull_request.user.login != 'jayair' &&
+    #   github.event.pull_request.user.login != 'fwang' &&
+    #   github.event.pull_request.user.login != 'adamdotdevin' &&
+    #   github.event.pull_request.user.login != 'iamdavidhill' &&
+    #   github.event.pull_request.user.login != 'opencode-agent[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/publish-github-action.yml
+++ b/.github/workflows/publish-github-action.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   publish:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode GitHub Action publishing)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   publish:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode VSCode extension publishing)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,9 @@ permissions:
 jobs:
   publish:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: github.repository == 'anomalyco/opencode'
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode npm/AUR publishing)
+    if: false
+    # kilocode_change end - original: if: github.repository == 'anomalyco/opencode'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   release:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode GitHub Action release)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,10 +6,14 @@ on:
 
 jobs:
   check-guidelines:
-    if: |
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/review') &&
-      contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
+    # kilocode_change start - disabled for kilo-cli fork (requires OpenCode install and API keys)
+    if: false
+    # kilocode_change end
+    # Original condition:
+    # if: |
+    #   github.event.issue.pull_request &&
+    #   startsWith(github.event.comment.body, '/review') &&
+    #   contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -9,7 +9,9 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   stats:
-    if: github.repository == 'anomalyco/opencode'
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode stats tracking)
+    if: false
+    # kilocode_change end - original: if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write

--- a/.github/workflows/sync-zed-extension.yml
+++ b/.github/workflows/sync-zed-extension.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   zed:
+    # kilocode_change start - disabled for kilo-cli fork (OpenCode Zed extension sync)
+    if: false
+    # kilocode_change end
     name: Release Zed Extension
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   triage:
+    # kilocode_change start - disabled for kilo-cli fork (requires OpenCode API key and install)
+    if: false
+    # kilocode_change end
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Disables 17 GitHub Actions workflows that are specific to the upstream OpenCode repository and won't work in the kilo-cli fork.

## Changes

All disabled workflows use the `kilocode_change` marker pattern for easy upstream merging:
```yaml
# kilocode_change start - disabled for kilo-cli fork (reason)
if: false
# kilocode_change end
```

### Disabled Workflows

#### OpenCode Infrastructure (12 workflows)
| File | Reason |
|------|--------|
| `daily-issues-recap.yml` | OpenCode Discord integration |
| `daily-pr-recap.yml` | OpenCode Discord integration |
| `deploy.yml` | OpenCode infrastructure deployment |
| `docs-update.yml` | OpenCode docs automation |
| `notify-discord.yml` | OpenCode Discord notifications |
| `opencode.yml` | OpenCode bot commands |
| `publish.yml` | OpenCode npm/AUR publishing |
| `publish-github-action.yml` | OpenCode GitHub Action |
| `publish-vscode.yml` | OpenCode VSCode extension |
| `release-github-action.yml` | OpenCode GitHub Action release |
| `stats.yml` | OpenCode stats tracking |
| `sync-zed-extension.yml` | OpenCode Zed extension sync |

#### AI-Powered Workflows (5 workflows)
| File | Reason |
|------|--------|
| `duplicate-issues.yml` | Requires OpenCode API key |
| `duplicate-prs.yml` | Requires OpenCode API key + maintainer list |
| `pr-standards.yml` | OpenCode maintainer allowlist |
| `review.yml` | Requires OpenCode install + API keys |
| `triage.yml` | Requires OpenCode API key |

### Kept Active (6 workflows)
These generic CI/CD workflows remain active:
- `test.yml` - Core testing
- `typecheck.yml` - TypeScript checking
- `generate.yml` - Code generation
- `nix-desktop.yml` - Nix builds
- `update-nix-hashes.yml` - Nix maintenance
- `stale-issues.yml` - Auto-close stale issues

## Analysis Document

See `plans/github-actions-analysis.md` for the full analysis.