### PR TITLE
fix: use reasoningEffort instead of nested reasoning object for Kilo Gateway

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -355,7 +355,7 @@ export namespace ProviderTransform {
           OPENAI_EFFORTS.map((effort) => [
             effort,
             {
-              reasoning: { effort },
+              reasoningEffort: effort,
               reasoningSummary: "auto",
               include: ["reasoning.encrypted_content"],
             },


### PR DESCRIPTION
## Summary
- Fixes Codex reasoning effort errors when using GPT Codex 5.2 with xhigh reasoning effort via Kilo Gateway
- Changes `reasoning: { effort }` to `reasoningEffort: effort` to match the expected API format for the Kilo Gateway provider