### PR TITLE
fix: update --help output to show Kilo branding instead of opencode

### DIFF
--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -5,7 +5,7 @@ import { $ } from "bun"
 
 export const PrCommand = cmd({
   command: "pr <number>",
-  describe: "fetch and checkout a GitHub PR branch, then run opencode",
+  describe: "fetch and checkout a GitHub PR branch, then run kilo", // kilocode_change
   builder: (yargs) =>
     yargs.positional("number", {
       type: "number",

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,7 +27,7 @@ const TOOL: Record<string, [string, string]> = {
 
 export const RunCommand = cmd({
   command: "run [message..]",
-  describe: "run opencode with a message",
+  describe: "run kilo with a message", // kilocode_change
   builder: (yargs: Argv) => {
     return yargs
       .positional("message", {
@@ -81,7 +81,7 @@ export const RunCommand = cmd({
       })
       .option("attach", {
         type: "string",
-        describe: "attach to a running opencode server (e.g., http://localhost:4096)",
+        describe: "attach to a running kilo server (e.g., http://localhost:4096)", // kilocode_change
       })
       .option("port", {
         type: "number",

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -6,14 +6,14 @@ import { Flag } from "../../flag/flag"
 export const ServeCommand = cmd({
   command: "serve",
   builder: (yargs) => withNetworkOptions(yargs),
-  describe: "starts a headless opencode server",
+  describe: "starts a headless kilo server", // kilocode_change
   handler: async (args) => {
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
-    console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    console.log(`kilo server listening on http://${server.hostname}:${server.port}`) // kilocode_change
     await new Promise(() => {})
     await server.stop()
   },

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -3,7 +3,7 @@ import { tui } from "./app"
 
 export const AttachCommand = cmd({
   command: "attach <url>",
-  describe: "attach to a running opencode server",
+  describe: "attach to a running kilo server", // kilocode_change
   builder: (yargs) =>
     yargs
       .positional("url", {

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -42,12 +42,12 @@ function createEventSource(client: RpcClient): EventSource {
 
 export const TuiThreadCommand = cmd({
   command: "$0 [project]",
-  describe: "start opencode tui",
+  describe: "start kilo tui", // kilocode_change
   builder: (yargs) =>
     withNetworkOptions(yargs)
       .positional("project", {
         type: "string",
-        describe: "path to start opencode in",
+        describe: "path to start kilo in", // kilocode_change
       })
       .option("model", {
         type: "string",

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -23,7 +23,7 @@ interface RemovalTargets {
 
 export const UninstallCommand = {
   command: "uninstall",
-  describe: "uninstall opencode and remove all related files",
+  describe: "uninstall kilo and remove all related files", // kilocode_change
   builder: (yargs: Argv) =>
     yargs
       .option("keep-config", {

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -5,7 +5,7 @@ import { Installation } from "../../installation"
 
 export const UpgradeCommand = {
   command: "upgrade [target]",
-  describe: "upgrade opencode to the latest or a specific version",
+  describe: "upgrade kilo to the latest or a specific version", // kilocode_change
   builder: (yargs: Argv) => {
     return yargs
       .positional("target", {

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -31,7 +31,7 @@ function getNetworkIPs() {
 export const WebCommand = cmd({
   command: "web",
   builder: (yargs) => withNetworkOptions(yargs),
-  describe: "start opencode server and open web interface",
+  describe: "start kilo server and open web interface", // kilocode_change
   handler: async (args) => {
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -3,12 +3,13 @@ import { EOL } from "os"
 import { NamedError } from "@opencode-ai/util/error"
 
 export namespace UI {
+  // kilocode_change start
   const LOGO = [
-    [`                    `, `             ▄     `],
-    [`█▀▀█ █▀▀█ █▀▀█ █▀▀▄ `, `█▀▀▀ █▀▀█ █▀▀█ █▀▀█`],
-    [`█░░█ █░░█ █▀▀▀ █░░█ `, `█░░░ █░░█ █░░█ █▀▀▀`],
-    [`▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ `, `▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀`],
+    `⢰⣶⠀⠀⣶⡆⢰⣶⣶⣄⠀⠀⢰⣶⠀⠀⣶⡄⠀⠀⣴⣶⣦⡀      ⢰⣶⣶⣶⣄⠀⠀⢰⣶⠀⠀   ⢰⣶⣶⣄⠀⠀`,
+    `⢸⣿⠿⠿⣦⡀⠀⠀⢸⣿⠀⠀⢸⣿⠀⠀⠀⠀⢰⣿⠁⠀⣿⡇     ⢸⣿⠀⠀⠀⠀⠀⠀⢸⣿⠀⠀⠀⠀⠀⠀ ⢸⣿⠀⠀`,
+    `⠸⠿⠀⠀⠿⠃⠘⠿⠿⠿⠿⠇⠘⠿⠿⠿⠿⠇⠈⠻⠿⠿⠀       ⢰⣶⣶⣶⣦⠀⠀⠘⠿⠿⠿⠿⠇ ⠘⠿⠿⠿⠿⠇`,
   ]
+  // kilocode_change end
 
   export const CancelledError = NamedError.create("UICancelledError", z.void())
 
@@ -46,18 +47,20 @@ export namespace UI {
     blank = true
   }
 
+  // kilocode_change start
   export function logo(pad?: string) {
+    const yellow = "\x1b[93m" // bright yellow
     const result = []
     for (const row of LOGO) {
       if (pad) result.push(pad)
-      result.push(Bun.color("gray", "ansi"))
-      result.push(row[0])
+      result.push(yellow)
+      result.push(row)
       result.push("\x1b[0m")
-      result.push(row[1])
       result.push(EOL)
     }
     return result.join("").trimEnd()
   }
+  // kilocode_change end
 
   export async function input(prompt: string): Promise<string> {
     const readline = require("readline")

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -41,7 +41,7 @@ process.on("uncaughtException", (e) => {
 
 const cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
-  .scriptName("opencode")
+  .scriptName("kilo") // kilocode_change
   .wrap(100)
   .help("help", "show help")
   .alias("help", "h")


### PR DESCRIPTION
## Summary

Updates the CLI `--help` output to show Kilo branding instead of opencode.

## Changes

- Changed `scriptName` from `'opencode'` to `'kilo'` in yargs configuration
- Replaced opencode ASCII logo with Kilo braille logo (yellow color) in `UI.logo()`
- Updated all command descriptions to reference `'kilo'` instead of `'opencode'`

## Files Modified

- `packages/opencode/src/index.ts` - scriptName change
- `packages/opencode/src/cli/ui.ts` - Logo replacement
- `packages/opencode/src/cli/cmd/run.ts` - Description updates
- `packages/opencode/src/cli/cmd/tui/thread.ts` - Description updates
- `packages/opencode/src/cli/cmd/tui/attach.ts` - Description update
- `packages/opencode/src/cli/cmd/serve.ts` - Description and console output updates
- `packages/opencode/src/cli/cmd/web.ts` - Description update
- `packages/opencode/src/cli/cmd/upgrade.ts` - Description update
- `packages/opencode/src/cli/cmd/uninstall.ts` - Description update
- `packages/opencode/src/cli/cmd/pr.ts` - Description update

All changes include `kilocode_change` markers for upstream merge tracking.

<img width="750" height="308" alt="image" src="https://github.com/user-attachments/assets/bd961684-365a-4196-ac46-8c8ab1b50b22" />
