### PR TITLE
feat: replace settings tab navigation with kilo-ui Tabs (Phase 2)

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/Settings.tsx
@@ -26,19 +26,25 @@ const Settings: Component<SettingsProps> = (props) => {
   const server = useServer()
 
   return (
-    <div data-component="settings-page">
+    <div style={{ display: "flex", "flex-direction": "column", height: "100%" }}>
       {/* Header */}
-      <div data-slot="settings-header">
-        <div data-slot="settings-header-left">
-          <Button variant="ghost" size="small" onClick={() => props.onBack?.()} title="Done">
-            <Icon name="arrow-left" />
-          </Button>
-          <h2 data-slot="settings-title">Settings</h2>
-        </div>
+      <div
+        style={{
+          padding: "12px 16px",
+          "border-bottom": "1px solid var(--border-weak-base)",
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
+        }}
+      >
+        <Button variant="ghost" size="small" onClick={() => props.onBack?.()} title="Done">
+          <Icon name="arrow-left" />
+        </Button>
+        <h2 style={{ "font-size": "16px", "font-weight": "600", margin: 0 }}>Settings</h2>
       </div>
 
       {/* Settings tabs */}
-      <Tabs orientation="vertical" variant="settings" defaultValue="providers" class="settings-tabs">
+      <Tabs orientation="vertical" variant="settings" defaultValue="providers" style={{ flex: 1, overflow: "hidden" }}>
         <Tabs.List>
           <Tabs.SectionTitle>Configuration</Tabs.SectionTitle>
           <Tabs.Trigger value="providers">
@@ -100,59 +106,59 @@ const Settings: Component<SettingsProps> = (props) => {
         </Tabs.List>
 
         <Tabs.Content value="providers">
-          <h3 data-slot="settings-content-title">Providers</h3>
+          <h3>Providers</h3>
           <ProvidersTab />
         </Tabs.Content>
         <Tabs.Content value="agentBehaviour">
-          <h3 data-slot="settings-content-title">Agent Behaviour</h3>
+          <h3>Agent Behaviour</h3>
           <AgentBehaviourTab />
         </Tabs.Content>
         <Tabs.Content value="autoApprove">
-          <h3 data-slot="settings-content-title">Auto-Approve</h3>
+          <h3>Auto-Approve</h3>
           <AutoApproveTab />
         </Tabs.Content>
         <Tabs.Content value="browser">
-          <h3 data-slot="settings-content-title">Browser</h3>
+          <h3>Browser</h3>
           <BrowserTab />
         </Tabs.Content>
         <Tabs.Content value="checkpoints">
-          <h3 data-slot="settings-content-title">Checkpoints</h3>
+          <h3>Checkpoints</h3>
           <CheckpointsTab />
         </Tabs.Content>
         <Tabs.Content value="display">
-          <h3 data-slot="settings-content-title">Display</h3>
+          <h3>Display</h3>
           <DisplayTab />
         </Tabs.Content>
         <Tabs.Content value="autocomplete">
-          <h3 data-slot="settings-content-title">Autocomplete</h3>
+          <h3>Autocomplete</h3>
           <AutocompleteTab />
         </Tabs.Content>
         <Tabs.Content value="notifications">
-          <h3 data-slot="settings-content-title">Notifications</h3>
+          <h3>Notifications</h3>
           <NotificationsTab />
         </Tabs.Content>
         <Tabs.Content value="context">
-          <h3 data-slot="settings-content-title">Context</h3>
+          <h3>Context</h3>
           <ContextTab />
         </Tabs.Content>
         <Tabs.Content value="terminal">
-          <h3 data-slot="settings-content-title">Terminal</h3>
+          <h3>Terminal</h3>
           <TerminalTab />
         </Tabs.Content>
         <Tabs.Content value="prompts">
-          <h3 data-slot="settings-content-title">Prompts</h3>
+          <h3>Prompts</h3>
           <PromptsTab />
         </Tabs.Content>
         <Tabs.Content value="experimental">
-          <h3 data-slot="settings-content-title">Experimental</h3>
+          <h3>Experimental</h3>
           <ExperimentalTab />
         </Tabs.Content>
         <Tabs.Content value="language">
-          <h3 data-slot="settings-content-title">Language</h3>
+          <h3>Language</h3>
           <LanguageTab />
         </Tabs.Content>
         <Tabs.Content value="aboutKiloCode">
-          <h3 data-slot="settings-content-title">About Kilo Code</h3>
+          <h3>About Kilo Code</h3>
           <AboutKiloCodeTab port={server.serverInfo()?.port ?? null} connectionState={server.connectionState()} />
         </Tabs.Content>
       </Tabs>

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -373,48 +373,6 @@
 }
 
 /* ============================================
-   Settings Page
-   ============================================ */
-
-[data-component="settings-page"] {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-[data-slot="settings-header"] {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--vscode-panel-border);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-[data-slot="settings-header-left"] {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-[data-slot="settings-title"] {
-  font-size: 16px;
-  font-weight: 600;
-  margin: 0;
-}
-
-.settings-tabs {
-  flex: 1;
-  overflow: hidden;
-}
-
-[data-slot="settings-content-title"] {
-  font-size: 14px;
-  font-weight: 600;
-  margin: 0 0 16px 0;
-  padding: 16px 16px 0;
-}
-
-/* ============================================
    Permission Dialog
    ============================================ */
 


### PR DESCRIPTION
Replace the custom signal-based tab navigation in Settings.tsx (~80 lines of inline styles) with kilo-ui's Tabs component.

**Changes:**
- Settings shell now uses `Tabs` with `orientation="vertical"` and `variant="settings"`
- Tab sidebar uses `Tabs.List`, `Tabs.SectionTitle`, `Tabs.Trigger` (with Icon + label)
- Tab content uses `Tabs.Content` — stubs are unchanged
- Removed `createSignal`-based active tab tracking, `For` loop, manual hover/active styles
- Added minimal CSS for settings page header layout (`data-component="settings-page"` + slots)
- Net: -82 lines (146 added, 228 removed)

Follows the same pattern as the desktop app's `DialogSettings` in `packages/app/src/components/dialog-settings.tsx`.

Implements [Phase 2](docs/ui-implementation-plan.md#phase-2-settings-ui-overhaul) of the kilo-ui migration (UI shell only — tab content stays as stubs).

<img width="895" height="555" alt="CleanShot 2026-02-11 at 11 47 00" src="https://github.com/user-attachments/assets/2380ba8d-f79e-4579-8df4-205602532b90" />

Again, ugly, but I'm trying to strip down our custom styling so we can fix it in the theme