### PR TITLE
fix: rebrand OpenCode to Kilo in permission dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -336,7 +336,8 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
           <text fg={theme.text}>Reject permission</text>
         </box>
         <box paddingLeft={1}>
-          <text fg={theme.textMuted}>Tell OpenCode what to do differently</text>
+          {/* kilocode_change */}
+          <text fg={theme.textMuted}>Tell Kilo what to do differently</text>
         </box>
       </box>
       <box


### PR DESCRIPTION
## Summary
- Replaces "OpenCode" with "Kilo" in the "Always allow" permission dialog text
- Adds `kilocode_change` markers for upstream merge tracking

Fixes the branding inconsistency where the permission prompt showed "until OpenCode is restarted" instead of "until Kilo is restarted".