### PR TITLE
feat: add recommended models for Kilo Gateway provider selection

### DIFF
--- a/packages/app/src/components/dialog-manage-models.tsx
+++ b/packages/app/src/components/dialog-manage-models.tsx
@@ -3,7 +3,7 @@ import { List } from "@opencode-ai/ui/list"
 import { Switch } from "@opencode-ai/ui/switch"
 import type { Component } from "solid-js"
 import { useLocal } from "@/context/local"
-import { popularProviders } from "@/hooks/use-providers"
+import { preferredProviders } from "@/hooks/use-providers"
 import { useLanguage } from "@/context/language"
 
 export const DialogManageModels: Component = () => {
@@ -22,9 +22,9 @@ export const DialogManageModels: Component = () => {
         sortGroupsBy={(a, b) => {
           const aProvider = a.items[0].provider.id
           const bProvider = b.items[0].provider.id
-          if (popularProviders.includes(aProvider) && !popularProviders.includes(bProvider)) return -1
-          if (!popularProviders.includes(aProvider) && popularProviders.includes(bProvider)) return 1
-          return popularProviders.indexOf(aProvider) - popularProviders.indexOf(bProvider)
+          if (preferredProviders.includes(aProvider) && !preferredProviders.includes(bProvider)) return -1
+          if (!preferredProviders.includes(aProvider) && preferredProviders.includes(bProvider)) return 1
+          return preferredProviders.indexOf(aProvider) - preferredProviders.indexOf(bProvider)
         }}
         onSelect={(x) => {
           if (!x) return

--- a/packages/app/src/components/dialog-select-model-unpaid.tsx
+++ b/packages/app/src/components/dialog-select-model-unpaid.tsx
@@ -8,7 +8,7 @@ import { Tag } from "@opencode-ai/ui/tag"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { type Component, onCleanup, onMount, Show } from "solid-js"
 import { useLocal } from "@/context/local"
-import { popularProviders, useProviders } from "@/hooks/use-providers"
+import { preferredProviders, useProviders } from "@/hooks/use-providers"
 import { DialogConnectProvider } from "./dialog-connect-provider"
 import { DialogSelectProvider } from "./dialog-select-provider"
 import { ModelTooltip } from "./model-tooltip"
@@ -87,11 +87,11 @@ export const DialogSelectModelUnpaid: Component = () => {
               <List
                 class="w-full px-0"
                 key={(x) => x?.id}
-                items={providers.popular}
+                items={providers.preferred}
                 activeIcon="plus-small"
                 sortBy={(a, b) => {
-                  if (popularProviders.includes(a.id) && popularProviders.includes(b.id))
-                    return popularProviders.indexOf(a.id) - popularProviders.indexOf(b.id)
+                  if (preferredProviders.includes(a.id) && preferredProviders.includes(b.id))
+                    return preferredProviders.indexOf(a.id) - preferredProviders.indexOf(b.id)
                   return a.name.localeCompare(b.name)
                 }}
                 onSelect={(x) => {

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -3,7 +3,7 @@ import { Component, ComponentProps, createEffect, createMemo, JSX, onCleanup, Sh
 import { createStore } from "solid-js/store"
 import { useLocal } from "@/context/local"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { popularProviders } from "@/hooks/use-providers"
+import { preferredProviders } from "@/hooks/use-providers"
 import { Button } from "@opencode-ai/ui/button"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tag } from "@opencode-ai/ui/tag"
@@ -45,9 +45,9 @@ const ModelList: Component<{
       sortGroupsBy={(a, b) => {
         const aProvider = a.items[0].provider.id
         const bProvider = b.items[0].provider.id
-        if (popularProviders.includes(aProvider) && !popularProviders.includes(bProvider)) return -1
-        if (!popularProviders.includes(aProvider) && popularProviders.includes(bProvider)) return 1
-        return popularProviders.indexOf(aProvider) - popularProviders.indexOf(bProvider)
+        if (preferredProviders.includes(aProvider) && !preferredProviders.includes(bProvider)) return -1
+        if (!preferredProviders.includes(aProvider) && preferredProviders.includes(bProvider)) return 1
+        return preferredProviders.indexOf(aProvider) - preferredProviders.indexOf(bProvider)
       }}
       itemWrapper={(item, node) => (
         <Tooltip

--- a/packages/app/src/components/dialog-select-provider.tsx
+++ b/packages/app/src/components/dialog-select-provider.tsx
@@ -1,6 +1,6 @@
 import { Component, Show } from "solid-js"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { popularProviders, useProviders } from "@/hooks/use-providers"
+import { preferredProviders, useProviders } from "@/hooks/use-providers"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { List } from "@opencode-ai/ui/list"
 import { Tag } from "@opencode-ai/ui/tag"
@@ -14,8 +14,10 @@ export const DialogSelectProvider: Component = () => {
   const providers = useProviders()
   const language = useLanguage()
 
-  const popularGroup = () => language.t("dialog.provider.group.popular")
+  // kilocode_change start - Use "Recommended" terminology to match kilocode
+  const recommendedGroup = () => language.t("dialog.provider.group.recommended")
   const otherGroup = () => language.t("dialog.provider.group.other")
+  // kilocode_change end
 
   return (
     <Dialog title={language.t("command.provider.connect")}>
@@ -29,16 +31,16 @@ export const DialogSelectProvider: Component = () => {
           return providers.all()
         }}
         filterKeys={["id", "name"]}
-        groupBy={(x) => (popularProviders.includes(x.id) ? popularGroup() : otherGroup())}
+        groupBy={(x) => (preferredProviders.includes(x.id) ? recommendedGroup() : otherGroup())}
         sortBy={(a, b) => {
-          if (popularProviders.includes(a.id) && popularProviders.includes(b.id))
-            return popularProviders.indexOf(a.id) - popularProviders.indexOf(b.id)
+          if (preferredProviders.includes(a.id) && preferredProviders.includes(b.id))
+            return preferredProviders.indexOf(a.id) - preferredProviders.indexOf(b.id)
           return a.name.localeCompare(b.name)
         }}
         sortGroupsBy={(a, b) => {
-          const popular = popularGroup()
-          if (a.category === popular && b.category !== popular) return -1
-          if (b.category === popular && a.category !== popular) return 1
+          const recommended = recommendedGroup()
+          if (a.category === recommended && b.category !== recommended) return -1
+          if (b.category === recommended && a.category !== recommended) return 1
           return 0
         }}
         onSelect={(x) => {

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -3,8 +3,8 @@ import { base64Decode } from "@opencode-ai/util/encode"
 import { useParams } from "@solidjs/router"
 import { createMemo } from "solid-js"
 
-// kilocode_change start - Kilo Gateway at top
-export const popularProviders = [
+// kilocode_change start - Preferred providers list (order determines display priority)
+export const preferredProviders = [
   "kilo",
   "opencode",
   "anthropic",
@@ -31,11 +31,11 @@ export function useProviders() {
   const paid = createMemo(() =>
     connected().filter((p) => p.id !== "opencode" || Object.values(p.models).find((m) => m.cost?.input)),
   )
-  const popular = createMemo(() => providers().all.filter((p) => popularProviders.includes(p.id)))
+  const preferred = createMemo(() => providers().all.filter((p) => preferredProviders.includes(p.id)))
   return {
     all: createMemo(() => providers().all),
     default: createMemo(() => providers().default),
-    popular,
+    preferred, // kilocode_change - renamed from popular
     connected,
     paid,
   }

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -85,6 +85,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "البحث عن موفرين",
   "dialog.provider.empty": "لم يتم العثور على موفرين",
   "dialog.provider.group.popular": "شائع",
+  "dialog.provider.group.recommended": "موصى به", // kilocode_change
   "dialog.provider.group.other": "آخر",
   "dialog.provider.tag.recommended": "موصى به",
   "dialog.provider.kilo.note": "الوصول إلى أكثر من 500 نموذج ذكاء اصطناعي",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -85,6 +85,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Buscar provedores",
   "dialog.provider.empty": "Nenhum provedor encontrado",
   "dialog.provider.group.popular": "Popular",
+  "dialog.provider.group.recommended": "Recomendado", // kilocode_change
   "dialog.provider.group.other": "Outro",
   "dialog.provider.tag.recommended": "Recomendado",
   "dialog.provider.kilo.note": "Acesse mais de 500 modelos de IA",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -83,6 +83,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Søg udbydere",
   "dialog.provider.empty": "Ingen udbydere fundet",
   "dialog.provider.group.popular": "Populære",
+  "dialog.provider.group.recommended": "Anbefalet", // kilocode_change
   "dialog.provider.group.other": "Andre",
   "dialog.provider.tag.recommended": "Anbefalet",
   "dialog.provider.kilo.note": "Adgang til 500+ AI-modeller",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -87,6 +87,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Anbieter durchsuchen",
   "dialog.provider.empty": "Keine Anbieter gefunden",
   "dialog.provider.group.popular": "Beliebt",
+  "dialog.provider.group.recommended": "Empfohlen", // kilocode_change
   "dialog.provider.group.other": "Andere",
   "dialog.provider.tag.recommended": "Empfohlen",
   "dialog.provider.kilo.note": "Zugriff auf über 500 KI-Modelle",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -85,6 +85,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Search providers",
   "dialog.provider.empty": "No providers found",
   "dialog.provider.group.popular": "Popular",
+  "dialog.provider.group.recommended": "Recommended", // kilocode_change
   "dialog.provider.group.other": "Other",
   "dialog.provider.tag.recommended": "Recommended",
   "dialog.provider.kilo.note": "Access 500+ AI models",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -83,6 +83,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Buscar proveedores",
   "dialog.provider.empty": "No se encontraron proveedores",
   "dialog.provider.group.popular": "Popular",
+  "dialog.provider.group.recommended": "Recomendado", // kilocode_change
   "dialog.provider.group.other": "Otro",
   "dialog.provider.tag.recommended": "Recomendado",
   "dialog.provider.kilo.note": "Accede a más de 500 modelos de IA",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -83,6 +83,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Rechercher des fournisseurs",
   "dialog.provider.empty": "Aucun fournisseur trouvé",
   "dialog.provider.group.popular": "Populaire",
+  "dialog.provider.group.recommended": "Recommandé", // kilocode_change
   "dialog.provider.group.other": "Autre",
   "dialog.provider.tag.recommended": "Recommandé",
   "dialog.provider.kilo.note": "Accédez à plus de 500 modèles d'IA",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -83,6 +83,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "プロバイダーを検索",
   "dialog.provider.empty": "プロバイダーが見つかりません",
   "dialog.provider.group.popular": "人気",
+  "dialog.provider.group.recommended": "推奨", // kilocode_change
   "dialog.provider.group.other": "その他",
   "dialog.provider.tag.recommended": "推奨",
   "dialog.provider.kilo.note": "500以上のAIモデルにアクセス",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -87,6 +87,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "공급자 검색",
   "dialog.provider.empty": "공급자 없음",
   "dialog.provider.group.popular": "인기",
+  "dialog.provider.group.recommended": "추천", // kilocode_change
   "dialog.provider.group.other": "기타",
   "dialog.provider.tag.recommended": "추천",
   "dialog.provider.kilo.note": "500개 이상의 AI 모델에 액세스",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -88,6 +88,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Søk etter leverandører",
   "dialog.provider.empty": "Ingen leverandører funnet",
   "dialog.provider.group.popular": "Populære",
+  "dialog.provider.group.recommended": "Anbefalt", // kilocode_change
   "dialog.provider.group.other": "Andre",
   "dialog.provider.tag.recommended": "Anbefalt",
   "dialog.provider.kilo.note": "Tilgang til 500+ AI-modeller",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -85,6 +85,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Szukaj dostawców",
   "dialog.provider.empty": "Nie znaleziono dostawców",
   "dialog.provider.group.popular": "Popularne",
+  "dialog.provider.group.recommended": "Zalecane", // kilocode_change
   "dialog.provider.group.other": "Inne",
   "dialog.provider.tag.recommended": "Zalecane",
   "dialog.provider.kilo.note": "Dostęp do ponad 500 modeli AI",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -85,6 +85,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "Поиск провайдеров",
   "dialog.provider.empty": "Провайдеры не найдены",
   "dialog.provider.group.popular": "Популярные",
+  "dialog.provider.group.recommended": "Рекомендуемые", // kilocode_change
   "dialog.provider.group.other": "Другие",
   "dialog.provider.tag.recommended": "Рекомендуемые",
   "dialog.provider.kilo.note": "Доступ к более чем 500 моделям ИИ",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -87,6 +87,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "搜索提供商",
   "dialog.provider.empty": "未找到提供商",
   "dialog.provider.group.popular": "热门",
+  "dialog.provider.group.recommended": "推荐", // kilocode_change
   "dialog.provider.group.other": "其他",
   "dialog.provider.tag.recommended": "推荐",
   "dialog.provider.kilo.note": "访问 500+ AI 模型",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -87,6 +87,7 @@ export const dict = {
   "dialog.provider.search.placeholder": "搜尋提供者",
   "dialog.provider.empty": "找不到提供者",
   "dialog.provider.group.popular": "熱門",
+  "dialog.provider.group.recommended": "推薦", // kilocode_change
   "dialog.provider.group.other": "其他",
   "dialog.provider.tag.recommended": "推薦",
   "dialog.provider.kilo.note": "存取 500+ AI 模型",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -8,6 +8,19 @@ import { createDialogProviderOptions, DialogProvider } from "./dialog-provider"
 import { useKeybind } from "../context/keybind"
 import * as fuzzysort from "fuzzysort"
 
+// kilocode_change start - Recommended models for Kilo Gateway (order determines display priority)
+const KILO_RECOMMENDED_MODELS = [
+  "anthropic/claude-sonnet-4.5",
+  "anthropic/claude-opus-4.5",
+  "anthropic/claude-haiku-4.5",
+  "openai/gpt-5.2",
+  "openai/gpt-5.2-codex",
+  "google/gemini-3-pro-preview",
+  "google/gemini-3-flash-preview",
+  "mistralai/devstral-2512",
+]
+// kilocode_change end
+
 export function useConnected() {
   const sync = useSync()
   return createMemo(() =>
@@ -128,6 +141,14 @@ export function DialogModel(props: { providerID?: string }) {
               providerID: provider.id,
               modelID: model,
             }
+            // kilocode_change start - Show "Recommended" category for recommended Kilo models
+            const isKiloRecommended = provider.id === "kilo" && KILO_RECOMMENDED_MODELS.includes(model)
+            const category = connected()
+              ? isKiloRecommended
+                ? "Recommended"
+                : provider.name
+              : undefined
+            // kilocode_change end
             return {
               value,
               title: info.name ?? model,
@@ -136,7 +157,7 @@ export function DialogModel(props: { providerID?: string }) {
               )
                 ? "(Favorite)"
                 : undefined,
-              category: connected() ? provider.name : undefined,
+              category,
               disabled: provider.id === "opencode" && model.includes("-nano"),
               footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
               onSelect() {
@@ -165,6 +186,15 @@ export function DialogModel(props: { providerID?: string }) {
             return true
           }),
           sortBy(
+            // kilocode_change start - Sort recommended models first for Kilo Gateway
+            (x) => {
+              if (x.value.providerID === "kilo") {
+                const idx = KILO_RECOMMENDED_MODELS.indexOf(x.value.modelID)
+                return idx >= 0 ? idx : KILO_RECOMMENDED_MODELS.length + 1
+              }
+              return 0
+            },
+            // kilocode_change end
             (x) => x.footer !== "Free",
             (x) => x.title,
           ),


### PR DESCRIPTION
## Summary

This PR implements a recommended models mechanism for Kilo Gateway provider selection, mirroring the `preferredIndex` pattern from kilocode/kilocode-backend.

## Changes

### Web App (`packages/app`)
- Renamed `popularProviders` to `preferredProviders` for consistency with kilocode terminology
- Changed provider group header from "Popular" to "Recommended"
- Added `dialog.provider.group.recommended` translation to all 14 i18n files

### TUI (`packages/opencode`)
- Added `KILO_RECOMMENDED_MODELS` list with priority models:
  - anthropic/claude-sonnet-4.5
  - anthropic/claude-opus-4.5
  - anthropic/claude-haiku-4.5
  - openai/gpt-5.2
  - openai/gpt-5.2-codex
  - google/gemini-3-pro-preview
  - google/gemini-3-flash-preview
  - mistralai/devstral-2512
- Shows recommended Kilo models under "Recommended" category
- Sorts recommended models first (by priority order)
- Remaining models appear under "Kilo Gateway" category

## Testing

- Initial onboarding: After connecting to Kilo Gateway, the model picker shows recommended models first
- Model selection: When opening the model picker with Kilo as provider, recommended models appear first

## Notes

All changes are marked with `kilocode_change` comments to minimize merge conflicts with upstream opencode.


<img width="496" height="310" alt="image" src="https://github.com/user-attachments/assets/7606ef9a-2e66-4dbf-abea-18c4f5e506f1" />
