### PR TITLE
Add dispatch to homebrew-tap repo

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Update Homebrew Tap
         run: |
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -f -X POST \
+            -H "Authorization: token ${{ secrets.KILO_GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
             https://api.github.com/repos/Kilo-Org/homebrew-tap/dispatches \
             -d '{"event_type": "update-formula", "client_payload": {"version": "${{ inputs.version }}"}}'


### PR DESCRIPTION
This adds a dispatch to https://github.com/Kilo-Org/homebrew-tap to update the brew tap with the new version on the release of a new stable version