### PR TITLE
fix: use github-hosted runners for npm publish with provenance

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   publish-next:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   publish-stable:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary

Fixes npm publish failures when using `--provenance` flag for supply chain security attestation.

## Problem

The publish workflows were running on Depot self-hosted runners (`depot-ubuntu-24.04-4`), but npm's provenance verification **only supports GitHub-hosted runners**. This caused the release to fail with:

```
Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: "self-hosted". 
Only "github-hosted" runners are supported when publishing with provenance.
```

## Solution

Switch publish jobs from `depot-ubuntu-24.04-4` to `ubuntu-latest` (GitHub-hosted).

The build artifacts are already created before publish, so only the publish step needs to run on GitHub-hosted runners. npm signs the provenance statement at publish time, attesting where the package was published from - not where it was built.

## Changes

- `publish-next.yml`: `runs-on: ubuntu-latest`
- `publish-stable.yml`: `runs-on: ubuntu-latest`