### PR TITLE
Text-only updates OpenCode > Kilo CLI

### DIFF
--- a/packages/web/src/content/docs/acp.mdx
+++ b/packages/web/src/content/docs/acp.mdx
@@ -1,9 +1,9 @@
 ---
 title: ACP Support
-description: Use OpenCode in any ACP-compatible editor.
+description: Use Kilo CLI in any ACP-compatible editor.
 ---
 
-OpenCode supports the [Agent Client Protocol](https://agentclientprotocol.com) or (ACP), allowing you to use it directly in compatible editors and IDEs.
+Kilo CLI supports the [Agent Client Protocol](https://agentclientprotocol.com) or (ACP), allowing you to use it directly in compatible editors and IDEs.
 
 :::tip
 For a list of editors and tools that support ACP, check out the [ACP progress report](https://zed.dev/blog/acp-progress-report#available-now).
@@ -15,9 +15,9 @@ ACP is an open protocol that standardizes communication between code editors and
 
 ## Configure
 
-To use OpenCode via ACP, configure your editor to run the `opencode acp` command.
+To use Kilo CLI via ACP, configure your editor to run the `opencode acp` command.
 
-The command starts OpenCode as an ACP-compatible subprocess that communicates with your editor over JSON-RPC via stdio.
+The command starts Kilo CLI as an ACP-compatible subprocess that communicates with your editor over JSON-RPC via stdio.
 
 Below are examples for popular editors that support ACP.
 
@@ -121,7 +121,7 @@ If you need to pass environment variables:
 
 ### CodeCompanion.nvim
 
-To use OpenCode as an ACP agent in [CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim), add the following to your Neovim config:
+To use Kilo CLI as an ACP agent in [CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim), add the following to your Neovim config:
 
 ```lua
 require("codecompanion").setup({
@@ -136,13 +136,13 @@ require("codecompanion").setup({
 })
 ```
 
-This config sets up CodeCompanion to use OpenCode as the ACP agent for chat.
+This config sets up CodeCompanion to use Kilo CLI as the ACP agent for chat.
 
 If you need to pass environment variables (like `OPENCODE_API_KEY`), refer to [Configuring Adapters: Environment Variables](https://codecompanion.olimorris.dev/getting-started#setting-an-api-key) in the CodeCompanion.nvim documentation for full details.
 
 ## Support
 
-OpenCode works the same via ACP as it does in the terminal. All features are supported:
+Kilo CLI works the same via ACP as it does in the terminal. All features are supported:
 
 :::note
 Some built-in slash commands like `/undo` and `/redo` are currently unsupported.
@@ -150,7 +150,7 @@ Some built-in slash commands like `/undo` and `/redo` are currently unsupported.
 
 - Built-in tools (file operations, terminal commands, etc.)
 - Custom tools and slash commands
-- MCP servers configured in your OpenCode config
+- MCP servers configured in your Kilo CLI config
 - Project-specific rules from `AGENTS.md`
 - Custom formatters and linters
 - Agents and permissions system

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -15,7 +15,7 @@ You can switch between agents during a session or invoke them with the `@` menti
 
 ## Types
 
-There are two types of agents in OpenCode; primary agents and subagents.
+There are two types of agents in Kilo CLI; primary agents and subagents.
 
 ---
 
@@ -27,7 +27,7 @@ Primary agents are the main assistants you interact with directly. You can cycle
 You can use the **Tab** key to switch between primary agents during a session.
 :::
 
-OpenCode comes with two built-in primary agents, **Build** and **Plan**. We'll
+Kilo CLI comes with two built-in primary agents, **Build** and **Plan**. We'll
 look at these below.
 
 ---
@@ -36,13 +36,13 @@ look at these below.
 
 Subagents are specialized assistants that primary agents can invoke for specific tasks. You can also manually invoke them by **@ mentioning** them in your messages.
 
-OpenCode comes with two built-in subagents, **General** and **Explore**. We'll look at this below.
+Kilo CLI comes with two built-in subagents, **General** and **Explore**. We'll look at this below.
 
 ---
 
 ## Built-in
 
-OpenCode comes with two built-in primary agents and two built-in subagents.
+Kilo CLI comes with two built-in primary agents and two built-in subagents.
 
 ---
 
@@ -253,7 +253,7 @@ Temperature values typically range from 0.0 to 1.0:
 }
 ```
 
-If no temperature is specified, OpenCode uses model-specific defaults; typically 0 for most models, 0.55 for Qwen models.
+If no temperature is specified, Kilo CLI uses model-specific defaults; typically 0 for most models, 0.55 for Qwen models.
 
 ---
 
@@ -309,7 +309,7 @@ Specify a custom system prompt file for this agent with the `prompt` config. The
 }
 ```
 
-This path is relative to where the config file is located. So this works for both the global OpenCode config and the project specific config.
+This path is relative to where the config file is located. So this works for both the global Kilo CLI config and the project specific config.
 
 ---
 
@@ -331,7 +331,7 @@ If you don’t specify a model, primary agents use the [model globally configure
 }
 ```
 
-The model ID in your OpenCode config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
+The model ID in your Kilo CLI config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
 
 ---
 

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -1,17 +1,17 @@
 ---
 title: CLI
-description: OpenCode CLI options and commands.
+description: Kilo CLI options and commands.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components"
 
-The OpenCode CLI by default starts the [TUI](/docs/tui) when run without any arguments.
+The Kilo CLI by default starts the [TUI](/docs/tui) when run without any arguments.
 
 ```bash
 opencode
 ```
 
-But it also accepts commands as documented on this page. This allows you to interact with OpenCode programmatically.
+But it also accepts commands as documented on this page. This allows you to interact with Kilo CLI programmatically.
 
 ```bash
 opencode run "Explain how closures work in JavaScript"
@@ -21,7 +21,7 @@ opencode run "Explain how closures work in JavaScript"
 
 ### tui
 
-Start the OpenCode terminal user interface.
+Start the Kilo CLI terminal user interface.
 
 ```bash
 opencode [project]
@@ -43,13 +43,13 @@ opencode [project]
 
 ## Commands
 
-The OpenCode CLI also has the following commands.
+The Kilo CLI also has the following commands.
 
 ---
 
 ### agent
 
-Manage agents for OpenCode.
+Manage agents for Kilo.
 
 ```bash
 opencode agent [command]
@@ -59,13 +59,13 @@ opencode agent [command]
 
 ### attach
 
-Attach a terminal to an already running OpenCode backend server started via `serve` or `web` commands.
+Attach a terminal to an already running Kilo CLI backend server started via `serve` or `web` commands.
 
 ```bash
 opencode attach [url]
 ```
 
-This allows using the TUI with a remote OpenCode backend. For example:
+This allows using the TUI with a remote Kilo CLI backend. For example:
 
 ```bash
 # Start the backend server for web/mobile access
@@ -118,13 +118,13 @@ opencode auth [command]
 
 #### login
 
-OpenCode is powered by the provider list at [Models.dev](https://models.dev), so you can use `opencode auth login` to configure API keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`.
+Kilo CLI is powered by the provider list at [Models.dev](https://models.dev), so you can use `opencode auth login` to configure API keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`.
 
 ```bash
 opencode auth login
 ```
 
-When OpenCode starts up it loads the providers from the credentials file. And if there are any keys defined in your environments or a `.env` file in your project.
+When Kilo CLI starts up it loads the providers from the credentials file. And if there are any keys defined in your environments or a `.env` file in your project.
 
 ---
 
@@ -310,7 +310,7 @@ opencode models --refresh
 
 ### run
 
-Run opencode in non-interactive mode by passing a prompt directly.
+Run Kilo CLI in non-interactive mode by passing a prompt directly.
 
 ```bash
 opencode run [message..]
@@ -345,20 +345,20 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | `--file`     | `-f`  | File(s) to attach to message                                       |
 | `--format`   |       | Format: default (formatted) or json (raw JSON events)              |
 | `--title`    |       | Title for the session (uses truncated prompt if no value provided) |
-| `--attach`   |       | Attach to a running opencode server (e.g., http://localhost:4096)  |
+| `--attach`   |       | Attach to a running Kilo CLI server (e.g., http://localhost:4096)  |
 | `--port`     |       | Port for the local server (defaults to random port)                |
 
 ---
 
 ### serve
 
-Start a headless OpenCode server for API access. Check out the [server docs](/docs/server) for the full HTTP interface.
+Start a headless Kilo CLI server for API access. Check out the [server docs](/docs/server) for the full HTTP interface.
 
 ```bash
 opencode serve
 ```
 
-This starts an HTTP server that provides API access to opencode functionality without the TUI interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
+This starts an HTTP server that provides API access to Kilo CLI functionality without the TUI interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
 
 #### Flags
 
@@ -373,7 +373,7 @@ This starts an HTTP server that provides API access to opencode functionality wi
 
 ### session
 
-Manage OpenCode sessions.
+Manage Kilo CLI sessions.
 
 ```bash
 opencode session [command]
@@ -383,7 +383,7 @@ opencode session [command]
 
 #### list
 
-List all OpenCode sessions.
+List all Kilo CLI sessions.
 
 ```bash
 opencode session list
@@ -400,7 +400,7 @@ opencode session list
 
 ### stats
 
-Show token usage and cost statistics for your OpenCode sessions.
+Show token usage and cost statistics for your Kilo CLI sessions.
 
 ```bash
 opencode stats
@@ -431,13 +431,13 @@ If you don't provide a session ID, you'll be prompted to select from available s
 
 ### import
 
-Import session data from a JSON file or OpenCode share URL.
+Import session data from a JSON file or Kilo CLI share URL.
 
 ```bash
 opencode import <file>
 ```
 
-You can import from a local file or an OpenCode share URL.
+You can import from a local file or an Kilo CLI share URL.
 
 ```bash
 opencode import session.json
@@ -448,13 +448,13 @@ opencode import https://opncd.ai/s/abc123
 
 ### web
 
-Start a headless OpenCode server with a web interface.
+Start a headless Kilo CLI server with a web interface.
 
 ```bash
 opencode web
 ```
 
-This starts an HTTP server and opens a web browser to access OpenCode through a web interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
+This starts an HTTP server and opens a web browser to access Kilo CLI through a web interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
 
 #### Flags
 
@@ -489,7 +489,7 @@ This command starts an ACP server that communicates via stdin/stdout using nd-JS
 
 ### uninstall
 
-Uninstall OpenCode and remove all related files.
+Uninstall Kilo CLI and remove all related files.
 
 ```bash
 opencode uninstall
@@ -508,7 +508,7 @@ opencode uninstall
 
 ### upgrade
 
-Updates opencode to the latest version or a specific version.
+Updates Kilo CLI to the latest version or a specific version.
 
 ```bash
 opencode upgrade [target]
@@ -536,7 +536,7 @@ opencode upgrade v0.1.48
 
 ## Global Flags
 
-The opencode CLI takes the following global flags.
+The Kilo CLI takes the following global flags.
 
 | Flag           | Short | Description                          |
 | -------------- | ----- | ------------------------------------ |
@@ -549,7 +549,7 @@ The opencode CLI takes the following global flags.
 
 ## Environment variables
 
-OpenCode can be configured using environment variables.
+Kilo CLI can be configured using environment variables.
 
 | Variable                              | Type    | Description                                       |
 | ------------------------------------- | ------- | ------------------------------------------------- |

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -42,13 +42,13 @@ Use the command by typing `/` followed by the command name.
 
 ## Configure
 
-You can add custom commands through the OpenCode config or by creating markdown files in the `commands/` directory.
+You can add custom commands through the Kilo CLI config or by creating markdown files in the `commands/` directory.
 
 ---
 
 ### JSON
 
-Use the `command` option in your OpenCode [config](/docs/config):
+Use the `command` option in your Kilo CLI [config](/docs/config):
 
 ```json title="opencode.jsonc" {4-12}
 {
@@ -314,7 +314,7 @@ This is an **optional** config option.
 
 ## Built-in
 
-opencode includes several built-in commands like `/init`, `/undo`, `/redo`, `/share`, `/help`; [learn more](/docs/tui#commands).
+Kilo CLI includes several built-in commands like `/init`, `/undo`, `/redo`, `/share`, `/help`; [learn more](/docs/tui#commands).
 
 :::note
 Custom commands can override built-in commands.

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -1,15 +1,15 @@
 ---
 title: Config
-description: Using the OpenCode JSON config.
+description: Using the Kilo CLI JSON config.
 ---
 
-You can configure OpenCode using a JSON config file.
+You can configure Kilo CLI using a JSON config file.
 
 ---
 
 ## Format
 
-OpenCode supports both **JSON** and **JSONC** (JSON with Comments) formats.
+Kilo CLI supports both **JSON** and **JSONC** (JSON with Comments) formats.
 
 ```jsonc title="opencode.jsonc"
 {
@@ -95,7 +95,7 @@ You can enable specific servers in your local config:
 
 ### Global
 
-Place your global OpenCode config in `~/.config/opencode/opencode.json`. Use global config for user-wide preferences like themes, providers, or keybinds.
+Place your global Kilo CLI config in `~/.config/opencode/opencode.json`. Use global config for user-wide preferences like themes, providers, or keybinds.
 
 Global config overrides remote organizational defaults.
 
@@ -199,7 +199,7 @@ Available options:
 
 - `port` - Port to listen on.
 - `hostname` - Hostname to listen on. When `mdns` is enabled and no hostname is set, defaults to `0.0.0.0`.
-- `mdns` - Enable mDNS service discovery. This allows other devices on the network to discover your OpenCode server.
+- `mdns` - Enable mDNS service discovery. This allows other devices on the network to discover your Kilo CLI server.
 - `cors` - Additional origins to allow for CORS when using the HTTP server from a browser-based client. Values must be full origins (scheme + host + optional port), eg `https://app.example.com`.
 
 [Learn more about the server here](/docs/server).
@@ -226,7 +226,7 @@ You can manage the tools an LLM can use through the `tools` option.
 
 ### Models
 
-You can configure the providers and models you want to use in your OpenCode config through the `provider`, `model` and `small_model` options.
+You can configure the providers and models you want to use in your Kilo CLI config through the `provider`, `model` and `small_model` options.
 
 ```json title="opencode.json"
 {
@@ -237,7 +237,7 @@ You can configure the providers and models you want to use in your OpenCode conf
 }
 ```
 
-The `small_model` option configures a separate model for lightweight tasks like title generation. By default, OpenCode tries to use a cheaper model if one is available from your provider, otherwise it falls back to your main model.
+The `small_model` option configures a separate model for lightweight tasks like title generation. By default, Kilo CLI tries to use a cheaper model if one is available from your provider, otherwise it falls back to your main model.
 
 Provider options can include `timeout` and `setCacheKey`:
 
@@ -299,7 +299,7 @@ Bearer tokens (`AWS_BEARER_TOKEN_BEDROCK` or `/connect`) take precedence over pr
 
 ### Themes
 
-You can configure the theme you want to use in your OpenCode config through the `theme` option.
+You can configure the theme you want to use in your Kilo CLI config through the `theme` option.
 
 ```json title="opencode.json"
 {
@@ -349,7 +349,7 @@ You can set the default agent using the `default_agent` option. This determines 
 }
 ```
 
-The default agent must be a primary agent (not a subagent). This can be a built-in agent like `"build"` or `"plan"`, or a [custom agent](/docs/agents) you've defined. If the specified agent doesn't exist or is a subagent, OpenCode will fall back to `"build"` with a warning.
+The default agent must be a primary agent (not a subagent). This can be a built-in agent like `"build"` or `"plan"`, or a [custom agent](/docs/agents) you've defined. If the specified agent doesn't exist or is a subagent, Kilo CLI will fall back to `"build"` with a warning.
 
 This setting applies across all interfaces: TUI, CLI (`opencode run`), desktop app, and GitHub Action.
 
@@ -461,7 +461,7 @@ You can configure code formatters through the `formatter` option.
 
 ### Permissions
 
-By default, opencode **allows all operations** without requiring explicit approval. You can change this using the `permission` option.
+By default, Kilo CLI **allows all operations** without requiring explicit approval. You can change this using the `permission` option.
 
 For example, to ensure that the `edit` and `bash` tools require user approval:
 
@@ -532,7 +532,7 @@ You can configure MCP servers you want to use through the `mcp` option.
 
 ### Plugins
 
-[Plugins](/docs/plugins) extend OpenCode with custom tools, hooks, and integrations.
+[Plugins](/docs/plugins) extend Kilo CLI with custom tools, hooks, and integrations.
 
 Place plugin files in `.opencode/plugins/` or `~/.config/opencode/plugins/`. You can also load plugins from npm through the `plugin` option.
 
@@ -597,7 +597,7 @@ You can specify an allowlist of providers through the `enabled_providers` option
 }
 ```
 
-This is useful when you want to restrict OpenCode to only use specific providers rather than disabling them one by one.
+This is useful when you want to restrict Kilo CLI to only use specific providers rather than disabling them one by one.
 
 :::note
 The `disabled_providers` takes priority over `enabled_providers`.

--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -1,9 +1,9 @@
 ---
 title: Custom Tools
-description: Create tools the LLM can call in opencode.
+description: Create tools the LLM can call in Kilo CLI.
 ---
 
-Custom tools are functions you create that the LLM can call during conversations. They work alongside opencode's [built-in tools](/docs/tools) like `read`, `write`, and `bash`.
+Custom tools are functions you create that the LLM can call during conversations. They work alongside Kilo CLI's [built-in tools](/docs/tools) like `read`, `write`, and `bash`.
 
 ---
 

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -1,15 +1,15 @@
 ---
 title: Formatters
-description: OpenCode uses language specific formatters.
+description: Kilo CLI uses language specific formatters.
 ---
 
-OpenCode automatically formats files after they are written or edited using language-specific formatters. This ensures that the code that is generated follows the code styles of your project.
+Kilo CLI automatically formats files after they are written or edited using language-specific formatters. This ensures that the code that is generated follows the code styles of your project.
 
 ---
 
 ## Built-in
 
-OpenCode comes with several built-in formatters for popular languages and frameworks. Below is a list of the formatters, supported file extensions, and commands or config options it needs.
+Kilo CLI comes with several built-in formatters for popular languages and frameworks. Below is a list of the formatters, supported file extensions, and commands or config options it needs.
 
 | Formatter            | Extensions                                                                                               | Requirements                                                                                          |
 | -------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -37,13 +37,13 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | pint                 | .php                                                                                                     | `laravel/pint` dependency in `composer.json`                                                          |
 | oxfmt (Experimental) | .js, .jsx, .ts, .tsx                                                                                     | `oxfmt` dependency in `package.json` and an [experimental env variable flag](/docs/cli/#experimental) |
 
-So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
+So if your project has `prettier` in your `package.json`, Kilo CLI will automatically use it.
 
 ---
 
 ## How it works
 
-When OpenCode writes or edits a file, it:
+When Kilo CLI writes or edits a file, it:
 
 1. Checks the file extension against all enabled formatters.
 2. Runs the appropriate formatter command on the file.
@@ -55,7 +55,7 @@ This process happens in the background, ensuring your code styles are maintained
 
 ## Configure
 
-You can customize formatters through the `formatter` section in your OpenCode config.
+You can customize formatters through the `formatter` section in your Kilo CLI config.
 
 ```json title="opencode.json"
 {

--- a/packages/web/src/content/docs/ide.mdx
+++ b/packages/web/src/content/docs/ide.mdx
@@ -1,24 +1,24 @@
 ---
 title: IDE
-description: The OpenCode extension for VS Code, Cursor, and other IDEs
+description: The Kilo CLI extension for VS Code, Cursor, and other IDEs
 ---
 
-OpenCode integrates with VS Code, Cursor, or any IDE that supports a terminal. Just run `opencode` in the terminal to get started.
+Kilo CLI integrates with VS Code, Cursor, or any IDE that supports a terminal. Just run `opencode` in the terminal to get started.
 
 ---
 
 ## Usage
 
-- **Quick Launch**: Use `Cmd+Esc` (Mac) or `Ctrl+Esc` (Windows/Linux) to open OpenCode in a split terminal view, or focus an existing terminal session if one is already running.
-- **New Session**: Use `Cmd+Shift+Esc` (Mac) or `Ctrl+Shift+Esc` (Windows/Linux) to start a new OpenCode terminal session, even if one is already open. You can also click the OpenCode button in the UI.
-- **Context Awareness**: Automatically share your current selection or tab with OpenCode.
+- **Quick Launch**: Use `Cmd+Esc` (Mac) or `Ctrl+Esc` (Windows/Linux) to open Kilo CLI in a split terminal view, or focus an existing terminal session if one is already running.
+- **New Session**: Use `Cmd+Shift+Esc` (Mac) or `Ctrl+Shift+Esc` (Windows/Linux) to start a new Kilo CLI terminal session, even if one is already open. You can also click the OpenCode button in the UI.
+- **Context Awareness**: Automatically share your current selection or tab with Kilo CLI.
 - **File Reference Shortcuts**: Use `Cmd+Option+K` (Mac) or `Alt+Ctrl+K` (Linux/Windows) to insert file references. For example, `@File#L37-42`.
 
 ---
 
 ## Installation
 
-To install OpenCode on VS Code and popular forks like Cursor, Windsurf, VSCodium:
+To install Kilo CLI on VS Code and popular forks like Cursor, Windsurf, VSCodium:
 
 1. Open VS Code
 2. Open the integrated terminal
@@ -30,7 +30,7 @@ If on the other hand you want to use your own IDE when you run `/editor` or `/ex
 
 ### Manual Install
 
-Search for **OpenCode** in the Extension Marketplace and click **Install**.
+Search for **Kilo Code** in the Extension Marketplace and click **Install**.
 
 ---
 

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -279,7 +279,7 @@ You can ask OpenCode to add new features to your project. Though we first recomm
 
 ### Make changes
 
-For more straightforward changes, you can ask OpenCode to directly build it
+For more straightforward changes, you can ask Kilo CLI to directly build it
 without having to review the plan first.
 
 ```txt frame="none" "@packages/functions/src/settings.ts" "@packages/functions/src/notes.ts"
@@ -288,14 +288,14 @@ handled in the /notes route in @packages/functions/src/notes.ts and implement
 the same logic in @packages/functions/src/settings.ts
 ```
 
-You want to make sure you provide a good amount of detail so OpenCode makes the right
+You want to make sure you provide a good amount of detail so Kilo CLI makes the right
 changes.
 
 ---
 
 ### Undo changes
 
-Let's say you ask OpenCode to make some changes.
+Let's say you ask Kilo CLI to make some changes.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
@@ -308,14 +308,14 @@ using the `/undo` command.
 /undo
 ```
 
-OpenCode will now revert the changes you made and show your original message
+Kilo CLI will now revert the changes you made and show your original message
 again.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
 ```
 
-From here you can tweak the prompt and ask OpenCode to try again.
+From here you can tweak the prompt and ask Kilo CLI to try again.
 
 :::tip
 You can run `/undo` multiple times to undo multiple changes.
@@ -331,7 +331,7 @@ Or you **can redo** the changes using the `/redo` command.
 
 ## Share
 
-The conversations that you have with OpenCode can be [shared with your
+The conversations that you have with Kilo CLI can be [shared with your
 team](/docs/share).
 
 ```bash frame="none"
@@ -344,12 +344,12 @@ This will create a link to the current conversation and copy it to your clipboar
 Conversations are not shared by default.
 :::
 
-Here's an [example conversation](https://opencode.ai/s/4XP1fce5) with OpenCode.
+Here's an [example conversation](https://opencode.ai/s/4XP1fce5) with Kilo CLI.
 
 ---
 
 ## Customize
 
-And that's it! You are now a pro at using OpenCode.
+And that's it! You are now a pro at using Kilo CLI.
 
-To make it your own, we recommend [picking a theme](/docs/themes), [customizing the keybinds](/docs/keybinds), [configuring code formatters](/docs/formatters), [creating custom commands](/docs/commands), or playing around with the [OpenCode config](/docs/config).
+To make it your own, we recommend [picking a theme](/docs/themes), [customizing the keybinds](/docs/keybinds), [configuring code formatters](/docs/formatters), [creating custom commands](/docs/commands), or playing around with the [Kilo CLI config](/docs/config).

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -3,7 +3,7 @@ title: Keybinds
 description: Customize your keybinds.
 ---
 
-OpenCode has a list of keybinds that you can customize through the OpenCode config.
+Kilo CLI has a list of keybinds that you can customize through the Kilo CLI config.
 
 ```json title="opencode.json"
 {
@@ -106,7 +106,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
 
 ## Leader key
 
-OpenCode uses a `leader` key for most keybinds. This avoids conflicts in your terminal.
+Kilo CLI uses a `leader` key for most keybinds. This avoids conflicts in your terminal.
 
 By default, `ctrl+x` is the leader key and most actions require you to first press the leader key and then the shortcut. For example, to start a new session you first press `ctrl+x` and then press `n`.
 
@@ -131,7 +131,7 @@ You can disable a keybind by adding the key to your config with a value of "none
 
 ## Desktop prompt shortcuts
 
-The OpenCode desktop app prompt input supports common Readline/Emacs-style shortcuts for editing text. These are built-in and currently not configurable via `opencode.json`.
+The Kilo CLI desktop app prompt input supports common Readline/Emacs-style shortcuts for editing text. These are built-in and currently not configurable via `opencode.json`.
 
 | Shortcut | Action                                   |
 | -------- | ---------------------------------------- |

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -1,15 +1,15 @@
 ---
 title: LSP Servers
-description: OpenCode integrates with your LSP servers.
+description: Kilo CLI integrates with your LSP servers.
 ---
 
-OpenCode integrates with your Language Server Protocol (LSP) to help the LLM interact with your codebase. It uses diagnostics to provide feedback to the LLM.
+Kilo CLI integrates with your Language Server Protocol (LSP) to help the LLM interact with your codebase. It uses diagnostics to provide feedback to the LLM.
 
 ---
 
 ## Built-in
 
-OpenCode comes with several built-in LSP servers for popular languages:
+Kilo CLI comes with several built-in LSP servers for popular languages:
 
 | LSP Server         | Extensions                                                          | Requirements                                                 |
 | ------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -55,7 +55,7 @@ You can disable automatic LSP server downloads by setting the `OPENCODE_DISABLE_
 
 ## How It Works
 
-When opencode opens a file, it:
+When Kilo CLI opens a file, it:
 
 1. Checks the file extension against all enabled LSP servers.
 2. Starts the appropriate LSP server if not already running.
@@ -64,7 +64,7 @@ When opencode opens a file, it:
 
 ## Configure
 
-You can customize LSP servers through the `lsp` section in your opencode config.
+You can customize LSP servers through the `lsp` section in your Kilo CLI config.
 
 ```json title="opencode.json"
 {

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -3,7 +3,7 @@ title: MCP servers
 description: Add local and remote MCP tools.
 ---
 
-You can add external tools to OpenCode using the _Model Context Protocol_, or MCP. OpenCode supports both local and remote servers.
+You can add external tools to Kilo CLI using the _Model Context Protocol_, or MCP. Kilo CLI supports both local and remote servers.
 
 Once added, MCP tools are automatically available to the LLM alongside built-in tools.
 
@@ -23,7 +23,7 @@ Certain MCP servers, like the GitHub MCP server, tend to add a lot of tokens and
 
 ## Enable
 
-You can define MCP servers in your [OpenCode Config](https://opencode.ai/docs/config/) under `mcp`. Add each MCP with a unique name. You can refer to that MCP by name when prompting the LLM.
+You can define MCP servers in your [Kilo CLI Config](https://opencode.ai/docs/config/) under `mcp`. Add each MCP with a unique name. You can refer to that MCP by name when prompting the LLM.
 
 ```jsonc title="opencode.jsonc" {6}
 {
@@ -165,7 +165,7 @@ The `url` is the URL of the remote MCP server and with the `headers` option you 
 
 ## OAuth
 
-OpenCode automatically handles OAuth authentication for remote MCP servers. When a server requires authentication, OpenCode will:
+Kilo CLI automatically handles OAuth authentication for remote MCP servers. When a server requires authentication, Kilo CLI will:
 
 1. Detect the 401 response and initiate the OAuth flow
 2. Use **Dynamic Client Registration (RFC 7591)** if supported by the server
@@ -189,7 +189,7 @@ For most OAuth-enabled MCP servers, no special configuration is needed. Just con
 }
 ```
 
-If the server requires authentication, OpenCode will prompt you to authenticate when you first try to use it. If not, you can [manually trigger the flow](#authenticating) with `opencode mcp auth <server-name>`.
+If the server requires authentication, Kilo CLI will prompt you to authenticate when you first try to use it. If not, you can [manually trigger the flow](#authenticating) with `opencode mcp auth <server-name>`.
 
 ---
 
@@ -238,7 +238,7 @@ Remove stored credentials:
 opencode mcp logout my-oauth-server
 ```
 
-The `mcp auth` command will open your browser for authorization. After you authorize, OpenCode will store the tokens securely in `~/.local/share/opencode/mcp-auth.json`.
+The `mcp auth` command will open your browser for authorization. After you authorize, Kilo CLI will store the tokens securely in `~/.local/share/opencode/mcp-auth.json`.
 
 ---
 
@@ -291,7 +291,7 @@ The `mcp debug` command shows the current auth status, tests HTTP connectivity, 
 
 ## Manage
 
-Your MCPs are available as tools in OpenCode, alongside built-in tools. So you can manage them through the OpenCode config like any other tool.
+Your MCPs are available as tools in Kilo CLI, alongside built-in tools. So you can manage them through the Kilo CLI config like any other tool.
 
 ---
 
@@ -423,7 +423,7 @@ After adding the configuration, authenticate with Sentry:
 opencode mcp auth sentry
 ```
 
-This will open a browser window to complete the OAuth flow and connect OpenCode to your Sentry account.
+This will open a browser window to complete the OAuth flow and connect Kilo CLI to your Sentry account.
 
 Once authenticated, you can use Sentry tools in your prompts to query issues, projects, and error data.
 

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -3,13 +3,13 @@ title: Models
 description: Configuring an LLM provider and model.
 ---
 
-OpenCode uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support **75+ LLM providers** and it supports running local models.
+Kilo CLI uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support **75+ LLM providers** and it supports running local models.
 
 ---
 
 ## Providers
 
-Most popular providers are preloaded by default. If you've added the credentials for a provider through the `/connect` command, they'll be available when you start OpenCode.
+Most popular providers are preloaded by default. If you've added the credentials for a provider through the `/connect` command, they'll be available when you start Kilo CLI.
 
 Learn more about [providers](/docs/providers).
 
@@ -35,7 +35,7 @@ Consider using one of the models we recommend.
 
 However, there are only a few of them that are good at both generating code and tool calling.
 
-Here are several models that work well with OpenCode, in no particular order. (This is not an exhaustive list nor is it necessarily up to date):
+Here are several models that work well with Kilo CLI, in no particular order. (This is not an exhaustive list nor is it necessarily up to date):
 
 - GPT 5.2
 - GPT 5.1 Codex
@@ -49,7 +49,7 @@ Here are several models that work well with OpenCode, in no particular order. (T
 ## Set a default
 
 To set one of these as the default model, you can set the `model` key in your
-OpenCode config.
+Kilo CLI config.
 
 ```json title="opencode.json" {3}
 {
@@ -137,11 +137,11 @@ You can also define custom variants that extend built-in ones. Variants let you 
 
 ## Variants
 
-Many models support multiple variants with different configurations. OpenCode ships with built-in default variants for popular providers.
+Many models support multiple variants with different configurations. Kilo CLI ships with built-in default variants for popular providers.
 
 ### Built-in variants
 
-OpenCode ships with default variants for many providers:
+Kilo CLI ships with default variants for many providers:
 
 **Anthropic**:
 
@@ -203,11 +203,11 @@ Use the keybind `variant_cycle` to quickly switch between variants. [Learn more]
 
 ## Loading models
 
-When OpenCode starts up, it checks for models in the following priority order:
+When Kilo CLI starts up, it checks for models in the following priority order:
 
 1. The `--model` or `-m` command line flag. The format is the same as in the config file: `provider_id/model_id`.
 
-2. The model list in the OpenCode config.
+2. The model list in the Kilo CLI config.
 
    ```json title="opencode.json"
    {

--- a/packages/web/src/content/docs/modes.mdx
+++ b/packages/web/src/content/docs/modes.mdx
@@ -4,14 +4,14 @@ description: Different modes for different use cases.
 ---
 
 :::caution
-Modes are now configured through the `agent` option in the opencode config. The
+Modes are now configured through the `agent` option in the Kilo CLI config. The
 `mode` option is now deprecated. [Learn more](/docs/agents).
 :::
 
-Modes in opencode allow you to customize the behavior, tools, and prompts for different use cases.
+Modes in Kilo CLI allow you to customize the behavior, tools, and prompts for different use cases.
 
 It comes with two built-in modes: **build** and **plan**. You can customize
-these or configure your own through the opencode config.
+these or configure your own through the Kilo CLI config.
 
 You can switch between modes during a session or configure them in your config file.
 
@@ -19,7 +19,7 @@ You can switch between modes during a session or configure them in your config f
 
 ## Built-in
 
-opencode comes with two built-in modes.
+Kilo CLI comes with two built-in modes.
 
 ---
 
@@ -173,7 +173,7 @@ Temperature values typically range from 0.0 to 1.0:
 }
 ```
 
-If no temperature is specified, opencode uses model-specific defaults (typically 0 for most models, 0.55 for Qwen models).
+If no temperature is specified, Kilo CLI uses model-specific defaults (typically 0 for most models, 0.55 for Qwen models).
 
 ---
 
@@ -192,7 +192,7 @@ Specify a custom system prompt file for this mode with the `prompt` config. The 
 ```
 
 This path is relative to where the config file is located. So this works for
-both the global opencode config and the project specific config.
+both the global Kilo CLI config and the project specific config.
 
 ---
 

--- a/packages/web/src/content/docs/network.mdx
+++ b/packages/web/src/content/docs/network.mdx
@@ -3,13 +3,13 @@ title: Network
 description: Configure proxies and custom certificates.
 ---
 
-OpenCode supports standard proxy environment variables and custom certificates for enterprise network environments.
+Kilo CLI supports standard proxy environment variables and custom certificates for enterprise network environments.
 
 ---
 
 ## Proxy
 
-OpenCode respects standard proxy environment variables.
+Kilo CLI respects standard proxy environment variables.
 
 ```bash
 # HTTPS proxy (recommended)
@@ -48,7 +48,7 @@ For proxies requiring advanced authentication like NTLM or Kerberos, consider us
 
 ## Custom certificates
 
-If your enterprise uses custom CAs for HTTPS connections, configure OpenCode to trust them.
+If your enterprise uses custom CAs for HTTPS connections, configure Kilo CLI to trust them.
 
 ```bash
 export NODE_EXTRA_CA_CERTS=/path/to/ca-cert.pem

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -3,7 +3,7 @@ title: Permissions
 description: Control which actions require approval to run.
 ---
 
-OpenCode uses the `permission` config to decide whether a given action should run automatically, prompt you, or be blocked.
+Kilo CLI uses the `permission` config to decide whether a given action should run automatically, prompt you, or be blocked.
 
 As of `v1.1.1`, the legacy `tools` boolean config is deprecated and has been merged into `permission`. The old `tools` config is still supported for backwards compatibility.
 
@@ -90,7 +90,7 @@ You can use `~` or `$HOME` at the start of a pattern to reference your home dire
 
 ## Available Permissions
 
-OpenCode permissions are keyed by tool name, plus a couple of safety guards:
+Kilo CLI permissions are keyed by tool name, plus a couple of safety guards:
 
 - `read` — reading a file (matches the file path)
 - `edit` — all file modifications (covers `edit`, `write`, `patch`, `multiedit`)
@@ -111,7 +111,7 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 
 ## Defaults
 
-If you don’t specify anything, OpenCode starts from permissive defaults:
+If you don’t specify anything, Kilo CLI starts from permissive defaults:
 
 - Most permissions default to `"allow"`.
 - `doom_loop` and `external_directory` default to `"ask"`.
@@ -134,10 +134,10 @@ If you don’t specify anything, OpenCode starts from permissive defaults:
 
 ## What “Ask” Does
 
-When OpenCode prompts for approval, the UI offers three outcomes:
+When Kilo CLI prompts for approval, the UI offers three outcomes:
 
 - `once` — approve just this request
-- `always` — approve future requests matching the suggested patterns (for the rest of the current OpenCode session)
+- `always` — approve future requests matching the suggested patterns (for the rest of the current Kilo CLI session)
 - `reject` — deny the request
 
 The set of patterns that `always` would approve is provided by the tool (for example, bash approvals typically whitelist a safe command prefix like `git status*`).

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -1,9 +1,9 @@
 ---
 title: Plugins
-description: Write your own plugins to extend OpenCode.
+description: Write your own plugins to extend Kilo CLI.
 ---
 
-Plugins allow you to extend OpenCode by hooking into various events and customizing behavior. You can create plugins to add new features, integrate with external services, or modify OpenCode's default behavior.
+Plugins allow you to extend Kilo CLI by hooking into various events and customizing behavior. You can create plugins to add new features, integrate with external services, or modify Kilo CLI's default behavior.
 
 For examples, check out the [plugins](/docs/ecosystem#plugins) created by the community.
 
@@ -83,7 +83,7 @@ Local plugins and custom tools can use external npm packages. Add a `package.jso
 }
 ```
 
-OpenCode runs `bun install` at startup to install these. Your plugins and tools can then import them.
+Kilo CLI runs `bun install` at startup to install these. Your plugins and tools can then import them.
 
 ```ts title=".opencode/plugins/my-plugin.ts"
 import { escape } from "shescape"
@@ -118,7 +118,7 @@ The plugin function receives:
 - `project`: The current project information.
 - `directory`: The current working directory.
 - `worktree`: The git worktree path.
-- `client`: An opencode SDK client for interacting with the AI.
+- `client`: A Kilo CLI SDK client for interacting with the AI.
 - `$`: Bun's [shell API](https://bun.com/docs/runtime/shell) for executing commands.
 
 ---
@@ -207,7 +207,7 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 ## Examples
 
-Here are some examples of plugins you can use to extend opencode.
+Here are some examples of plugins you can use to extend Kilo CLI.
 
 ---
 
@@ -231,14 +231,14 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
 We are using `osascript` to run AppleScript on macOS. Here we are using it to send notifications.
 
 :::note
-If you’re using the OpenCode desktop app, it can send system notifications automatically when a response is ready or when a session errors.
+If you’re using the Kilo CLI desktop app, it can send system notifications automatically when a response is ready or when a session errors.
 :::
 
 ---
 
 ### .env protection
 
-Prevent opencode from reading `.env` files:
+Prevent Kilo CLI from reading `.env` files:
 
 ```javascript title=".opencode/plugins/env-protection.js"
 export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
@@ -256,7 +256,7 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
 
 ### Custom tools
 
-Plugins can also add custom tools to opencode:
+Plugins can also add custom tools to Kilo CLI:
 
 ```ts title=".opencode/plugins/custom-tools.ts"
 import { type Plugin, tool } from "@opencode-ai/plugin"
@@ -278,13 +278,13 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 }
 ```
 
-The `tool` helper creates a custom tool that opencode can call. It takes a Zod schema function and returns a tool definition with:
+The `tool` helper creates a custom tool that Kilo CLI can call. It takes a Zod schema function and returns a tool definition with:
 
 - `description`: What the tool does
 - `args`: Zod schema for the tool's arguments
 - `execute`: Function that runs when the tool is called
 
-Your custom tools will be available to opencode alongside built-in tools.
+Your custom tools will be available to Kilo CLI alongside built-in tools.
 
 ---
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1,17 +1,17 @@
 ---
 title: Providers
-description: Using any LLM provider in OpenCode.
+description: Using any LLM provider in Kilo CLI.
 ---
 
 import config from "../../../config.mjs"
 export const console = config.console
 
-OpenCode uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support **75+ LLM providers** and it supports running local models.
+Kilo CLI uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support **75+ LLM providers** and it supports running local models.
 
 To add a provider you need to:
 
 1. Add the API keys for the provider using the `/connect` command.
-2. Configure the provider in your OpenCode config.
+2. Configure the provider in your Kilo CLI config.
 
 ---
 
@@ -24,7 +24,7 @@ in `~/.local/share/opencode/auth.json`.
 
 ### Config
 
-You can customize the providers through the `provider` section in your OpenCode
+You can customize the providers through the `provider` section in your Kilo CLI
 config.
 
 ---
@@ -124,7 +124,7 @@ Don't see a provider here? Submit a PR.
 
 ### Amazon Bedrock
 
-To use Amazon Bedrock with OpenCode:
+To use Amazon Bedrock with Kilo CLI:
 
 1. Head over to the **Model catalog** in the Amazon Bedrock console and request
    access to the models you want.
@@ -137,7 +137,7 @@ To use Amazon Bedrock with OpenCode:
 
    #### Environment Variables (Quick Start)
 
-   Set one of these environment variables while running opencode:
+   Set one of these environment variables while running Kilo CLI:
 
    ```bash
    # Option 1: Using AWS access keys
@@ -257,7 +257,7 @@ For custom inference profiles, use the model and provider name in the key and se
 We recommend signing up for [Claude Pro](https://www.anthropic.com/news/claude-pro) or [Max](https://www.anthropic.com/max).
 
 :::info
-We've received reports of some users having their subscriptions blocked while using it with OpenCode.
+We've received reports of some users having their subscriptions blocked while using it with Kilo CLI.
 :::
 
 1. Once you've signed up, run the `/connect` command and select Anthropic.
@@ -305,7 +305,7 @@ If you encounter "I'm sorry, but I cannot assist with that request" errors, try 
 2. Go to [Azure AI Foundry](https://ai.azure.com/) and deploy a model.
 
    :::note
-   The deployment name must match the model name for opencode to work properly.
+   The deployment name must match the model name for Kilo CLI to work properly.
    :::
 
 3. Run the `/connect` command and search for **Azure**.
@@ -352,7 +352,7 @@ If you encounter "I'm sorry, but I cannot assist with that request" errors, try 
 2. Go to [Azure AI Foundry](https://ai.azure.com/) and deploy a model.
 
    :::note
-   The deployment name must match the model name for opencode to work properly.
+   The deployment name must match the model name for Kilo CLI to work properly.
    :::
 
 3. Run the `/connect` command and search for **Azure Cognitive Services**.
@@ -484,7 +484,7 @@ Cloudflare AI Gateway lets you access models from OpenAI, Anthropic, Workers AI,
    /models
    ```
 
-   You can also add models through your opencode config.
+   You can also add models through your Kilo CLI config.
 
    ```json title="opencode.json"
    {
@@ -681,14 +681,14 @@ GitLab Duo provides AI-powered agentic chat with native tool calling capabilitie
 
 :::note
 You can also specify 'GITLAB_TOKEN' environment variable if you don't want
-to store token in opencode auth storage.
+to store token in Kilo CLI auth storage.
 :::
 
 ##### Self-Hosted GitLab
 
 :::note[compliance note]
-OpenCode uses a small model for some AI tasks like generating the session title.
-It is configured to use gpt-5-nano by default, hosted by Zen. To lock OpenCode
+Kilo CLI uses a small model for some AI tasks like generating the session title.
+It is configured to use gpt-5-nano by default, hosted by Zen. To lock Kilo CLI
 to only use your own GitLab-hosted instance, add the following to your
 `opencode.json` file. It is also recommended to disable session sharing.
 
@@ -788,7 +788,7 @@ This plugin provides comprehensive GitLab repository management capabilities inc
 
 ### GitHub Copilot
 
-To use your GitHub Copilot subscription with opencode:
+To use your GitHub Copilot subscription with Kilo CLI:
 
 :::note
 Some models might need a [Pro+
@@ -825,7 +825,7 @@ Some models need to be manually enabled in your [GitHub Copilot settings](https:
 
 ### Google Vertex AI
 
-To use Google Vertex AI with OpenCode:
+To use Google Vertex AI with Kilo CLI:
 
 1. Head over to the **Model Garden** in the Google Cloud Console and check the
    models available in your region.
@@ -841,7 +841,7 @@ To use Google Vertex AI with OpenCode:
      - `GOOGLE_APPLICATION_CREDENTIALS`: Path to your service account JSON key file
      - Authenticate using gcloud CLI: `gcloud auth application-default login`
 
-   Set them while running opencode.
+   Set them while running Kilo CLI.
 
    ```bash
    GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json GOOGLE_CLOUD_PROJECT=your-project-id opencode
@@ -954,7 +954,7 @@ For more providers and advanced features like caching and rate limiting, check t
 
 #### Optional Configs
 
-In the event you see a feature or model from Helicone that isn't configured automatically through opencode, you can always configure it yourself.
+In the event you see a feature or model from Helicone that isn't configured automatically through Kilo CLI, you can always configure it yourself.
 
 Here's [Helicone's Model Directory](https://helicone.ai/models), you'll need this to grab the IDs of the models you want to add.
 
@@ -1007,7 +1007,7 @@ Helicone supports custom headers for features like caching, user tracking, and s
 
 ##### Session tracking
 
-Helicone's [Sessions](https://docs.helicone.ai/features/sessions) feature lets you group related LLM requests together. Use the [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session) plugin to automatically log each OpenCode conversation as a session in Helicone.
+Helicone's [Sessions](https://docs.helicone.ai/features/sessions) feature lets you group related LLM requests together. Use the [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session) plugin to automatically log each Kilo CLI conversation as a session in Helicone.
 
 ```bash
 npm install -g opencode-helicone-session
@@ -1021,7 +1021,7 @@ Add it to your config.
 }
 ```
 
-The plugin injects `Helicone-Session-Id` and `Helicone-Session-Name` headers into your requests. In Helicone's Sessions page, you'll see each OpenCode conversation listed as a separate session.
+The plugin injects `Helicone-Session-Id` and `Helicone-Session-Name` headers into your requests. In Helicone's Sessions page, you'll see each Kilo CLI conversation listed as a separate session.
 
 ##### Common Helicone headers
 
@@ -1038,7 +1038,7 @@ See the [Helicone Header Directory](https://docs.helicone.ai/helicone-headers/he
 
 ### llama.cpp
 
-You can configure opencode to use local models through [llama.cpp's](https://github.com/ggml-org/llama.cpp) llama-server utility
+You can configure Kilo CLI to use local models through [llama.cpp's](https://github.com/ggml-org/llama.cpp) llama-server utility
 
 ```json title="opencode.json" "llama.cpp" {5, 6, 8, 10-15}
 {
@@ -1105,7 +1105,7 @@ IO.NET offers 17 models optimized for various use cases:
 
 ### LM Studio
 
-You can configure opencode to use local models through LM Studio.
+You can configure Kilo CLI to use local models through LM Studio.
 
 ```json title="opencode.json" "lmstudio" {5, 6, 8, 10-14}
 {
@@ -1222,7 +1222,7 @@ To use Kimi K2 from Moonshot AI:
 
 ### Ollama
 
-You can configure opencode to use local models through Ollama.
+You can configure Kilo CLI to use local models through Ollama.
 
 ```json title="opencode.json" "ollama" {5, 6, 8, 10-14}
 {
@@ -1260,13 +1260,13 @@ If tool calls aren't working, try increasing `num_ctx` in Ollama. Start around 1
 
 ### Ollama Cloud
 
-To use Ollama Cloud with OpenCode:
+To use Ollama Cloud with Kilo CLI:
 
 1. Head over to [https://ollama.com/](https://ollama.com/) and sign in or create an account.
 
 2. Navigate to **Settings** > **Keys** and click **Add API Key** to generate a new API key.
 
-3. Copy the API key for use in OpenCode.
+3. Copy the API key for use in Kilo CLI.
 
 4. Run the `/connect` command and search for **Ollama Cloud**.
 
@@ -1283,7 +1283,7 @@ To use Ollama Cloud with OpenCode:
    └ enter
    ```
 
-6. **Important**: Before using cloud models in OpenCode, you must pull the model information locally:
+6. **Important**: Before using cloud models in Kilo CLI, you must pull the model information locally:
 
    ```bash
    ollama pull gpt-oss:20b-cloud
@@ -1384,7 +1384,7 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
    /models
    ```
 
-   You can also add additional models through your opencode config.
+   You can also add additional models through your Kilo CLI config.
 
    ```json title="opencode.json" {6}
    {
@@ -1399,7 +1399,7 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
    }
    ```
 
-5. You can also customize them through your opencode config. Here's an example of specifying a provider
+5. You can also customize them through your Kilo CLI config. Here's an example of specifying a provider
 
    ```json title="opencode.json"
    {
@@ -1507,7 +1507,7 @@ SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon
 
 ### Scaleway
 
-To use [Scaleway Generative APIs](https://www.scaleway.com/en/docs/generative-apis/) with Opencode:
+To use [Scaleway Generative APIs](https://www.scaleway.com/en/docs/generative-apis/) with Kilo CLI:
 
 1. Head over to the [Scaleway Console IAM settings](https://console.scaleway.com/iam/api-keys) to generate a new API key.
 
@@ -1615,7 +1615,7 @@ Vercel AI Gateway lets you access models from OpenAI, Anthropic, Google, xAI, an
    /models
    ```
 
-You can also customize models through your opencode config. Here's an example of specifying provider routing order.
+You can also customize models through your Kilo CLI config. Here's an example of specifying provider routing order.
 
 ```json title="opencode.json"
 {
@@ -1725,7 +1725,7 @@ Some useful routing options:
    /models
    ```
 
-   You can also add additional models through your opencode config.
+   You can also add additional models through your Kilo CLI config.
 
    ```json title="opencode.json" {6}
    {
@@ -1747,7 +1747,7 @@ Some useful routing options:
 To add any **OpenAI-compatible** provider that's not listed in the `/connect` command:
 
 :::tip
-You can use any OpenAI-compatible provider with opencode. Most modern AI providers offer OpenAI-compatible APIs.
+You can use any OpenAI-compatible provider with Kilo CLI. Most modern AI providers offer OpenAI-compatible APIs.
 :::
 
 1. Run the `/connect` command and scroll down to **Other**.
@@ -1868,7 +1868,7 @@ Configuration details:
 - **limit.context**: Maximum input tokens the model accepts.
 - **limit.output**: Maximum tokens the model can generate.
 
-The `limit` fields allow OpenCode to understand how much context you have left. Standard providers pull these from models.dev automatically.
+The `limit` fields allow Kilo CLI to understand how much context you have left. Standard providers pull these from models.dev automatically.
 
 ---
 
@@ -1881,7 +1881,7 @@ If you are having trouble with configuring a provider, check the following:
 
    This doesn't apply to providers like Amazon Bedrock, that rely on environment variables for their auth.
 
-2. For custom providers, check the opencode config and:
-   - Make sure the provider ID used in the `/connect` command matches the ID in your opencode config.
+2. For custom providers, check the Kilo CLI config and:
+   - Make sure the provider ID used in the `/connect` command matches the ID in your Kilo CLI config.
    - The right npm package is used for the provider. For example, use `@ai-sdk/cerebras` for Cerebras. And for all other OpenAI-compatible providers, use `@ai-sdk/openai-compatible`.
    - Check correct API endpoint is used in the `options.baseURL` field.

--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -1,21 +1,21 @@
 ---
 title: Rules
-description: Set custom instructions for opencode.
+description: Set custom instructions for Kilo CLI.
 ---
 
-You can provide custom instructions to opencode by creating an `AGENTS.md` file. This is similar to Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
+You can provide custom instructions to Kilo CLI by creating an `AGENTS.md` file. This is similar to Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
 
 ---
 
 ## Initialize
 
-To create a new `AGENTS.md` file, you can run the `/init` command in opencode.
+To create a new `AGENTS.md` file, you can run the `/init` command in Kilo CLI.
 
 :::tip
 You should commit your project's `AGENTS.md` file to Git.
 :::
 
-This will scan your project and all its contents to understand what the project is about and generate an `AGENTS.md` file with it. This helps opencode to navigate the project better.
+This will scan your project and all its contents to understand what the project is about and generate an `AGENTS.md` file with it. This helps Kilo CLI to navigate the project better.
 
 If you have an existing `AGENTS.md` file, this will try to add to it.
 
@@ -54,7 +54,7 @@ We are adding project-specific instructions here and this will be shared across 
 
 ## Types
 
-opencode also supports reading the `AGENTS.md` file from multiple locations. And this serves different purposes.
+Kilo CLI also supports reading the `AGENTS.md` file from multiple locations. And this serves different purposes.
 
 ### Project
 
@@ -62,13 +62,13 @@ Place an `AGENTS.md` in your project root for project-specific rules. These only
 
 ### Global
 
-You can also have global rules in a `~/.config/opencode/AGENTS.md` file. This gets applied across all opencode sessions.
+You can also have global rules in a `~/.config/opencode/AGENTS.md` file. This gets applied across all Kilo CLI sessions.
 
 Since this isn't committed to Git or shared with your team, we recommend using this to specify any personal rules that the LLM should follow.
 
 ### Claude Code Compatibility
 
-For users migrating from Claude Code, OpenCode supports Claude Code's file conventions as fallbacks:
+For users migrating from Claude Code, Kilo CLI supports Claude Code's file conventions as fallbacks:
 
 - **Project rules**: `CLAUDE.md` in your project directory (used if no `AGENTS.md` exists)
 - **Global rules**: `~/.claude/CLAUDE.md` (used if no `~/.config/opencode/AGENTS.md` exists)
@@ -86,7 +86,7 @@ export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1 # Disable only .claude/skills
 
 ## Precedence
 
-When opencode starts, it looks for rule files in this order:
+When Kilo CLI starts, it looks for rule files in this order:
 
 1. **Local files** by traversing up from the current directory (`AGENTS.md`, `CLAUDE.md`, or `CONTEXT.md`)
 2. **Global file** at `~/.config/opencode/AGENTS.md`
@@ -126,7 +126,7 @@ All instruction files are combined with your `AGENTS.md` files.
 
 ## Referencing External Files
 
-While opencode doesn't automatically parse file references in `AGENTS.md`, you can achieve similar functionality in two ways:
+While Kilo CLI doesn't automatically parse file references in `AGENTS.md`, you can achieve similar functionality in two ways:
 
 ### Using opencode.json
 
@@ -141,7 +141,7 @@ The recommended approach is to use the `instructions` field in `opencode.json`:
 
 ### Manual Instructions in AGENTS.md
 
-You can teach opencode to read external files by providing explicit instructions in your `AGENTS.md`. Here's a practical example:
+You can teach Kilo CLI to read external files by providing explicit instructions in your `AGENTS.md`. Here's a practical example:
 
 ```markdown title="AGENTS.md"
 # TypeScript Project Rules
@@ -173,7 +173,7 @@ This approach allows you to:
 - Create modular, reusable rule files
 - Share rules across projects via symlinks or git submodules
 - Keep AGENTS.md concise while referencing detailed guidelines
-- Ensure opencode loads files only when needed for the specific task
+- Ensure Kilo CLI loads files only when needed for the specific task
 
 :::tip
 For monorepos or projects with shared standards, using `opencode.json` with glob patterns (like `packages/*/AGENTS.md`) is more maintainable than manual instructions.

--- a/packages/web/src/content/docs/sdk.mdx
+++ b/packages/web/src/content/docs/sdk.mdx
@@ -1,13 +1,13 @@
 ---
 title: SDK
-description: Type-safe JS client for opencode server.
+description: Type-safe JS client for Kilo CLI server.
 ---
 
 import config from "../../../config.mjs"
 export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types.gen.ts`
 
-The opencode JS/TS SDK provides a type-safe client for interacting with the server.
-Use it to build integrations and control opencode programmatically.
+The Kilo CLI JS/TS SDK provides a type-safe client for interacting with the server.
+Use it to build integrations and control Kilo CLI programmatically.
 
 [Learn more](/docs/server) about how the server works. For examples, check out the [projects](/docs/ecosystem#projects) built by the community.
 
@@ -25,7 +25,7 @@ npm install @opencode-ai/sdk
 
 ## Create client
 
-Create an instance of opencode:
+Create an instance of Kilo CLI:
 
 ```javascript
 import { createOpencode } from "@opencode-ai/sdk"
@@ -69,7 +69,7 @@ opencode.server.close()
 
 ## Client only
 
-If you already have a running instance of opencode, you can create a client instance to connect to it:
+If you already have a running instance of Kilo CLI, you can create a client instance to connect to it:
 
 ```javascript
 import { createOpencodeClient } from "@opencode-ai/sdk"

--- a/packages/web/src/content/docs/server.mdx
+++ b/packages/web/src/content/docs/server.mdx
@@ -1,12 +1,12 @@
 ---
 title: Server
-description: Interact with opencode server over HTTP.
+description: Interact with Kilo CLI server over HTTP.
 ---
 
 import config from "../../../config.mjs"
 export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types.gen.ts`
 
-The `opencode serve` command runs a headless HTTP server that exposes an OpenAPI endpoint that an opencode client can use.
+The `opencode serve` command runs a headless HTTP server that exposes an OpenAPI endpoint that an Kilo CLI client can use.
 
 ---
 
@@ -50,13 +50,13 @@ client that talks to the server. The server exposes an OpenAPI 3.1 spec
 endpoint. This endpoint is also used to generate an [SDK](/docs/sdk).
 
 :::tip
-Use the opencode server to interact with opencode programmatically.
+Use the Kilo CLI server to interact with Kilo CLI programmatically.
 :::
 
-This architecture lets opencode support multiple clients and allows you to interact with opencode programmatically.
+This architecture lets Kilo CLI support multiple clients and allows you to interact with Kilo CLI programmatically.
 
 You can run `opencode serve` to start a standalone server. If you have the
-opencode TUI running, `opencode serve` will start a new server.
+Kilo CLI TUI running, `opencode serve` will start a new server.
 
 ---
 
@@ -64,7 +64,7 @@ opencode TUI running, `opencode serve` will start a new server.
 
 When you start the TUI it randomly assigns a port and hostname. You can instead pass in the `--hostname` and `--port` [flags](/docs/cli). Then use this to connect to its server.
 
-The [`/tui`](#tui) endpoint can be used to drive the TUI through the server. For example, you can prefill or run a prompt. This setup is used by the OpenCode [IDE](/docs/ide) plugins.
+The [`/tui`](#tui) endpoint can be used to drive the TUI through the server. For example, you can prefill or run a prompt. This setup is used by the Kilo CLI [IDE](/docs/ide) plugins.
 
 ---
 
@@ -82,7 +82,7 @@ For example, `http://localhost:4096/doc`. Use the spec to generate clients or in
 
 ## APIs
 
-The opencode server exposes the following APIs.
+The Kilo CLI server exposes the following APIs.
 
 ---
 

--- a/packages/web/src/content/docs/share.mdx
+++ b/packages/web/src/content/docs/share.mdx
@@ -1,9 +1,9 @@
 ---
 title: Share
-description: Share your OpenCode conversations.
+description: Share your Kilo CLI conversations.
 ---
 
-OpenCode's share feature allows you to create public links to your OpenCode conversations, so you can collaborate with teammates or get help from others.
+Kilo CLI's share feature allows you to create public links to your Kilo CLI conversations, so you can collaborate with teammates or get help from others.
 
 :::note
 Shared conversations are publicly accessible to anyone with the link.
@@ -13,7 +13,7 @@ Shared conversations are publicly accessible to anyone with the link.
 
 ## How it works
 
-When you share a conversation, OpenCode:
+When you share a conversation, Kilo CLI:
 
 1. Creates a unique public URL for your session
 2. Syncs your conversation history to our servers
@@ -23,13 +23,13 @@ When you share a conversation, OpenCode:
 
 ## Sharing
 
-OpenCode supports three sharing modes that control how conversations are shared:
+Kilo CLI supports three sharing modes that control how conversations are shared:
 
 ---
 
 ### Manual (default)
 
-By default, OpenCode uses manual sharing mode. Sessions are not shared automatically, but you can manually share them using the `/share` command:
+By default, Kilo CLI uses manual sharing mode. Sessions are not shared automatically, but you can manually share them using the `/share` command:
 
 ```
 /share
@@ -125,4 +125,4 @@ For enterprise deployments, the share feature can be:
 - **Restricted** to users authenticated through SSO only
 - **Self-hosted** on your own infrastructure
 
-[Learn more](/docs/enterprise) about using opencode in your organization.
+[Learn more](/docs/enterprise) about using Kilo CLI in your organization.

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -3,7 +3,7 @@ title: "Agent Skills"
 description: "Define reusable behavior via SKILL.md definitions"
 ---
 
-Agent skills let OpenCode discover reusable instructions from your repo or home directory.
+Agent skills let Kilo CLI discover reusable instructions from your repo or home directory.
 Skills are loaded on-demand via the native `skill` tool—agents see available skills and can load the full content when needed.
 
 ---
@@ -11,7 +11,7 @@ Skills are loaded on-demand via the native `skill` tool—agents see available s
 ## Place files
 
 Create one folder per skill name and put a `SKILL.md` inside it.
-OpenCode searches these locations:
+Kilo CLI searches these locations:
 
 - Project config: `.opencode/skills/<name>/SKILL.md`
 - Global config: `~/.config/opencode/skills/<name>/SKILL.md`
@@ -22,7 +22,7 @@ OpenCode searches these locations:
 
 ## Understand discovery
 
-For project-local paths, OpenCode walks up from your current working directory until it reaches the git worktree.
+For project-local paths, Kilo CLI walks up from your current working directory until it reaches the git worktree.
 It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` along the way.
 
 Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md` and `~/.claude/skills/*/SKILL.md`.
@@ -100,7 +100,7 @@ Ask clarifying questions if the target versioning scheme is unclear.
 
 ## Recognize tool description
 
-OpenCode lists available skills in the `skill` tool description.
+Kilo CLI lists available skills in the `skill` tool description.
 Each entry includes the skill name and description:
 
 ```xml

--- a/packages/web/src/content/docs/themes.mdx
+++ b/packages/web/src/content/docs/themes.mdx
@@ -3,9 +3,9 @@ title: Themes
 description: Select a built-in theme or define your own.
 ---
 
-With OpenCode you can select from one of several built-in themes, use a theme that adapts to your terminal theme, or define your own custom theme.
+With Kilo CLI you can select from one of several built-in themes, use a theme that adapts to your terminal theme, or define your own custom theme.
 
-By default, OpenCode uses our own `opencode` theme.
+By default, Kilo CLI uses our own `opencode` theme.
 
 ---
 
@@ -23,7 +23,7 @@ Without truecolor support, themes may appear with reduced color accuracy or fall
 
 ## Built-in themes
 
-OpenCode comes with several built-in themes.
+Kilo CLI comes with several built-in themes.
 
 | Name                   | Description                                                                  |
 | ---------------------- | ---------------------------------------------------------------------------- |
@@ -53,7 +53,7 @@ The `system` theme is designed to automatically adapt to your terminal's color s
 
 The system theme is for users who:
 
-- Want OpenCode to match their terminal's appearance
+- Want Kilo CLI to match their terminal's appearance
 - Use custom terminal color schemes
 - Prefer a consistent look across all terminal applications
 
@@ -74,7 +74,7 @@ You can select a theme by bringing up the theme select with the `/theme` command
 
 ## Custom themes
 
-OpenCode supports a flexible JSON-based theme system that allows users to create and customize themes easily.
+Kilo CLI supports a flexible JSON-based theme system that allows users to create and customize themes easily.
 
 ---
 

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -3,7 +3,7 @@ title: Tools
 description: Manage the tools an LLM can use.
 ---
 
-Tools allow the LLM to perform actions in your codebase. OpenCode comes with a set of built-in tools, but you can extend it with [custom tools](/docs/custom-tools) or [MCP servers](/docs/mcp-servers).
+Tools allow the LLM to perform actions in your codebase. Kilo CLI comes with a set of built-in tools, but you can extend it with [custom tools](/docs/custom-tools) or [MCP servers](/docs/mcp-servers).
 
 By default, all tools are **enabled** and don't need permission to run. You can control tool behavior through [permissions](/docs/permissions).
 
@@ -41,7 +41,7 @@ You can also use wildcards to control multiple tools at once. For example, to re
 
 ## Built-in
 
-Here are all the built-in tools available in OpenCode.
+Here are all the built-in tools available in Kilo CLI.
 
 ---
 

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -3,7 +3,7 @@ title: Troubleshooting
 description: Common issues and how to resolve them.
 ---
 
-To debug issues with OpenCode, start by checking the logs and local data it stores on disk.
+To debug issues with Kilo CLI, start by checking the logs and local data it stores on disk.
 
 ---
 
@@ -22,7 +22,7 @@ You can set the log level with the `--log-level` command-line option to get more
 
 ## Storage
 
-opencode stores session data and other application data on disk at:
+Kilo CLI stores session data and other application data on disk at:
 
 - **macOS/Linux**: `~/.local/share/opencode/`
 - **Windows**: Press `WIN+R` and paste `%USERPROFILE%\.local\share\opencode`
@@ -165,7 +165,7 @@ To find the directory quickly:
 
 ## Getting help
 
-If you're experiencing issues with OpenCode:
+If you're experiencing issues with Kilo CLI:
 
 1. **Report issues on GitHub**
 
@@ -179,7 +179,7 @@ If you're experiencing issues with OpenCode:
 
    For real-time help and community discussion, join our Discord server:
 
-   [**opencode.ai/discord**](https://opencode.ai/discord)
+   [**kilo.ai/discord**](https://kilo.ai/discord)
 
 ---
 
@@ -189,7 +189,7 @@ Here are some common issues and how to resolve them.
 
 ---
 
-### OpenCode won't start
+### Kilo CLI won't start
 
 1. Check the logs for error messages
 2. Try running with `--print-logs` to see output in the terminal
@@ -246,7 +246,7 @@ To resolve this:
 
 ### AI_APICallError and provider package issues
 
-If you encounter API call errors, this may be due to outdated provider packages. opencode dynamically installs provider packages (OpenAI, Anthropic, Google, etc.) as needed and caches them locally.
+If you encounter API call errors, this may be due to outdated provider packages. Kilo CLI dynamically installs provider packages (OpenAI, Anthropic, Google, etc.) as needed and caches them locally.
 
 To resolve provider package issues:
 
@@ -258,9 +258,9 @@ To resolve provider package issues:
 
    On Windows, press `WIN+R` and delete: `%USERPROFILE%\.cache\opencode`
 
-2. Restart opencode to reinstall the latest provider packages
+2. Restart Kilo CLI to reinstall the latest provider packages
 
-This will force opencode to download the most recent versions of provider packages, which often resolves compatibility issues with model parameters and API changes.
+This will force Kilo CLI to download the most recent versions of provider packages, which often resolves compatibility issues with model parameters and API changes.
 
 ---
 
@@ -291,4 +291,4 @@ Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 export DISPLAY=:99.0
 ```
 
-opencode will detect if you're using Wayland and prefer `wl-clipboard`, otherwise it will try to find clipboard tools in order of: `xclip` and `xsel`.
+Kilo CLI will detect if you're using Wayland and prefer `wl-clipboard`, otherwise it will try to find clipboard tools in order of: `xclip` and `xsel`.

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -1,13 +1,13 @@
 ---
 title: TUI
-description: Using the OpenCode terminal user interface.
+description: Using the Kilo CLI terminal user interface.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components"
 
-OpenCode provides an interactive terminal interface or TUI for working on your projects with an LLM.
+Kilo CLI provides an interactive terminal interface or TUI for working on your projects with an LLM.
 
-Running OpenCode starts the TUI for the current directory.
+Running Kilo CLI starts the TUI for the current directory.
 
 ```bash
 opencode
@@ -57,7 +57,7 @@ The output of the command is added to the conversation as a tool result.
 
 ## Commands
 
-When using the OpenCode TUI, you can type `/` followed by a command name to quickly execute actions. For example:
+When using the Kilo CLI TUI, you can type `/` followed by a command name to quickly execute actions. For example:
 
 ```bash frame="none"
 /help
@@ -71,7 +71,7 @@ Here are all available slash commands:
 
 ### connect
 
-Add a provider to OpenCode. Allows you to select from available providers and add their API keys.
+Add a provider to Kilo CLI. Allows you to select from available providers and add their API keys.
 
 ```bash frame="none"
 /connect
@@ -117,7 +117,7 @@ Open external editor for composing messages. Uses the editor set in your `EDITOR
 
 ### exit
 
-Exit OpenCode. _Aliases_: `/quit`, `/q`
+Exit Kilo CLI. _Aliases_: `/quit`, `/q`
 
 ```bash frame="none"
 /exit
@@ -355,7 +355,7 @@ Some editors need command-line arguments to run in blocking mode. The `--wait` f
 
 ## Configure
 
-You can customize TUI behavior through your OpenCode config file.
+You can customize TUI behavior through your Kilo CLI config file.
 
 ```json title="opencode.json"
 {


### PR DESCRIPTION
### What does this PR do?
It updates text in the support docs to use 'Kilo CLI' instead of 'OpenCode'
Some caveats:
- docs still contain a lot of references to `opencode` in the code blocks
- did not update all docs in this folder because I wasn't sure about the desired changes (github/gitlab support, OpenCode Zen, desktop app)
