### PR TITLE
fix: run bun install before building CLI binary in prepare-cli-binary

### DIFF
--- a/packages/kilo-vscode/scripts/prepare-cli-binary.mjs
+++ b/packages/kilo-vscode/scripts/prepare-cli-binary.mjs
@@ -80,7 +80,7 @@ function ensureBuiltBinary() {
 
   // Ensure dependencies are installed before building.
   log("Installing dependencies in opencode package...")
-  execSync("bun install", {
+  execSync("bun install --frozen-lockfile", {
     cwd: opencodeDir,
     stdio: "inherit",
     env: process.env,


### PR DESCRIPTION
The `prepare-cli-binary` script fails when opencode dependencies aren't installed because `bunfig.toml` requires `@opentui/solid/preload` as a preload.

This adds a `bun install` step before the `bun run build --single` call to ensure dependencies are available.

**Error before fix:**
```
error: preload not found "@opentui/solid/preload"
error: script "build" exited with code 1
```