### PR TITLE
feat(contributing): add kilo-plugin-contributing package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -286,6 +286,20 @@
         "solid-js",
       ],
     },
+    "packages/kilo-plugin-contributing": {
+      "name": "@kilocode/kilo-plugin-contributing",
+      "version": "1.0.0",
+      "dependencies": {
+        "@opencode-ai/plugin": "workspace:*",
+      },
+      "devDependencies": {
+        "@tsconfig/bun": "catalog:",
+        "@types/bun": "1.3.5",
+        "@types/node": "catalog:",
+        "@typescript/native-preview": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/opencode": {
       "name": "@kilocode/cli",
       "version": "1.1.36",
@@ -1147,6 +1161,8 @@
     "@kilocode/cli": ["@kilocode/cli@workspace:packages/opencode"],
 
     "@kilocode/kilo-gateway": ["@kilocode/kilo-gateway@workspace:packages/kilo-gateway"],
+
+    "@kilocode/kilo-plugin-contributing": ["@kilocode/kilo-plugin-contributing@workspace:packages/kilo-plugin-contributing"],
 
     "@kobalte/core": ["@kobalte/core@0.13.11", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@internationalized/date": "^3.4.0", "@internationalized/number": "^3.2.1", "@kobalte/utils": "^0.9.1", "@solid-primitives/props": "^3.1.8", "@solid-primitives/resize-observer": "^2.0.26", "solid-presence": "^0.1.8", "solid-prevent-scroll": "^0.1.4" }, "peerDependencies": { "solid-js": "^1.8.15" } }, "sha512-hK7TYpdib/XDb/r/4XDBFaO9O+3ZHz4ZWryV4/3BfES+tSQVgg2IJupDnztKXB0BqbSRy/aWlHKw1SPtNPYCFQ=="],
 

--- a/packages/kilo-plugin-contributing/README.md
+++ b/packages/kilo-plugin-contributing/README.md
@@ -1,0 +1,42 @@
+# kilo-plugin-contributing
+
+An OpenCode plugin that generates and maintains a living contributing guide for your project.
+
+## Overview
+
+This plugin helps maintain a comprehensive `CONTRIBUTING.md` document that serves as the definitive guide for AI agents and human contributors working on your project. The guide covers:
+
+- **Brief Overview** - High-level project description and purpose
+- **Technology Choices** - Languages, frameworks, and tooling decisions
+- **Development** - Setup, workflow, and coding standards
+- **Architecture** - System design, patterns, and structure
+- **Product** - Features, goals, and domain knowledge
+
+## How It Works
+
+The plugin hooks into `experimental.chat.system.transform` to:
+
+1. Read the current contents of your project's contributing guide
+2. Inject the guide into the system prompt so the AI has full context
+3. Encourage the AI to keep the contributing guide up-to-date as it learns about the project
+
+This creates a feedback loop where the AI both reads from and writes to the contributing guide, keeping it accurate and comprehensive over time.
+
+## Installation
+
+```
+npm install -S @kilocode/kilo-plugin-contributing
+```
+
+Add the plugin to your OpenCode configuration:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@kilocode/kilo-plugin-contributing"]
+}
+```
+
+## Configuration
+
+The plugin expects a `CONTRIBUTING.md` file in your project root. If one doesn't exist, it will be created with a template structure.

--- a/packages/kilo-plugin-contributing/package.json
+++ b/packages/kilo-plugin-contributing/package.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@kilocode/kilo-plugin-contributing",
+  "version": "1.0.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Kilo plugin for contributing guidelines and workflows",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@opencode-ai/plugin": "workspace:*"
+  },
+  "devDependencies": {
+    "@tsconfig/bun": "catalog:",
+    "@types/bun": "1.3.5",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/kilo-plugin-contributing/src/contributing.plugin.ts
+++ b/packages/kilo-plugin-contributing/src/contributing.plugin.ts
@@ -1,0 +1,49 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { join } from "node:path"
+
+const CONTRIBUTING_FILE = process.env.KILOCODE_CONTRIBUTING_FILE ?? ".kilocode/CONTRIBUTING.md"
+const service = "kilo-plugin-contributing"
+
+export const ContributingPlugin: Plugin = async (ctx) => {
+  const path = join(ctx.directory, CONTRIBUTING_FILE)
+  const file = Bun.file(path)
+
+  void ctx.client.app.log({
+    body: {
+      level: "debug",
+      service,
+      message: `Plugin initalized with path ${path}`,
+    },
+  })
+
+  return {
+    "experimental.chat.system.transform": async (_input, output) => {
+      if (!(await file.exists())) {
+        await ctx.client.app.log({
+          body: {
+            level: "debug",
+            service,
+            message: `No contributing guide found at ${path}`,
+          },
+        })
+        return
+      }
+
+      const content = await file.text()
+
+      output.system.push(getPrompt(path, content))
+    },
+  }
+}
+function getPrompt(contributingPath: string, content: string) {
+  return `
+You have access to this project's contributing guide below. As you work on this project:
+- Reference the contributing guide for context on architecture, conventions, and decisions
+- If you discover new patterns, make architectural decisions, or learn important project details, update the contributing guide to reflect this knowledge
+- Keep the contributing guide accurate, concise, and comprehensive
+- Update the contributing guide with the write tool at file path: ${contributingPath}
+
+# Contributing Guide
+
+${content}`
+}

--- a/packages/kilo-plugin-contributing/src/index.ts
+++ b/packages/kilo-plugin-contributing/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./contributing.plugin"

--- a/packages/kilo-plugin-contributing/tsconfig.json
+++ b/packages/kilo-plugin-contributing/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "preserve",
+    "declaration": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Introduce a new plugin that manages a living contributing guide by injecting `.kilocode/CONTRIBUTING.md` into the system prompt. This allows AI agents to maintain project context and update documentation as they learn about the codebase.

- Create `@kilocode/kilo-plugin-contributing` package
- Implement `experimental.chat.system.transform` hook
- Add automatic prompt injection for contributing guidelines
- Include README and configuration boilerplate