### PR TITLE
feat(opencode): add project ID resolution and tracking

### DIFF
--- a/packages/opencode/src/kilocode/project-id.ts
+++ b/packages/opencode/src/kilocode/project-id.ts
@@ -1,0 +1,106 @@
+// kilocode_change - new file
+import { Instance } from "@/project/instance"
+import path from "path"
+import { $ } from "bun"
+
+/**
+ * Normalize a project identifier: extract repo name from git URLs, truncate to 100 chars
+ * @param input - Raw project identifier (URL or plain string)
+ * @returns Normalized project ID
+ */
+function normalizeProjectId(input: string): string {
+  const trimmed = input.trim()
+
+  // Try parsing as URL (handles http://, https://, ssh://)
+  try {
+    const url = new URL(trimmed)
+    // Extract last path segment and remove .git extension
+    const pathname = url.pathname.replace(/\.git$/i, "")
+    const parts = pathname.split("/").filter(Boolean)
+    const repo = parts[parts.length - 1]
+    return repo ? repo.slice(-100) : trimmed.slice(-100)
+  } catch {
+    // Not a standard URL - check for git@host:org/repo format (SCP-like syntax)
+    const scpPattern = /^git@[^:]+:(.+)/i
+    const match = scpPattern.exec(trimmed)
+    if (match) {
+      const pathPart = match[1].replace(/\.git$/i, "")
+      const parts = pathPart.split("/").filter(Boolean)
+      const repo = parts[parts.length - 1]
+      return repo ? repo.slice(-100) : trimmed.slice(-100)
+    }
+  }
+
+  // Plain string - return as-is, truncated to 100 chars
+  return trimmed.slice(-100)
+}
+
+/**
+ * Read project ID from .kilocode/config.json
+ * @param directory - Project directory
+ * @returns Normalized project ID or undefined
+ */
+async function getProjectIdFromConfig(directory: string): Promise<string | undefined> {
+  const file = Bun.file(path.join(directory, ".kilocode", "config.json"))
+  const text = await file.text().catch(() => undefined)
+  if (!text) return undefined
+
+  try {
+    const parsed = JSON.parse(text)
+    const id = parsed?.project?.id
+    // Trim whitespace/newlines to ensure valid HTTP header value
+    return typeof id === "string" && id.trim() ? normalizeProjectId(id) : undefined
+  } catch {
+    // Malformed JSON - return undefined to fall back to git
+    return undefined
+  }
+}
+
+/**
+ * Read git origin remote URL using git command
+ * @param directory - Project directory
+ * @returns Normalized project ID from git origin URL or undefined
+ */
+async function getProjectIdFromGit(directory: string): Promise<string | undefined> {
+  // Use git command to handle worktrees correctly (git resolves .git symlinks/files)
+  const url = await $`git config --get remote.origin.url`
+    .cwd(directory)
+    .quiet()
+    .nothrow()
+    .text()
+    .then((x) => x.trim())
+    .catch(() => undefined)
+
+  return url ? normalizeProjectId(url) : undefined
+}
+
+/**
+ * Resolve project ID with priority: .kilocode/config.json -> git origin URL
+ * @returns Normalized project ID or undefined
+ */
+async function resolveProjectId(): Promise<string | undefined> {
+  const dir = Instance.directory
+
+  // Priority 1: .kilocode/config.json
+  const id = await getProjectIdFromConfig(dir)
+  if (id) return id
+
+  // Priority 2: git origin URL
+  return getProjectIdFromGit(dir)
+}
+
+/**
+ * Per-project cached state for project ID
+ */
+const state = Instance.state(async () => {
+  const id = await resolveProjectId()
+  return { id }
+})
+
+/**
+ * Get the project ID for the current Instance context (cached per-project)
+ * @returns Normalized project ID or undefined
+ */
+export async function getKiloProjectId(): Promise<string | undefined> {
+  return (await state()).id
+}

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -24,6 +24,10 @@ import { PermissionNext } from "@/permission/next"
 import { Auth } from "@/auth"
 import { DEFAULT_HEADERS } from "@/kilocode/const" // kilocode_change
 import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
+// kilocode_change start
+import { getKiloProjectId } from "@/kilocode/project-id"
+import { HEADER_PROJECTID } from "@kilocode/kilo-gateway"
+// kilocode_change end
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
@@ -155,6 +159,11 @@ export namespace LLM {
       },
     )
 
+    // kilocode_change start - resolve project ID for kilo provider
+    const kiloProjectId =
+      input.model.api.npm === "@kilocode/kilo-gateway" ? await getKiloProjectId().catch(() => undefined) : undefined
+    // kilocode_change end
+
     const maxOutputTokens =
       isCodex || provider.id.includes("github-copilot")
         ? undefined
