### PR TITLE
feat: add kilo-gateway to thinking variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -345,6 +345,7 @@ export namespace ProviderTransform {
 
     switch (model.api.npm) {
       case "@openrouter/ai-sdk-provider":
+      case "@kilocode/kilo-gateway": // kilocode_change
         if (!model.id.includes("gpt") && !model.id.includes("gemini-3")) return {}
         return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))
 


### PR DESCRIPTION
## Summary

- Adds `@kilocode/kilo-gateway` alongside `@openrouter/ai-sdk-provider` in the `variants()` switch statement
- Enables Ctrl+T thinking effort cycling for GPT and Gemini-3 models via the Kilo provider

## Notes

- Claude models via OpenRouter/Kilo don't have thinking variants yet (they need `reasoning.max_tokens` format instead of `reasoning.effort`)
- Models must have `capabilities.reasoning: true` to show variants

<img width="594" height="67" alt="image" src="https://github.com/user-attachments/assets/3e3b74cd-dad4-4115-866b-12e4d854686d" />
