### PR TITLE
Add kilo provider model configuration

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -97,8 +97,11 @@ export namespace Provider {
         autoload: false,
         options: {
           headers: {
+            // kilocode_change
+            // TODO: Add adaptive thinking headers when @ai-sdk/anthropic supports it:
+            // adaptive-thinking-2026-01-28,effort-2025-11-24,max-effort-2026-01-24
             "anthropic-beta":
-              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,context-1m-2025-08-07",
           },
         },
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -445,8 +445,31 @@ export namespace ProviderTransform {
         if (!model.id.includes("gpt") && !model.id.includes("gemini-3")) return {}
         return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))
 
-      // kilocode_change start - Claude and GPT models via Kilo Gateway
+      // kilocode_change start
       case "@kilocode/kilo-gateway":
+        // kilocode_change - adaptive thinking with effort levels
+        // TODO: Enable when @ai-sdk/anthropic supports thinking.type: "adaptive"
+        const ADAPTIVE_THINKING_ENABLED = false
+        if (ADAPTIVE_THINKING_ENABLED && id.includes("claude-opus-4-6")) {
+          return {
+            low: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "low" },
+            },
+            medium: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "medium" },
+            },
+            high: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "high" },
+            },
+            max: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "max" },
+            },
+          }
+        }
         // Claude/Anthropic models support reasoning via effort levels through OpenRouter API
         // OpenRouter maps effort to budget_tokens percentages (xhigh=95%, high=80%, medium=50%, low=20%, minimal=10%)
         if (
@@ -563,6 +586,30 @@ export namespace ProviderTransform {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
       case "@ai-sdk/google-vertex/anthropic":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
+        // kilocode_change start
+        // TODO: Enable when @ai-sdk/anthropic supports thinking.type: "adaptive"
+        const ADAPTIVE_THINKING_ENABLED_ANTHROPIC = false
+        if (ADAPTIVE_THINKING_ENABLED_ANTHROPIC && id.includes("claude-opus-4-6")) {
+          return {
+            low: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "low" },
+            },
+            medium: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "medium" },
+            },
+            high: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "high" },
+            },
+            max: {
+              thinking: { type: "adaptive" },
+              output_config: { effort: "max" },
+            },
+          }
+        }
+        // kilocode_change end
         return {
           high: {
             thinking: {
@@ -840,6 +887,11 @@ export namespace ProviderTransform {
 
     if (npm === "@ai-sdk/anthropic" || npm === "@ai-sdk/google-vertex/anthropic") {
       const thinking = options?.["thinking"]
+      // kilocode_change start - adaptive thinking doesn't use budgetTokens
+      if (thinking?.["type"] === "adaptive") {
+        return standardLimit
+      }
+      // kilocode_change end
       const budgetTokens = typeof thinking?.["budgetTokens"] === "number" ? thinking["budgetTokens"] : 0
       const enabled = thinking?.["type"] === "enabled"
       if (enabled && budgetTokens > 0) {


### PR DESCRIPTION
## Summary

- Adds adaptive thinking configuration (currently behind a flag) for Claude Opus 4.6 models across kilo-gateway, anthropic, and google-vertex providers
- Adds `context-1m-2025-08-07` to the Anthropic beta headers for kilo provider
- Handles adaptive thinking in max output calculation (no budgetTokens needed)