### PR TITLE
fix: prevent startup banner layout shift and improve text rendering

### DIFF
--- a/packages/opencode/src/kilocode/components/kilo-news.tsx
+++ b/packages/opencode/src/kilocode/components/kilo-news.tsx
@@ -6,7 +6,7 @@
  * Shows a banner on the home screen; clicking opens a dialog with all news items.
  */
 
-import { createMemo, createSignal, onMount, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, on, Show } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { useSDK } from "@tui/context/sdk"
 import { useDialog } from "@tui/ui/dialog"
@@ -20,6 +20,7 @@ export function KiloNews() {
   const dialog = useDialog()
 
   const [notifications, setNotifications] = createSignal<KilocodeNotification[]>([])
+  const [fetched, setFetched] = createSignal(false)
   const isKiloConnected = createMemo(() => sync.data.provider_next.connected.includes("kilo"))
 
   const openNewsDialog = () => {
@@ -29,27 +30,31 @@ export function KiloNews() {
     }
   }
 
-  onMount(async () => {
-    // Wait for sync to complete
-    await new Promise<void>((resolve) => {
-      const check = () => {
-        if (sync.status === "complete") resolve()
-        else setTimeout(check, 100)
-      }
-      check()
-    })
+  // Reactively wait for sync to complete, then fetch notifications once
+  createEffect(
+    on(
+      () => sync.status,
+      async (status) => {
+        if (status !== "complete") return
+        if (fetched()) return
+        setFetched(true)
 
-    if (!isKiloConnected()) return
+        if (!isKiloConnected()) return
 
-    const result = await sdk.client.kilo.notifications()
-    const items = result.data
-    if (items && items.length > 0) {
-      setNotifications(items)
-    }
-  })
+        const result = await sdk.client.kilo.notifications()
+        const items = result.data
+        if (items && items.length > 0) {
+          setNotifications(items)
+        }
+      },
+    ),
+  )
 
+  // Always render the container to reserve layout space and prevent shift.
+  // The banner content appears once notifications are loaded; the fixed-height
+  // placeholder keeps the surrounding elements stable during the async fetch.
   return (
-    <Show when={notifications().length > 0}>
+    <Show when={notifications().length > 0} fallback={<box height={3} />}>
       <NotificationBanner
         notification={notifications()[0]}
         totalCount={notifications().length}

--- a/packages/opencode/src/kilocode/components/notification-banner.tsx
+++ b/packages/opencode/src/kilocode/components/notification-banner.tsx
@@ -6,7 +6,7 @@
  * Clicking opens the full notifications dialog.
  *
  * Layout:
- *   * Title (N new)
+ *   ● Title (N new)
  *     Message text with word wrap...
  */
 
@@ -29,10 +29,6 @@ export function NotificationBanner(props: NotificationBannerProps) {
       flexDirection="column"
       maxWidth="100%"
       backgroundColor={hover() ? theme.backgroundElement : undefined}
-      paddingTop={1}
-      paddingBottom={1}
-      paddingLeft={2}
-      paddingRight={2}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={props.onClick}
@@ -40,12 +36,12 @@ export function NotificationBanner(props: NotificationBannerProps) {
       {/* Line 1: Icon + Title + Count */}
       <box flexDirection="row" gap={1}>
         <text flexShrink={0} style={{ fg: hover() ? theme.primary : theme.info }}>
-          *
+          ●
         </text>
-        <text flexShrink={0} style={{ fg: hover() ? theme.primary : theme.text }}>
+        <text wrapMode="none" style={{ fg: hover() ? theme.primary : theme.text }}>
           {props.notification.title}
         </text>
-        <Show when={props.totalCount > 0}>
+        <Show when={props.totalCount > 1}>
           <text flexShrink={0} style={{ fg: hover() ? theme.primary : theme.textMuted }}>
             ({props.totalCount} new)
           </text>


### PR DESCRIPTION
## Summary

- Replace `setTimeout` polling loop in `KiloNews` with a reactive `createEffect(on(...))` that tracks `sync.status`, eliminating busy-polling
- Add a `<box height={3} />` placeholder fallback so the layout reserves space while notifications load, preventing the Tips/prompt area from shifting
- Fix banner icon from `*` to `●` for consistent rendering across terminal emulators (matches Tips component)
- Remove excessive padding from the banner container (parent already handles spacing)
- Change title text from `flexShrink={0}` to `wrapMode="none"` to prevent overflow on narrow terminals
- Only show "(N new)" count when there are 2+ notifications (redundant for single notification)

<img width="652" height="145" alt="image" src="https://github.com/user-attachments/assets/1c9aaaa0-718f-4bad-9b4c-c33e521baabd" />
