### PR TITLE
feat: Formatting for markdown tables in agent messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -74,6 +74,7 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { formatMarkdownTables } from "../../util/markdown" // kilocode_change
 
 addDefaultParsers(parsers.parsers)
 
@@ -1347,6 +1348,9 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  // kilocode_change start - format markdown tables with fixed-width columns
+  const content = createMemo(() => formatMarkdownTables(props.part.text.trim()))
+  // kilocode_change end
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1355,7 +1359,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           drawUnstyledText={false}
           streaming={true}
           syntaxStyle={syntax()}
-          content={props.part.text.trim()}
+          content={content()}
           conceal={ctx.conceal()}
           fg={theme.text}
         />

--- a/packages/opencode/src/cli/cmd/tui/util/markdown.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/markdown.ts
@@ -1,0 +1,212 @@
+// kilocode_change - new file
+
+/**
+ * Formats markdown tables with fixed-width columns, similar to VS Code's behavior.
+ * This normalizes column widths so tables render with aligned columns.
+ */
+
+type TableRow = string[]
+
+interface Table {
+  startIndex: number
+  endIndex: number
+  rows: TableRow[]
+  alignments: ("left" | "center" | "right" | "none")[]
+}
+
+/**
+ * Parses a single table row, splitting by | and trimming cells
+ */
+function parseRow(line: string): TableRow | null {
+  // Must start and end with | (after trimming)
+  const trimmed = line.trim()
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) return null
+
+  // Split by | and remove first/last empty elements
+  const cells = trimmed.split("|").slice(1, -1)
+  return cells.map((cell) => cell.trim())
+}
+
+/**
+ * Checks if a row is a separator row (contains only dashes, colons, and spaces)
+ */
+function isSeparatorRow(cells: TableRow): boolean {
+  return cells.every((cell) => /^:?-+:?$/.test(cell))
+}
+
+/**
+ * Extracts alignment from separator row cells
+ */
+function getAlignment(cell: string): "left" | "center" | "right" | "none" {
+  const left = cell.startsWith(":")
+  const right = cell.endsWith(":")
+  if (left && right) return "center"
+  if (right) return "right"
+  if (left) return "left"
+  return "none"
+}
+
+/**
+ * Gets the display width of a string, accounting for wide characters
+ */
+function getDisplayWidth(str: string): number {
+  let width = 0
+  for (const char of str) {
+    const code = char.codePointAt(0)!
+    // Check for wide characters (CJK, etc.)
+    if (
+      (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
+      (code >= 0x2e80 && code <= 0x9fff) || // CJK
+      (code >= 0xac00 && code <= 0xd7a3) || // Hangul Syllables
+      (code >= 0xf900 && code <= 0xfaff) || // CJK Compatibility Ideographs
+      (code >= 0xfe10 && code <= 0xfe1f) || // Vertical forms
+      (code >= 0xfe30 && code <= 0xfe6f) || // CJK Compatibility Forms
+      (code >= 0xff00 && code <= 0xff60) || // Fullwidth Forms
+      (code >= 0xffe0 && code <= 0xffe6) || // Fullwidth symbols
+      (code >= 0x20000 && code <= 0x2fffd) || // CJK Extension B-F
+      (code >= 0x30000 && code <= 0x3fffd) // CJK Extension G
+    ) {
+      width += 2
+    } else {
+      width += 1
+    }
+  }
+  return width
+}
+
+/**
+ * Pads a string to a target display width
+ */
+function padToWidth(str: string, width: number, align: "left" | "center" | "right" | "none"): string {
+  const currentWidth = getDisplayWidth(str)
+  const padding = width - currentWidth
+  if (padding <= 0) return str
+
+  switch (align) {
+    case "center": {
+      const left = Math.floor(padding / 2)
+      const right = padding - left
+      return " ".repeat(left) + str + " ".repeat(right)
+    }
+    case "right":
+      return " ".repeat(padding) + str
+    default:
+      return str + " ".repeat(padding)
+  }
+}
+
+/**
+ * Finds all markdown tables in the content
+ */
+function findTables(lines: string[]): Table[] {
+  const tables: Table[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    // Try to parse as table row
+    const headerCells = parseRow(lines[i])
+    if (!headerCells || headerCells.length === 0) {
+      i++
+      continue
+    }
+
+    // Check if next line is separator
+    if (i + 1 >= lines.length) {
+      i++
+      continue
+    }
+
+    const separatorCells = parseRow(lines[i + 1])
+    if (!separatorCells || !isSeparatorRow(separatorCells)) {
+      i++
+      continue
+    }
+
+    // Found a table! Parse all rows
+    const table: Table = {
+      startIndex: i,
+      endIndex: i + 1,
+      rows: [headerCells, separatorCells],
+      alignments: separatorCells.map(getAlignment),
+    }
+
+    // Continue parsing data rows
+    let j = i + 2
+    while (j < lines.length) {
+      const rowCells = parseRow(lines[j])
+      if (!rowCells) break
+      table.rows.push(rowCells)
+      table.endIndex = j
+      j++
+    }
+
+    tables.push(table)
+    i = j
+  }
+
+  return tables
+}
+
+/**
+ * Formats a table with fixed-width columns
+ */
+function formatTable(table: Table): string[] {
+  const columnCount = Math.max(...table.rows.map((row) => row.length))
+
+  // Calculate max width for each column
+  const columnWidths: number[] = Array(columnCount).fill(0)
+
+  for (const row of table.rows) {
+    for (let col = 0; col < columnCount; col++) {
+      const cell = row[col] ?? ""
+      // For separator rows, we use a minimum width of 3 (---)
+      if (isSeparatorRow(row)) {
+        columnWidths[col] = Math.max(columnWidths[col], 3)
+      } else {
+        columnWidths[col] = Math.max(columnWidths[col], getDisplayWidth(cell))
+      }
+    }
+  }
+
+  // Format each row
+  return table.rows.map((row, rowIndex) => {
+    const cells: string[] = []
+    for (let col = 0; col < columnCount; col++) {
+      const cell = row[col] ?? ""
+      const width = columnWidths[col]
+      const align = table.alignments[col] ?? "none"
+
+      if (rowIndex === 1) {
+        // Separator row - create dashes to match column width
+        const hasLeft = align === "left" || align === "center"
+        const hasRight = align === "right" || align === "center"
+        const dashCount = width - (hasLeft ? 1 : 0) - (hasRight ? 1 : 0)
+        const dashes = "-".repeat(Math.max(dashCount, 1))
+        cells.push((hasLeft ? ":" : "") + dashes + (hasRight ? ":" : ""))
+      } else {
+        cells.push(padToWidth(cell, width, align))
+      }
+    }
+    return "| " + cells.join(" | ") + " |"
+  })
+}
+
+/**
+ * Formats all markdown tables in the content with fixed-width columns.
+ * Tables that don't follow standard markdown table syntax are left unchanged.
+ */
+export function formatMarkdownTables(content: string): string {
+  const lines = content.split("\n")
+  const tables = findTables(lines)
+
+  if (tables.length === 0) return content
+
+  // Process tables in reverse order to maintain correct indices
+  for (let i = tables.length - 1; i >= 0; i--) {
+    const table = tables[i]
+    const formatted = formatTable(table)
+    lines.splice(table.startIndex, table.endIndex - table.startIndex + 1, ...formatted)
+  }
+
+  return lines.join("\n")
+}

--- a/packages/opencode/test/cli/tui/markdown.test.ts
+++ b/packages/opencode/test/cli/tui/markdown.test.ts
@@ -1,0 +1,162 @@
+// kilocode_change - new file
+import { describe, expect, it } from "bun:test"
+import { formatMarkdownTables } from "../../../src/cli/cmd/tui/util/markdown"
+
+describe("formatMarkdownTables", () => {
+  it("formats a simple table with fixed-width columns", () => {
+    const input = `| Name | Age |
+| --- | --- |
+| Alice | 30 |
+| Bob | 25 |`
+
+    const result = formatMarkdownTables(input)
+
+    // Each column should be padded to consistent width
+    const lines = result.split("\n")
+    expect(lines).toHaveLength(4)
+
+    // Check that all pipes are aligned
+    const pipePositions = lines.map((line) => {
+      const positions: number[] = []
+      for (let i = 0; i < line.length; i++) {
+        if (line[i] === "|") positions.push(i)
+      }
+      return positions
+    })
+
+    // All rows should have same pipe positions
+    for (let i = 1; i < pipePositions.length; i++) {
+      expect(pipePositions[i]).toEqual(pipePositions[0])
+    }
+  })
+
+  it("handles tables with varying cell widths", () => {
+    const input = `| Short | Very Long Header |
+| --- | --- |
+| A | B |
+| Much Longer Cell | X |`
+
+    const result = formatMarkdownTables(input)
+    const lines = result.split("\n")
+
+    // Column widths should be normalized
+    expect(lines[0]).toContain("Short")
+    expect(lines[0]).toContain("Very Long Header")
+    expect(lines[3]).toContain("Much Longer Cell")
+  })
+
+  it("preserves column alignment", () => {
+    const input = `| Left | Center | Right |
+| :--- | :---: | ---: |
+| 1 | 2 | 3 |`
+
+    const result = formatMarkdownTables(input)
+    const lines = result.split("\n")
+
+    // Check that alignment markers are preserved
+    expect(lines[1]).toContain(":--")
+    expect(lines[1]).toMatch(/:.*:/) // center has colons on both sides
+    expect(lines[1]).toMatch(/-+:/) // right-aligned ends with colon
+  })
+
+  it("handles content without tables unchanged", () => {
+    const input = `# Hello World
+
+This is a paragraph.
+
+- List item 1
+- List item 2`
+
+    const result = formatMarkdownTables(input)
+    expect(result).toBe(input)
+  })
+
+  it("handles multiple tables in content", () => {
+    const input = `# First Table
+
+| A | B |
+| --- | --- |
+| 1 | 2 |
+
+Some text between tables.
+
+| Column One | Column Two |
+| --- | --- |
+| Value | Another Value |`
+
+    const result = formatMarkdownTables(input)
+
+    // Both tables should be formatted
+    expect(result).toContain("| A ")
+    expect(result).toContain("| Column One ")
+  })
+
+  it("handles tables with empty cells", () => {
+    const input = `| Header 1 | Header 2 |
+| --- | --- |
+| Value |  |
+|  | Value |`
+
+    const result = formatMarkdownTables(input)
+    const lines = result.split("\n")
+
+    // Should still format correctly with empty cells
+    expect(lines).toHaveLength(4)
+    // Pipes should still be aligned
+    const firstPipe = lines[0].indexOf("|")
+    for (const line of lines) {
+      expect(line[firstPipe]).toBe("|")
+    }
+  })
+
+  it("handles tables with extra columns in some rows", () => {
+    const input = `| A | B |
+| --- | --- |
+| 1 | 2 | 3 |`
+
+    const result = formatMarkdownTables(input)
+    const lines = result.split("\n")
+
+    // Should handle the extra column
+    expect(lines[2]).toContain("3")
+  })
+
+  it("ignores malformed tables", () => {
+    const input = `| Not a table
+Just some text with pipes |`
+
+    const result = formatMarkdownTables(input)
+    expect(result).toBe(input)
+  })
+
+  it("handles tables without leading/trailing pipes", () => {
+    // Standard markdown tables require pipes
+    const input = `Name | Age
+--- | ---
+Alice | 30`
+
+    const result = formatMarkdownTables(input)
+    // Without proper pipe syntax, this shouldn't be formatted as a table
+    expect(result).toBe(input)
+  })
+
+  it("formats table embedded in markdown content", () => {
+    const input = `Here is some information:
+
+| Feature | Status |
+| --- | --- |
+| Tables | Supported |
+| Lists | Supported |
+
+And some more text after the table.`
+
+    const result = formatMarkdownTables(input)
+
+    // The table portion should be formatted
+    expect(result).toContain("| Feature")
+    expect(result).toContain("| Tables")
+    // Non-table content should be preserved
+    expect(result).toContain("Here is some information:")
+    expect(result).toContain("And some more text after the table.")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

When an agent outputs a table in markdown, it looks like this
<img width="2754" height="1116" alt="CleanShot 2026-01-28 at 14 48 03@2x" src="https://github.com/user-attachments/assets/19ad53bb-f421-4097-9aa2-91296c592519" />

But I think that formating it the way VSCode auto-markdown formating works is more readable

<img width="2652" height="964" alt="CleanShot 2026-01-28 at 14 46 55@2x" src="https://github.com/user-attachments/assets/63bed343-8a0d-4f2a-b191-cc22c348c0b0" />

### How did you verify your code works?

The screenshots above are before and after on the same session.

It's possible we'd want to upstream this instead.
