### PR TITLE
docs: improve AGENTS.md with build commands, monorepo map, and architecture patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,34 @@
 
 Kilo CLI is an open source AI coding agent that generates code from natural language, automates tasks, and supports 500+ AI models.
 
-- To regenerate the JavaScript SDK, run `./packages/sdk/js/script/build.ts`.
 - ALWAYS USE PARALLEL TOOLS WHEN APPLICABLE.
 - The default branch in this repo is `dev`.
 - Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
+
+## Build and Dev
+
+- **Dev**: `bun run dev` (runs from root) or `bun run --cwd packages/opencode --conditions=browser src/index.ts`
+- **Typecheck**: `bun turbo typecheck` (uses `tsgo`, not `tsc`)
+- **Test**: `bun test` from `packages/opencode/` (NOT from root -- root blocks tests)
+- **Single test**: `bun test test/tool/tool.test.ts` from `packages/opencode/`
+- **SDK regen**: After changing server endpoints in `packages/opencode/src/server/`, run `./script/generate.ts` from root to regenerate `packages/sdk/js/`
+
+## Monorepo Structure
+
+Turborepo + Bun workspaces. The packages you'll work with most:
+
+| Package                    | Name                       | Purpose                                                                                    |
+| -------------------------- | -------------------------- | ------------------------------------------------------------------------------------------ |
+| `packages/opencode/`       | `@kilocode/cli`            | Core CLI -- agents, tools, sessions, server, TUI. This is where most work happens.         |
+| `packages/sdk/js/`         | `@kilocode/sdk`            | Auto-generated TypeScript SDK (client for the server API). Do not edit `src/gen/` by hand. |
+| `packages/kilo-gateway/`   | `@kilocode/kilo-gateway`   | Kilo auth, provider routing, API integration                                               |
+| `packages/kilo-telemetry/` | `@kilocode/kilo-telemetry` | PostHog analytics + OpenTelemetry                                                          |
+| `packages/kilo-i18n/`      | `@kilocode/kilo-i18n`      | Internationalization / translations                                                        |
+| `packages/app/`            | `@opencode-ai/app`         | Web/TUI frontend (SolidJS + Vite)                                                          |
+| `packages/util/`           | `@opencode-ai/util`        | Shared utilities (error, path, retry, slug, etc.)                                          |
+| `packages/plugin/`         | `@kilocode/plugin`         | Plugin/tool interface definitions                                                          |
+
+Other packages (`console/`, `enterprise/`, `web/`, `desktop/`, `slack/`, `infra/`) are for the hosted platform and rarely need changes during CLI work.
 
 ## Style Guide
 

--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -1,27 +1,66 @@
 # opencode agent guidelines
 
-## Build/Test Commands
+## Build/Test
 
-- **Install**: `bun install`
 - **Run**: `bun run --conditions=browser ./src/index.ts`
-- **Typecheck**: `bun run typecheck` (npm run typecheck)
-- **Test**: `bun test` (runs all tests)
-- **Single test**: `bun test test/tool/tool.test.ts` (specific test file)
+- **Test**: `bun test` (all tests) or `bun test test/tool/tool.test.ts` (single test)
+- **Typecheck**: `bun run typecheck` (runs `tsgo --noEmit`)
 
-## Code Style
+## Import Aliases
 
-- **Runtime**: Bun with TypeScript ESM modules
-- **Imports**: Use relative imports for local modules, named imports preferred
-- **Types**: Zod schemas for validation, TypeScript interfaces for structure
-- **Naming**: camelCase for variables/functions, PascalCase for classes/namespaces
-- **Error handling**: Use Result patterns, avoid throwing exceptions in tools
-- **File structure**: Namespace-based organization (e.g., `Tool.define()`, `Session.create()`)
+- `@/*` maps to `./src/*`
+- `@tui/*` maps to `./src/cli/cmd/tui/*`
 
-## Architecture
+## Key Patterns
 
