### PR TITLE
fix: stop reasoning-only loops for GLM/minimax

### DIFF
--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -2,6 +2,7 @@ import { ConfigMarkdown } from "@/config/markdown"
 import { Config } from "../config/config"
 import { MCP } from "../mcp"
 import { Provider } from "../provider/provider"
+import { MessageV2 } from "../session/message-v2" // kilocode_change
 import { UI } from "./ui"
 
 export function FormatError(input: unknown) {
@@ -38,6 +39,12 @@ export function FormatError(input: unknown) {
     ].join("\n")
 
   if (UI.CancelledError.isInstance(input)) return ""
+
+  // kilocode_change start
+  if (MessageV2.ReasoningStuckError.isInstance(input)) {
+    return `Model got stuck producing reasoning only (chars: ${input.data.chars}, threshold: ${input.data.threshold}). Try retrying, switching models, or reducing task complexity.`
+  }
+  // kilocode_change end
 }
 
 export function FormatUnknownError(input: unknown): string {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -15,6 +15,18 @@ import type { Provider } from "@/provider/provider"
 
 export namespace MessageV2 {
   export const OutputLengthError = NamedError.create("MessageOutputLengthError", z.object({}))
+
+  // kilocode_change start
+  export const ReasoningStuckError = NamedError.create(
+    "MessageReasoningStuckError",
+    z.object({
+      message: z.string(),
+      threshold: z.number(),
+      chars: z.number(),
+      finish: z.string().optional(),
+    }),
+  )
+  // kilocode_change end
   export const AbortedError = NamedError.create("MessageAbortedError", z.object({ message: z.string() }))
   export const AuthError = NamedError.create(
     "ProviderAuthError",
@@ -360,6 +372,7 @@ export namespace MessageV2 {
         AuthError.Schema,
         NamedError.Unknown.Schema,
         OutputLengthError.Schema,
+        ReasoningStuckError.Schema,
         AbortedError.Schema,
         APIError.Schema,
       ])
@@ -675,6 +688,8 @@ export namespace MessageV2 {
           },
         ).toObject()
       case MessageV2.OutputLengthError.isInstance(e):
+        return e
+      case MessageV2.ReasoningStuckError.isInstance(e):
         return e
       case LoadAPIKeyError.isInstance(e):
         return new MessageV2.AuthError(

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -144,6 +144,16 @@ export type MessageOutputLengthError = {
   }
 }
 
+export type MessageReasoningStuckError = {
+  name: "MessageReasoningStuckError"
+  data: {
+    message: string
+    threshold: number
+    chars: number
+    finish?: string
+  }
+}
+
 export type MessageAbortedError = {
   name: "MessageAbortedError"
   data: {
@@ -175,7 +185,13 @@ export type AssistantMessage = {
     created: number
     completed?: number
   }
-  error?: ProviderAuthError | UnknownError | MessageOutputLengthError | MessageAbortedError | ApiError
+  error?:
+    | ProviderAuthError
+    | UnknownError
+    | MessageOutputLengthError
+    | MessageReasoningStuckError
+    | MessageAbortedError
+    | ApiError
   parentID: string
   modelID: string
   providerID: string
@@ -818,7 +834,13 @@ export type EventSessionError = {
   type: "session.error"
   properties: {
     sessionID?: string
-    error?: ProviderAuthError | UnknownError | MessageOutputLengthError | MessageAbortedError | ApiError
+    error?:
+      | ProviderAuthError
+      | UnknownError
+      | MessageOutputLengthError
+      | MessageReasoningStuckError
+      | MessageAbortedError
+      | ApiError
   }
 }
 


### PR DESCRIPTION
## Problem
Some models (reported with `z-ai/glm-4.7:free` and `minimax/minimax-m2.1:free`) can stream only reasoning (`<think>`/reasoning deltas) and finish the step with `finish: \"unknown\"`. `SessionPrompt.loop` keeps looping on `unknown`, causing an infinite repetition.

Original issue: https://github.com/Kilo-Org/kilocode/issues/6333

## Fix
- Add a dedicated `MessageReasoningStuckError`.
- In `SessionProcessor`, track whether a step produced any non-reasoning output (text/tool parts).
- If a step is reasoning-only and exceeds a threshold (or finishes with `unknown`), mark the message with `MessageReasoningStuckError` and stop the loop.
- Format the error nicely in the CLI.

## Tests
- `bun run typecheck`
- `bun test` (packages/opencode)

Closes Kilo-Org/kilocode#6333