### PR TITLE
feat: prompt for approval on bash commands by default

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -58,6 +58,8 @@ export namespace Agent {
     const skillDirs = await Skill.dirs()
     const defaults = PermissionNext.fromConfig({
       "*": "allow",
+      // kilocode_change - prompt for bash commands by default
+      bash: "ask",
       doom_loop: "ask",
       external_directory: {
         "*": "ask",


### PR DESCRIPTION
## Summary

- Add `bash: "ask"` to the default agent permission config so shell commands require explicit user approval before executing
- Read-only tools (grep, glob, read, etc.) remain auto-allowed — only bash is gated

## Problem

The default permission config sets `"*": "allow"`, which means all tools — including bash — execute immediately without confirmation. This is unexpected for users who want a review step before shell commands run, especially those coming from VS Code extension workflows where approval prompts are standard.

## Solution

A single-line addition to the default permission ruleset in `packages/opencode/src/agent/agent.ts` that sets `bash: "ask"`. This layers on top of the existing `"*": "allow"` fallback, so only bash commands prompt — everything else is unaffected.

**Opt-out paths remain intact:**
- Click "always" in the TUI to auto-approve for the session
- Set `"permission": { "bash": "allow" }` in `opencode.json` for permanent opt-out
- Use `kilo run --auto` for CI/CD (auto-approves everything)