-- **Tools**: Implement `Tool.Info` interface with `execute()` method
-- **Context**: Pass `sessionID` in tool context, use `App.provide()` for DI
-- **Validation**: All inputs validated with Zod schemas
-- **Logging**: Use `Log.create({ service: "name" })` pattern
-- **Storage**: Use `Storage` namespace for persistence
-- **API Client**: The TypeScript TUI (built with SolidJS + OpenTUI) communicates with the OpenCode server using `@kilocode/sdk`. When adding/modifying server endpoints in `packages/opencode/src/server/server.ts`, run `./script/generate.ts` to regenerate the SDK and related files.
+**Namespace modules** -- Code is organized as TypeScript namespaces, not classes. Each module exports a namespace with its Zod schemas, types, and functions:
+
+```ts
+export namespace Session {
+  export const Info = z.object({ ... })
+  export type Info = z.infer<typeof Info>
+  export const create = fn(z.object({ ... }), async (input) => { ... })
+}
+```
+
+**`Instance.state(init, dispose?)`** -- Per-project lazy singleton. Many modules register state this way. The state is tied to the project directory via `AsyncLocalStorage`:
+
+```ts
+const state = Instance.state(async () => {
+  // initialized once per project, cached
+  return { ... }
+})
+// later: (await state()).someValue
+```
+
+**`fn(schema, callback)`** -- Wraps functions with Zod input validation. Used for most exported functions:
+
+```ts
+export const get = fn(z.object({ id: z.string() }), async (input) => { ... })
+```
+
+**`Tool.define(id, init)`** -- All tools follow this pattern. The `init` returns `{ description, parameters, execute }`. Output is auto-truncated.
+
+**`BusEvent.define(type, schema)` + `Bus.publish()`** -- In-process pub/sub event system for cross-module communication.
+
+**`NamedError.create(name, schema)`** -- Structured errors with Zod schemas. Prefer these over throwing raw errors.
+
+**`iife()`** -- Immediately-invoked function expression helper. Used to avoid `let` statements per style guide.
+
+**Logging** -- Use `Log.create({ service: "name" })` pattern.
+
+## Storage
+
+Filesystem-based JSON, not a database. Data lives in `~/.local/share/kilo/storage/`. Keys are path arrays: `Storage.write(["session", projectID, sessionID], data)`.
+
+## TUI
+
+Built with **SolidJS + OpenTUI** (`@opentui/solid`) -- a terminal UI framework. JSX renders to the terminal using elements like `<box>`, `<text>`, `<scrollbox>`. The TUI communicates with the server via `@kilocode/sdk`.
+
+## Server
+
+Hono-based HTTP server with OpenAPI spec generation. SSE for real-time events. When you add/change routes, regenerate the SDK (see root AGENTS.md for the command).
+
+## Providers and Models
+
+Uses the **Vercel AI SDK** as the abstraction layer. Providers are loaded from a bundled map or dynamically installed at runtime. Models come from models.dev (external API), cached locally.


### PR DESCRIPTION
## Summary

- **Root AGENTS.md**: Added build/dev commands (dev, typecheck with `tsgo`, test from correct dir, SDK regen), monorepo structure table (8 key packages), removed stale SDK regen line
- **packages/opencode/AGENTS.md**: Replaced generic bullet points with package-specific knowledge: import aliases, key patterns (namespace modules, `Instance.state`, `fn()`, `Tool.define`, `BusEvent`, `NamedError`, `iife`), storage model (filesystem JSON), TUI stack (SolidJS + OpenTUI), server (Hono + OpenAPI), provider system (Vercel AI SDK)

## Motivation

The previous AGENTS.md lacked the high-value, stable knowledge that agents need to write matching code without rediscovering the project on every task. The package-level file duplicated root concerns and missed package-specific patterns.

The split follows the hierarchical AGENTS.md model: root covers repo-level concerns (monorepo, build, style, fork process), the package file covers what you need when working inside `packages/opencode/`.