### PR TITLE
fix(mcp-migrator): use correct project-level filename mcp.json

### DIFF
--- a/packages/opencode/src/kilocode/mcp-migrator.ts
+++ b/packages/opencode/src/kilocode/mcp-migrator.ts
@@ -73,8 +73,10 @@ export namespace McpMigrator {
     }
 
     // 2. Project-level MCP settings (if projectDir provided)
+    // The Kilocode extension uses ".kilocode/mcp.json" for project-level settings
+    // (not "mcp_settings.json" which is only used for global settings)
     if (options?.projectDir) {
-      const projectSettingsPath = path.join(options.projectDir, ".kilocode", "mcp_settings.json")
+      const projectSettingsPath = path.join(options.projectDir, ".kilocode", "mcp.json")
       const projectSettings = await readMcpSettings(projectSettingsPath)
       if (projectSettings?.mcpServers) {
         for (const [name, server] of Object.entries(projectSettings.mcpServers)) {

--- a/packages/opencode/test/kilocode/mcp-migrator.test.ts
+++ b/packages/opencode/test/kilocode/mcp-migrator.test.ts
@@ -161,12 +161,12 @@ describe("McpMigrator", () => {
       expect(result.skipped).toHaveLength(0)
     })
 
-    test("migrates servers from project .kilocode directory", async () => {
+    test("migrates servers from project .kilocode/mcp.json", async () => {
       await using tmp = await tmpdir({
         init: async (dir) => {
           const settingsDir = path.join(dir, ".kilocode")
           await Bun.write(
-            path.join(settingsDir, "mcp_settings.json"),
+            path.join(settingsDir, "mcp.json"),
             JSON.stringify({
               mcpServers: {
                 filesystem: {
@@ -196,7 +196,7 @@ describe("McpMigrator", () => {
         init: async (dir) => {
           const settingsDir = path.join(dir, ".kilocode")
           await Bun.write(
-            path.join(settingsDir, "mcp_settings.json"),
+            path.join(settingsDir, "mcp.json"),
             JSON.stringify({
               mcpServers: {
                 enabled: { command: "enabled-cmd" },
@@ -225,7 +225,7 @@ describe("McpMigrator", () => {
         init: async (dir) => {
           const settingsDir = path.join(dir, ".kilocode")
           await Bun.write(
-            path.join(settingsDir, "mcp_settings.json"),
+            path.join(settingsDir, "mcp.json"),
             JSON.stringify({
               mcpServers: {
                 filesystem: {
@@ -255,7 +255,7 @@ describe("McpMigrator", () => {
         init: async (dir) => {
           const settingsDir = path.join(dir, ".kilocode")
           await Bun.write(
-            path.join(settingsDir, "mcp_settings.json"),
+            path.join(settingsDir, "mcp.json"),
             JSON.stringify({
               mcpServers: {
                 filesystem: {
@@ -299,9 +299,33 @@ describe("McpMigrator", () => {
         init: async (dir) => {
           const settingsDir = path.join(dir, ".kilocode")
           await Bun.write(
-            path.join(settingsDir, "mcp_settings.json"),
+            path.join(settingsDir, "mcp.json"),
             JSON.stringify({
               mcpServers: {},
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(Object.keys(result.mcp)).toHaveLength(0)
+    })
+
+    // Regression: project-level MCP settings use mcp.json, not mcp_settings.json
+    test("does not read project-level .kilocode/mcp_settings.json", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const settingsDir = path.join(dir, ".kilocode")
+          await Bun.write(
+            path.join(settingsDir, "mcp_settings.json"),
+            JSON.stringify({
+              mcpServers: {
+                wrong: { command: "should-not-be-found" },
+              },
             }),
           )
         },


### PR DESCRIPTION
## Summary

- Fix project-level MCP settings migration to read from `.kilocode/mcp.json` (correct) instead of `.kilocode/mcp_settings.json` (wrong)
- The `mcp_settings.json` filename is only used for **global** settings in the VSCode extension storage; the extension uses `mcp.json` for project-level configs
- Add regression test confirming `.kilocode/mcp_settings.json` is not read at project level
