### PR TITLE
fix: replace Blacksmith runners with GitHub-hosted runners

### DIFF
--- a/.github/workflows/daily-issues-recap.yml
+++ b/.github/workflows/daily-issues-recap.yml
@@ -11,7 +11,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode Discord integration)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/daily-pr-recap.yml
+++ b/.github/workflows/daily-pr-recap.yml
@@ -11,7 +11,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode Discord integration)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode infrastructure deployment)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -13,7 +13,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode docs automation)
     if: false
     # kilocode_change end - original: if: github.repository == 'sst/opencode'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -9,7 +9,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (requires OpenCode API key and install)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -21,7 +21,7 @@ jobs:
     #   github.event.pull_request.user.login != 'adamdotdevin' &&
     #   github.event.pull_request.user.login != 'iamdavidhill' &&
     #   github.event.pull_request.user.login != 'opencode-agent[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   generate:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/nix-desktop.yml
+++ b/.github/workflows/nix-desktop.yml
@@ -26,8 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-4vcpu-ubuntu-2404
-          - blacksmith-4vcpu-ubuntu-2404-arm
+          - ubuntu-latest # kilocode_change - replaced blacksmith runner
+          - ubuntu-24.04-arm # kilocode_change - replaced blacksmith runner
           - macos-15-intel
           - macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -9,7 +9,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode Discord notifications)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - name: Send nicely-formatted embed to Discord
         uses: SethCohen/github-releases-to-discord@v1

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,7 +17,7 @@ jobs:
     #   startsWith(github.event.comment.body, '/oc') ||
     #   contains(github.event.comment.body, ' /opencode') ||
     #   startsWith(github.event.comment.body, '/opencode')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/publish-github-action.yml
+++ b/.github/workflows/publish-github-action.yml
@@ -17,7 +17,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode GitHub Action publishing)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -16,7 +16,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode VSCode extension publishing)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     # kilocode_change start - disabled for kilo-cli fork (OpenCode npm/AUR publishing)
     if: false
     # kilocode_change end - original: if: github.repository == 'anomalyco/opencode'
@@ -103,11 +103,11 @@ jobs:
             target: x86_64-apple-darwin
           - host: macos-latest
             target: aarch64-apple-darwin
-          - host: blacksmith-4vcpu-windows-2025
+          - host: windows-latest # kilocode_change - replaced blacksmith runner
             target: x86_64-pc-windows-msvc
-          - host: blacksmith-4vcpu-ubuntu-2404
+          - host: ubuntu-latest # kilocode_change - replaced blacksmith runner
             target: x86_64-unknown-linux-gnu
-          - host: blacksmith-4vcpu-ubuntu-2404-arm
+          - host: ubuntu-24.04-arm # kilocode_change - replaced blacksmith runner
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -212,7 +212,7 @@ jobs:
       - publish
       - publish-tauri
     if: needs.publish.outputs.tag
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -17,7 +17,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode GitHub Action release)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -14,7 +14,7 @@ jobs:
     #   github.event.issue.pull_request &&
     #   startsWith(github.event.comment.body, '/review') &&
     #   contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -12,7 +12,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (OpenCode stats tracking)
     if: false
     # kilocode_change end - original: if: github.repository == 'anomalyco/opencode'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: write
 

--- a/.github/workflows/sync-zed-extension.yml
+++ b/.github/workflows/sync-zed-extension.yml
@@ -11,7 +11,7 @@ jobs:
     if: false
     # kilocode_change end
     name: Release Zed Extension
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         settings:
           - name: linux
-            host: blacksmith-4vcpu-ubuntu-2404
+            host: ubuntu-latest # kilocode_change - replaced blacksmith runner
             playwright: bunx playwright install --with-deps
             workdir: .
             command: |

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -9,7 +9,7 @@ jobs:
     # kilocode_change start - disabled for kilo-cli fork (requires OpenCode API key and install)
     if: false
     # kilocode_change end
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   update-node-modules-hashes:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest # kilocode_change - replaced blacksmith runner
     env:
       TITLE: node_modules hashes
 


### PR DESCRIPTION
Replace all Blacksmith runner references with standard GitHub-hosted runners:
- blacksmith-4vcpu-ubuntu-2404 → ubuntu-latest
- blacksmith-4vcpu-ubuntu-2404-arm → ubuntu-24.04-arm
- blacksmith-4vcpu-windows-2025 → windows-latest

This enables GitHub Actions to run in the Kilo-Org fork which doesn't have access to Blacksmith runners.

Files modified (18 total):
- test.yml, typecheck.yml, deploy.yml, publish.yml
- daily-issues-recap.yml, daily-pr-recap.yml, docs-update.yml
- duplicate-issues.yml, duplicate-prs.yml, generate.yml
- nix-desktop.yml, notify-discord.yml, opencode.yml
- publish-github-action.yml, publish-vscode.yml
- release-github-action.yml, review.yml, stats.yml
- sync-zed-extension.yml, triage.yml, update-nix-hashes.yml

### What does this PR do?

### How did you verify your code works?
