### PR TITLE
fix: rebrand remaining OpenCode user-facing strings to Kilo

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -226,7 +226,7 @@ export const AuthLoginCommand = cmd({
   describe: "log in to a provider",
   builder: (yargs) =>
     yargs.positional("url", {
-      describe: "opencode auth provider",
+      describe: "kilo auth provider", // kilocode_change
       type: "string",
     }),
   async handler(args) {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -533,7 +533,7 @@ export const GithubRunCommand = cmd({
           await Session.share(session.id)
           return session.id.slice(-8)
         })()
-        console.log("opencode session", session.id)
+        console.log("kilo session", session.id) // kilocode_change
 
         // Handle event types:
         // REPO_EVENTS (schedule, workflow_dispatch): no issue/PR context, output to logs/PR only

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -84,7 +84,7 @@ export const McpListCommand = cmd({
 
         if (servers.length === 0) {
           prompts.log.warn("No MCP servers configured")
-          prompts.outro("Add servers with: opencode mcp add")
+          prompts.outro("Add servers with: kilo mcp add") // kilocode_change
           return
         }
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -666,7 +666,7 @@ function App() {
     toast.show({
       variant: "info",
       title: "Update Available",
-      message: `OpenCode v${evt.properties.version} is available. Run 'opencode upgrade' to update manually.`,
+      message: `Kilo v${evt.properties.version} is available. Run 'kilo upgrade' to update manually.`, // kilocode_change
       duration: 10000,
     })
   })

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -247,12 +247,14 @@ function ApiMethod(props: ApiMethodProps) {
       description={
         props.providerID === "opencode" ? (
           <box gap={1}>
+            {/* kilocode_change start */}
             <text fg={theme.textMuted}>
-              OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API key.
+              Kilo Gateway gives you access to all the best coding models at the cheapest prices with a single API key.
             </text>
             <text fg={theme.text}>
-              Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
+              Go to <span style={{ fg: theme.primary }}>https://kilo.ai/gateway</span> to get a key
             </text>
+            {/* kilocode_change end */}
           </box>
         ) : undefined
       }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -45,7 +45,8 @@ export function DialogStatus() {
         </text>
         <text fg={theme.textMuted}>esc</text>
       </box>
-      <text fg={theme.textMuted}>OpenCode v{Installation.VERSION}</text>
+      <text fg={theme.textMuted}>Kilo v{Installation.VERSION}</text>
+      {/* kilocode_change */}
       <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
         <box>
           <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
@@ -76,7 +77,7 @@ export function DialogStatus() {
                       <Match when={item.status === "failed" && item}>{(val) => val().error}</Match>
                       <Match when={item.status === "disabled"}>Disabled in configuration</Match>
                       <Match when={(item.status as string) === "needs_auth"}>
-                        Needs authentication (run: opencode mcp auth {key})
+                        Needs authentication (run: kilo mcp auth {key}){/* kilocode_change */}
                       </Match>
                       <Match when={(item.status as string) === "needs_client_registration" && item}>
                         {(val) => (val() as { error: string }).error}

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -54,7 +54,7 @@ export const UninstallCommand = {
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
-    prompts.intro("Uninstall OpenCode")
+    prompts.intro("Uninstall Kilo") // kilocode_change
 
     const method = await Installation.method()
     prompts.log.info(`Installation method: ${method}`)
@@ -231,7 +231,7 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
   }
 
   UI.empty()
-  prompts.log.success("Thank you for using OpenCode!")
+  prompts.log.success("Thank you for using Kilo!") // kilocode_change
 }
 
 async function getShellConfigFile(): Promise<string | null> {

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -27,7 +27,7 @@ export const UpgradeCommand = {
     const detectedMethod = await Installation.method()
     const method = (args.method as Installation.Method) ?? detectedMethod
     if (method === "unknown") {
-      prompts.log.error(`opencode is installed to ${process.execPath} and may be managed by a package manager`)
+      prompts.log.error(`kilo is installed to ${process.execPath} and may be managed by a package manager`) // kilocode_change
       const install = await prompts.select({
         message: "Install anyways?",
         options: [
@@ -45,7 +45,7 @@ export const UpgradeCommand = {
     const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest()
 
     if (Installation.VERSION === target) {
-      prompts.log.warn(`opencode upgrade skipped: ${target} is already installed`)
+      prompts.log.warn(`kilo upgrade skipped: ${target} is already installed`) // kilocode_change
       prompts.outro("Done")
       return
     }

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -12,7 +12,7 @@ export function FormatError(input: unknown) {
     return [
       `Model not found: ${providerID}/${modelID}`,
       ...(Array.isArray(suggestions) && suggestions.length ? ["Did you mean: " + suggestions.join(", ")] : []),
-      `Try: \`opencode models\` to list available models`,
+      `Try: \`kilo models\` to list available models`, // kilocode_change
       `Or check your config (opencode.json) provider/model names`,
     ].join("\n")
   }


### PR DESCRIPTION
## Summary

- Replace all remaining "OpenCode"/"opencode" references with "Kilo"/"kilo" in user-facing CLI strings, TUI dialogs, and error messages
- Update "OpenCode Zen" branding to "Kilo Gateway" with corrected URL (`kilo.ai/gateway`)
- All changes are string-only with `kilocode_change` markers for upstream merge tracking

## Changes (9 files, 12 string replacements)

| File | What changed |
|---|---|
| `app.tsx` | Update available toast: "OpenCode v..." → "Kilo v...", `opencode upgrade` → `kilo upgrade` |
| `dialog-status.tsx` | Version display: "OpenCode v..." → "Kilo v...", MCP auth hint: `opencode mcp auth` → `kilo mcp auth` |
| `dialog-provider.tsx` | "OpenCode Zen" → "Kilo Gateway", `opencode.ai/zen` → `kilo.ai/gateway` |
| `upgrade.ts` | "opencode is installed to..." → "kilo is installed to...", "opencode upgrade skipped" → "kilo upgrade skipped" |
| `uninstall.ts` | "Uninstall OpenCode" → "Uninstall Kilo", "Thank you for using OpenCode!" → "Thank you for using Kilo!" |
| `error.ts` | `` `opencode models` `` → `` `kilo models` `` |
| `mcp.ts` | "opencode mcp add" → "kilo mcp add" |
| `auth.ts` | "opencode auth provider" → "kilo auth provider" |
| `github.ts` | "opencode session" → "kilo session" |

## Testing

String-only changes — no logic or type changes. Typecheck could not run in the worktree (`tsgo` not installed), but these changes are guaranteed safe as they only modify string literal content.