### PR TITLE
ci: skip stable changelog generation

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           OPENCODE_CHANNEL: latest
           OPENCODE_VERSION: ${{ inputs.version }}
+          OPENCODE_SKIP_NOTES: "1"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/script/publish-start.ts
+++ b/script/publish-start.ts
@@ -37,7 +37,10 @@ let notes: string[] = []
 
 console.log("=== publishing ===\n")
 
-if (!Script.preview) {
+const skipNotes = process.env["OPENCODE_SKIP_NOTES"] === "1" // kilocode_change
+if (skipNotes) console.log("changelog skipped: OPENCODE_SKIP_NOTES=1") // kilocode_change
+
+if (!Script.preview && !skipNotes) {
   const previous = await getLatestRelease()
   notes = await buildNotes(previous, "HEAD")
   // notes.unshift(highlightsTemplate)


### PR DESCRIPTION
## Summary
- allow skipping changelog generation in stable releases via OPENCODE_SKIP_NOTES
- set OPENCODE_SKIP_NOTES=1 in publish-stable workflow to avoid opencode dependency