### PR TITLE
Add legacy Kilo CLI auth migration

### DIFF
--- a/packages/kilo-gateway/src/auth/legacy-migration.ts
+++ b/packages/kilo-gateway/src/auth/legacy-migration.ts
@@ -1,0 +1,101 @@
+// kilocode_change - new file
+/**
+ * Legacy Kilo CLI migration module
+ *
+ * Migrates authentication from the legacy Kilo Code VS Code extension CLI
+ * config path (~/.kilocode/cli/config.json) to the new auth.json format.
+ */
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+
+export const LEGACY_CONFIG_PATH = path.join(os.homedir(), ".kilocode", "cli", "config.json")
+
+interface LegacyProvider {
+  id: string
+  provider: string
+  kilocodeToken?: string
+  kilocodeModel?: string
+  kilocodeOrganizationId?: string
+}
+
+interface LegacyConfig {
+  providers?: LegacyProvider[]
+}
+
+interface LegacyKiloAuth {
+  token: string
+  organizationId?: string
+}
+
+// Auth info types matching opencode's Auth module
+type ApiAuth = { type: "api"; key: string }
+type OAuthAuth = { type: "oauth"; access: string; refresh: string; expires: number; accountId?: string }
+type AuthInfo = ApiAuth | OAuthAuth
+
+/**
+ * Extract kilo auth from legacy config
+ */
+function extractKiloAuth(config: LegacyConfig): LegacyKiloAuth | undefined {
+  if (!config.providers) return undefined
+
+  const provider = config.providers.find((p) => p.provider === "kilocode")
+  if (!provider?.kilocodeToken) return undefined
+
+  return {
+    token: provider.kilocodeToken,
+    organizationId: provider.kilocodeOrganizationId,
+  }
+}
+
+/**
+ * Migrate Kilo authentication from legacy CLI config path.
+ *
+ * Checks ~/.kilocode/cli/config.json for existing kilo credentials
+ * and migrates them to the new auth.json format.
+ *
+ * @param hasKiloAuth - Callback to check if kilo auth already exists
+ * @param saveKiloAuth - Callback to save the migrated auth
+ * @returns true if migration was performed, false otherwise
+ */
+export async function migrateLegacyKiloAuth(
+  hasKiloAuth: () => Promise<boolean>,
+  saveKiloAuth: (auth: AuthInfo) => Promise<void>,
+): Promise<boolean> {
+  // Skip if kilo auth already configured
+  if (await hasKiloAuth()) return false
+
+  // Check if legacy config exists and parse it
+  const content = await fs.readFile(LEGACY_CONFIG_PATH, "utf-8").catch(() => null)
+  if (!content) return false
+
+  let config: LegacyConfig | null = null
+  try {
+    config = JSON.parse(content) as LegacyConfig
+  } catch {
+    return false
+  }
+
+  // Extract kilo auth from legacy config
+  const legacy = extractKiloAuth(config)
+  if (!legacy) return false
+
+  // Migrate to new format
+  // Use OAuth format if organization ID present, otherwise API format
+  if (legacy.organizationId) {
+    await saveKiloAuth({
+      type: "oauth",
+      access: legacy.token,
+      refresh: "",
+      expires: 0,
+      accountId: legacy.organizationId,
+    })
+  } else {
+    await saveKiloAuth({
+      type: "api",
+      key: legacy.token,
+    })
+  }
+
+  return true
+}

--- a/packages/kilo-gateway/src/index.ts
+++ b/packages/kilo-gateway/src/index.ts
@@ -18,6 +18,7 @@ export { authenticateWithDeviceAuth } from "./auth/device-auth.js"
 export { authenticateWithDeviceAuthTUI } from "./auth/device-auth-tui.js"
 export { getKiloUrlFromToken, isValidKilocodeToken, getApiKey } from "./auth/token.js"
 export { poll, formatTimeRemaining } from "./auth/polling.js"
+export { migrateLegacyKiloAuth, LEGACY_CONFIG_PATH } from "./auth/legacy-migration.js"
 
 // ============================================================================
 // API

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -26,8 +26,9 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
-// kilocode_change start - Import telemetry
+// kilocode_change start - Import telemetry and legacy migration
 import { Telemetry } from "@kilocode/kilo-telemetry"
+import { migrateLegacyKiloAuth } from "@kilocode/kilo-gateway"
 import { Global } from "./global"
 import { Config } from "./config/config"
 import { Auth } from "./auth"
@@ -88,6 +89,12 @@ const cli = yargs(hideBin(process.argv))
       version: Installation.VERSION,
       enabled: globalCfg.experimental?.openTelemetry !== false,
     })
+
+    // Migrate legacy Kilo CLI auth if needed
+    await migrateLegacyKiloAuth(
+      async () => (await Auth.get("kilo")) !== undefined,
+      async (auth) => Auth.set("kilo", auth),
+    )
 
     const kiloAuth = await Auth.get("kilo")
     if (kiloAuth) {


### PR DESCRIPTION
Summary
- Automatically migrate Kilo authentication from the legacy VS Code extension CLI config path (~/.kilocode/cli/config.json) to the new auth.json format
- Support migration of both kilocodeToken and kilocodeOrganizationId fields
Details
When users upgrade from the Kilo Code VS Code extension CLI to Kilo CLI, their existing authentication credentials are now automatically migrated on first run. This provides a seamless transition without requiring users to re-authenticate.

Migration behavior:
- Silent migration - no user notification for a seamless experience
- Legacy file preserved - original config is not deleted in case of rollback
- One-time migration - only runs if auth.json doesn't already have kilo credentials configured
- Organization support - migrates kilocodeOrganizationId to the OAuth accountId field

Auth format mapping:
| Legacy field | New field |
|--------------|-----------|
| kilocodeToken | access (OAuth) or key (API) |
| kilocodeOrganizationId | accountId (OAuth only) |
