### PR TITLE
fix: e2e test fixes after OpenCode merge

### DIFF
--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -44,7 +44,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
     "session.previous",
     "session.next",
     "terminal.toggle",
-    "review.toggle",
+    "fileTree.toggle",
   ]
   const limit = 5
 

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -280,14 +280,17 @@ export function SessionHeader() {
                 </TooltipKeybind>
               </div>
               <div class="hidden md:block shrink-0">
-                <TooltipKeybind title={language.t("command.review.toggle")} keybind={command.keybind("review.toggle")}>
+                <TooltipKeybind
+                  title={language.t("command.fileTree.toggle")}
+                  keybind={command.keybind("fileTree.toggle")}
+                >
                   <Button
                     variant="ghost"
                     class="group/file-tree-toggle size-6 p-0"
                     onClick={() => layout.fileTree.toggle()}
-                    aria-label={language.t("command.review.toggle")}
+                    aria-label={language.t("command.fileTree.toggle")}
                     aria-expanded={layout.fileTree.opened()}
-                    aria-controls="review-panel"
+                    aria-controls="filetree-panel"
                   >
                     <div class="relative flex items-center justify-center size-4 [&>*]:absolute [&>*]:inset-0">
                       <Icon

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -93,10 +93,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       const state = visibility().get(key)
       if (state === "hide") return false
       if (state === "show") return true
-      if (latestSet().has(key)) return true
-      const m = find(model)
-      if (!m?.release_date || !DateTime.fromISO(m.release_date).isValid) return true
-      return false
+      return true
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1970,7 +1970,7 @@ export default function Layout(props: ParentProps) {
     const slug = createMemo(() => base64Encode(props.directory))
     const sessions = createMemo(() =>
       workspaceStore.session
-        .filter((session) => session.directory === workspaceStore.path.directory)
+        .filter((session) => session.directory === props.directory)
         .filter((session) => !session.parentID && !session.time?.archived)
         .toSorted(sortSessions(Date.now())),
     )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -730,8 +730,8 @@ export default function Page() {
       onSelect: () => view().terminal.toggle(),
     },
     {
-      id: "review.toggle",
-      title: language.t("command.review.toggle"),
+      id: "fileTree.toggle",
+      title: language.t("command.fileTree.toggle"),
       description: "",
       category: language.t("command.category.view"),
       keybind: "mod+shift+r",


### PR DESCRIPTION
## Summary
- Simplify model visibility to return `true` by default (fixes models not appearing)
- Rename `review.toggle` command to `fileTree.toggle` (upstream rename)
- Use `props.directory` for session filtering in `SortableWorkspace` (fixes timing issue)

These fixes address e2e test failures after merging OpenCode upstream changes.