### PR TITLE
Add envrc flake support with kilo dev command wrapper

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# Check if nix command is available before trying to use flake
+if command -v nix >/dev/null 2>&1; then
+    use flake
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -19,15 +19,26 @@
     in
     {
       devShells = forEachSystem (pkgs: {
-        default = pkgs.mkShell {
-          packages = with pkgs; [
-            bun
-            nodejs_20
-            pkg-config
-            openssl
-            git
-          ];
-        };
+        default =
+          let
+            kilo = pkgs.writeShellScriptBin "kilo" ''
+              cd "$KILO_ROOT"
+              exec ${pkgs.bun}/bin/bun dev "$@"
+            '';
+          in
+          pkgs.mkShell {
+            packages = with pkgs; [
+              bun
+              nodejs_20
+              pkg-config
+              openssl
+              git
+              kilo
+            ];
+            shellHook = ''
+              export KILO_ROOT="$PWD"
+            '';
+          };
       });
 
       packages = forEachSystem (


### PR DESCRIPTION
## Summary
- Adds .envrc file for automatic direnv integration with Nix flakes
- Enhances flake.nix dev shell with additional packages and a kilo helper script

## Changes
### .envrc (new file)
- Adds direnv configuration that conditionally enables the Nix flake when the nix command is available
- Allows developers using direnv to automatically enter the Nix dev shell
### flake.nix
- Adds a kilo shell script wrapper that runs bun dev from the repository root
- Sets KILO_ROOT environment variable via shellHook to track the repository root directory

## Why
This change improves the developer experience by:
1. Enabling automatic environment setup via direnv for Nix users
2. Providing a convenient kilo command to run the dev server from anywhere within the project