### PR TITLE
fix: use absolute paths for release archives to handle scoped package names

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { $ } from "bun"
+import path from "path" // kilocode_change
 import pkg from "../package.json"
 import { Script } from "@opencode-ai/script"
 import { fileURLToPath } from "url"
@@ -60,11 +61,15 @@ for (const tag of tags) {
 if (!Script.preview) {
   // Create archives for GitHub release
   for (const key of Object.keys(binaries)) {
+    // kilocode_change start - use absolute path for archive to handle scoped package names with /
+    const archiveName = key.replace("/", "-")
+    const archivePath = path.resolve(`dist/${archiveName}`)
     if (key.includes("linux")) {
-      await $`tar -czf ../../${key}.tar.gz *`.cwd(`dist/${key}/bin`)
+      await $`tar -czf ${archivePath}.tar.gz *`.cwd(`dist/${key}/bin`)
     } else {
-      await $`zip -r ../../${key}.zip *`.cwd(`dist/${key}/bin`)
+      await $`zip -r ${archivePath}.zip *`.cwd(`dist/${key}/bin`)
     }
+    // kilocode_change end
   }
 
   const image = "ghcr.io/kilo-org/kilo" // kilocode_change


### PR DESCRIPTION
## Summary
- Fixes tar/zip archive creation failing during publish for scoped packages like `@kilocode/cli-*`
- The `/` in scoped package names was being interpreted as a directory separator
- Uses `path.resolve()` with sanitized filenames to create archives in `dist/`

## Problem
```
tar (child): ../../@kilocode/cli-linux-arm64.tar.gz: Cannot open: No such file or directory
```

The relative path `../../${key}.tar.gz` from `dist/@kilocode/cli-linux-arm64/bin` tried to create a file in a non-existent `@kilocode/` directory.