### PR TITLE
fix: publish releases immediately for stable workflow

### DIFF
--- a/script/publish-start.ts
+++ b/script/publish-start.ts
@@ -89,7 +89,10 @@ if (!Script.preview) {
   await $`git cherry-pick HEAD..origin/dev`.nothrow()
   await $`git push origin HEAD --tags --no-verify --force-with-lease`
   await new Promise((resolve) => setTimeout(resolve, 5_000))
-  await $`gh release create v${Script.version} -d --title "v${Script.version}" --notes ${notes.join("\n") || "No notable changes"} ./packages/opencode/dist/archives/*.zip ./packages/opencode/dist/archives/*.tar.gz` // kilocode_change - archives now in subdirectory
+  // kilocode_change start - skip draft flag when OPENCODE_SKIP_NOTES=1 (used by publish-stable.yml which doesn't have a publish-complete step)
+  const draftFlag = skipNotes ? [] : ["-d"]
+  await $`gh release create v${Script.version} ${draftFlag} --title "v${Script.version}" --notes ${notes.join("\n") || "No notable changes"} ./packages/opencode/dist/archives/*.zip ./packages/opencode/dist/archives/*.tar.gz`
+  // kilocode_change end
   const release = await $`gh release view v${Script.version} --json id,tagName`.json()
   output += `release=${release.id}\n`
   output += `tag=${release.tagName}\n`


### PR DESCRIPTION
## Summary

- Fix `publish-stable.yml` releases staying as drafts forever
- Skip the `-d` (draft) flag when `OPENCODE_SKIP_NOTES=1` is set

## Problem

The `publish-stable.yml` workflow creates GitHub releases as drafts but never publishes them because:
1. It uses `publish-start.ts` which has `-d` flag (creates draft)
2. Unlike `publish.yml`, it doesn't have Tauri builds or call `publish-complete.ts` to publish the draft

## Solution

Conditionally skip the `-d` flag when `OPENCODE_SKIP_NOTES=1` is set (which is only set by `publish-stable.yml`).