### PR TITLE
feat: use provider-reported cost for OpenRouter/Kilo in sidebar

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -451,6 +451,19 @@ export namespace Session {
         },
       }
 
+      // kilocode_change start - Use provider-reported cost when available for OpenRouter/Kilo
+      // The OpenRouter AI SDK provider exposes cost at providerMetadata.openrouter.usage.cost
+      const openrouterUsage = input.metadata?.["openrouter"]?.["usage"] as { cost?: number } | undefined
+      const providerCost = openrouterUsage?.cost
+
+      if (providerCost !== undefined && providerCost !== null && Number.isFinite(providerCost)) {
+        return {
+          cost: safe(providerCost),
+          tokens,
+        }
+      }
+      // kilocode_change end
+
       const costInfo =
         input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
           ? input.model.cost.experimentalOver200K


### PR DESCRIPTION
## Summary

Use the actual cost from OpenRouter's `usage.cost` field instead of calculating locally. This ensures the sidebar displays the real billed cost for Kilo provider users.

## Problem

The opencode sidebar was calculating costs locally using model pricing data, but for the Kilo provider, the actual cost from OpenRouter may differ due to:
- Stale pricing data
- OpenRouter promotions/discounts
- BYOK (Bring Your Own Key) handling
- Rounding differences

## Solution

The OpenRouter AI SDK provider exposes the actual cost at `providerMetadata.openrouter.usage.cost`. This PR modifies `Session.getUsage()` to check for this provider-reported cost first, falling back to local calculation for other providers or when the cost is not available.

## Changes

- **`packages/opencode/src/session/index.ts`**: Added check for OpenRouter provider cost in `getUsage()` function
- **`packages/opencode/test/session/compaction.test.ts`**: Added 3 tests for the new functionality

## Testing

All tests pass:
```
✓ session.getUsage > uses openrouter provider cost when available
✓ session.getUsage > falls back to calculated cost when openrouter cost is not available  
✓ session.getUsage > falls back to calculated cost when openrouter metadata is empty
```

<img width="413" height="179" alt="image" src="https://github.com/user-attachments/assets/0cc4a290-bead-475b-b2c9-06a0f5cb221b" />
