### PR TITLE
fix: prioritize Kilo Gateway models in search results

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -215,13 +215,10 @@ export function DialogModel(props: { providerID?: string }) {
     if (needle) {
       const filteredProviders = fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj)
       const filteredPopular = fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj)
-      // kilocode_change start - Sort Kilo Gateway results first when searching
-      const sorted = [...filteredProviders].sort((a, b) => {
-        const aIsKilo = a.value.providerID === "kilo" ? 0 : 1
-        const bIsKilo = b.value.providerID === "kilo" ? 0 : 1
-        return aIsKilo - bIsKilo
-      })
-      return [...sorted, ...filteredPopular]
+      // kilocode_change start - Partition Kilo Gateway results first (preserves fuzzysort order)
+      const kilo = filteredProviders.filter((x) => x.value.providerID === "kilo")
+      const rest = filteredProviders.filter((x) => x.value.providerID !== "kilo")
+      return [...kilo, ...rest, ...filteredPopular]
       // kilocode_change end
     }
 


### PR DESCRIPTION
## Summary
- Sort model search results to show Kilo Gateway provider first when users search for models
- Maintains fuzzy search relevance within each provider group