### PR TITLE
feat: add npm provenance attestation and stable release workflow

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -1,0 +1,77 @@
+# kilocode_change - new file
+#
+# Stable Release Workflow for Kilo CLI
+# =====================================
+#
+# HOW TO RELEASE:
+# 1. Go to GitHub Actions → publish-stable
+# 2. Click "Run workflow"
+# 3. Enter the version (e.g., 1.0.0) - REQUIRED for stable releases
+# 4. Click "Run workflow"
+#
+# HOW USERS INSTALL:
+#   npm install -g @kilocode/cli
+#
+# REQUIRED GITHUB SECRETS:
+# - NPM_TOKEN: npm authentication token with publish access to @kilocode/cli
+#   (Get from: npmjs.com → Access Tokens → Generate New Token → Automation)
+#
+# WHAT THIS DOES:
+# - Runs the existing publish-start.ts script with OPENCODE_CHANNEL=latest
+# - Builds all platform binaries (Linux, macOS, Windows, x64, ARM64)
+# - Publishes to npm with @latest tag (default for npm install)
+# - Creates git tags and GitHub releases
+# - Includes npm provenance attestation for supply chain security
+#
+name: publish-stable
+run-name: "stable release v${{ inputs.version }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 1.0.0)"
+        required: true
+        type: string
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version }}
+
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+
+jobs:
+  publish-stable:
+    runs-on: depot-ubuntu-24.04-4
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: git fetch --force --tags
+
+      - uses: ./.github/actions/setup-bun
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup Git Identity
+        run: |
+          git config --global user.email "kilocode@kilo.ai"
+          git config --global user.name "kilocode"
+
+      - name: Publish Stable
+        run: ./script/publish-start.ts
+        env:
+          OPENCODE_CHANNEL: latest
+          OPENCODE_VERSION: ${{ inputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kilocode-cli-stable
+          path: packages/opencode/dist

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -45,12 +45,12 @@ const tasks = Object.entries(binaries).map(async ([name]) => {
   }
   await $`bun pm pack`.cwd(`./dist/${name}`)
   for (const tag of tags) {
-    await $`npm publish *.tgz --access public --tag ${tag}`.cwd(`./dist/${name}`)
+    await $`npm publish *.tgz --access public --tag ${tag} --provenance`.cwd(`./dist/${name}`)
   }
 })
 await Promise.all(tasks)
 for (const tag of tags) {
-  await $`cd ./dist/${pkg.name} && bun pm pack && npm publish *.tgz --access public --tag ${tag}`
+  await $`cd ./dist/${pkg.name} && bun pm pack && npm publish *.tgz --access public --tag ${tag} --provenance`
 }
 
 if (!Script.preview) {


### PR DESCRIPTION
## Summary

Fixes #5547 - npm releases missing provenance attestations

- Add `--provenance` flag to npm publish commands in `packages/opencode/script/publish.ts` for supply chain security
- Create new `publish-stable.yml` workflow for `@latest` releases (since the existing `publish.yml` is disabled for this fork)

## How to use

**For stable releases:**
1. Go to GitHub Actions → `publish-stable`
2. Click "Run workflow"
3. Enter version (e.g., `1.0.0`)
4. Run it

The published packages will now show the "Built and signed with provenance" badge on npm.