### PR TITLE
chore: use codestral for e2e prompt tests

### DIFF
--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -76,7 +76,7 @@ async function seedStorage(page: Page, input: { directory: string; extra?: strin
     localStorage.setItem(
       "opencode.global.dat:model",
       JSON.stringify({
-        recent: [{ providerID: "kilo", modelID: "kilo/auto" }], // kilocode_change
+        recent: [{ providerID: "kilo", modelID: "mistralai/codestral-2508" }], // kilocode_change
         user: [],
         variant: {},
       }),


### PR DESCRIPTION
Switch e2e prompt tests from kilo/auto to mistralai/codestral-2508 for more deterministic test results.