### PR TITLE
test: skip flaky prompt e2e test that blocks all PRs

### DIFF
--- a/packages/app/e2e/prompt/prompt.spec.ts
+++ b/packages/app/e2e/prompt/prompt.spec.ts
@@ -2,7 +2,10 @@ import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { sessionIDFromUrl, withSession } from "../actions"
 
-test("can send a prompt and receive a reply", async ({ page, sdk, gotoSession }) => {
+// Skip: this test depends on a live LLM backend responding in CI, which is
+// currently unreliable and blocks every PR.  Re-enable once the CI LLM
+// provider is stable.
+test.skip("can send a prompt and receive a reply", async ({ page, sdk, gotoSession }) => {
   test.setTimeout(120_000)
 
   const pageErrors: string[] = []


### PR DESCRIPTION
## Problem

The `can send a prompt and receive a reply` e2e test in `packages/app` is failing on **every PR** ([example run](https://github.com/Kilo-Org/kilo/actions/runs/21900180424/job/63226125624?pr=229)). The test sends a real prompt to the LLM backend and waits 90s for a reply, but the backend never responds. It retries 3 times and fails every time, blocking all CI.

## Fix

Skip the test with `test.skip()` until the CI LLM provider is stable. All other 61 e2e tests continue to pass.

## Re-enable

Remove the `test.skip` once the LLM backend used in CI is reliably responding.