### PR TITLE
fix: replace unsupported toLower function in containers workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -17,10 +17,15 @@ permissions:
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-      REGISTRY: ghcr.io/${{ toLower(github.repository_owner) }}
-      TAG: "24.04"
     steps:
+      # kilocode_change start
+      - name: Set lowercase repository owner
+        id: repo
+        run: echo "owner_lc=${OWNER,,}" >> $GITHUB_OUTPUT
+        env:
+          OWNER: ${{ github.repository_owner }}
+      # kilocode_change end
+
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-bun
@@ -41,5 +46,7 @@ jobs:
       - name: Build and push containers
         run: bun ./packages/containers/script/build.ts --push
         env:
-          REGISTRY: ${{ env.REGISTRY }}
-          TAG: ${{ env.TAG }}
+          # kilocode_change start
+          REGISTRY: ghcr.io/${{ steps.repo.outputs.owner_lc }}
+          TAG: "24.04"
+          # kilocode_change end


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions validation error in containers.yml workflow
- Replaced unsupported `toLower()` function with bash parameter expansion `${OWNER,,}` to convert repository owner to lowercase
- Required for proper GHCR registry naming when repository owner contains uppercase characters (e.g., `Kilo-Org` → `kilo-org`)