@@ -236,6 +245,11 @@ export namespace LLM {
         ...(input.model.api.npm === "@kilocode/kilo-gateway" && input.agent.name
           ? { "x-kilocode-mode": input.agent.name.toLowerCase() }
           : {}),
+        // kilocode_change start - add project ID header for kilo provider
+        ...(input.model.api.npm === "@kilocode/kilo-gateway" && kiloProjectId
+          ? { [HEADER_PROJECTID]: kiloProjectId }
+          : {}),
+        // kilocode_change end
         ...input.model.headers,
         ...headers,
       },

--- a/packages/opencode/test/kilocode/project-id.test.ts
+++ b/packages/opencode/test/kilocode/project-id.test.ts
@@ -1,0 +1,409 @@
+import { test, expect, describe } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+import fs from "fs/promises"
+import { Instance } from "../../src/project/instance"
+import { getKiloProjectId } from "../../src/kilocode/project-id"
+
+describe("project-id", () => {
+  describe("normalization", () => {
+    test("extracts repo name from HTTPS git URL", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          // Set git origin to HTTPS URL
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+
+    test("extracts repo name from SSH git URL", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          // Set git origin to SSH URL
+          await Bun.$`git remote add origin git@github.com:Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+
+    test("extracts repo name from HTTPS URL without .git extension", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+
+    test("extracts repo name from ssh:// URL", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.$`git remote add origin ssh://git@github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+
+    test("truncates long repo names to 100 characters", async () => {
+      const longName = "a".repeat(150)
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/${longName}.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe(longName.slice(-100))
+    })
+  })
+
+  describe("config file priority", () => {
+    test("uses project.id from .kilocode/config.json", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          // Create config with project ID
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: "my-custom-project",
+              },
+            }),
+          )
+
+          // Also set git origin - config should take priority
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("my-custom-project")
+    })
+
+    test("normalizes git URL in config file project.id", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: "https://github.com/Kilo-Org/another-repo.git",
+              },
+            }),
+          )
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("another-repo")
+    })
+
+    test("falls back to git origin when config file has no project.id", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                managedIndexingEnabled: true,
+              },
+            }),
+          )
+
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+
+    test("falls back to git origin when config has empty project.id", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: "",
+              },
+            }),
+          )
+
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+
+    test("trims whitespace from config file project.id", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: "  my-project\n",
+              },
+            }),
+          )
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("my-project")
+    })
+
+    test("falls back to git when config has whitespace-only project.id", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: "  \n\t  ",
+              },
+            }),
+          )
+
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+  })
+
+  describe("fallback behavior", () => {
+    test("returns undefined when no config and no git origin", async () => {
+      await using tmp = await tmpdir({ git: true })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBeUndefined()
+    })
+
+    test("returns undefined for non-git directory", async () => {
+      await using tmp = await tmpdir()
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBeUndefined()
+    })
+
+    test("handles malformed JSON in config file gracefully", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(path.join(dir, ".kilocode", "config.json"), "{ invalid json")
+
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      // Should fall back to git origin
+      expect(id).toBe("handbook")
+    })
+
+    test("handles config file with non-string project.id", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: 12345,
+              },
+            }),
+          )
+
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      // Should fall back to git origin
+      expect(id).toBe("handbook")
+    })
+  })
+
+  describe("caching", () => {
+    test("caches project ID per Instance", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.$`git remote add origin https://github.com/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id1 = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      const id2 = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id1).toBe(id2)
+      expect(id1).toBe("handbook")
+    })
+  })
+
+  describe("edge cases", () => {
+    test("handles git URLs with port numbers", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.$`git remote add origin https://github.com:443/Kilo-Org/handbook.git`.cwd(dir).quiet()
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("handbook")
+    })
+
+    test("handles plain string project IDs from config", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: "simple-name",
+              },
+            }),
+          )
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe("simple-name")
+    })
+
+    test("truncates plain string project IDs to 100 chars", async () => {
+      const longId = "x".repeat(150)
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await Bun.write(
+            path.join(dir, ".kilocode", "config.json"),
+            JSON.stringify({
+              project: {
+                id: longId,
+              },
+            }),
+          )
+        },
+      })
+
+      const id = await Instance.provide({
+        directory: tmp.path,
+        fn: () => getKiloProjectId(),
+      })
+
+      expect(id).toBe(longId.slice(-100))
+    })
+  })
+})


### PR DESCRIPTION
Implement logic to resolve a unique project identifier with priority given to `.kilocode/config.json` and falling back to the git origin remote URL. The resolved ID is normalized, cached per-instance, and sent as a header to the Kilo Gateway provider to enable project-specific tracking.