### PR TITLE
feat(flake): add Playwright support for e2e tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,10 +33,14 @@
               pkg-config
               openssl
               git
+              gh
+              playwright-driver.browsers
               kilo
             ];
             shellHook = ''
               export KILO_ROOT="$PWD"
+              export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+              export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
             '';
           };
       });


### PR DESCRIPTION
## Summary

- Adds `playwright-driver.browsers` package to the Nix dev shell for running e2e tests
- Sets `PLAYWRIGHT_BROWSERS_PATH` environment variable to use Nix-provided browsers
- Sets `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` to skip host validation checks on NixOS

## Usage

After entering the dev shell (`nix develop`), run e2e tests:

```bash
cd packages/app
bun run test:e2e:local
```

No need to run `bunx playwright install` - browsers are provided by Nix.