### PR TITLE
fix: update default $schema URL from opencode.ai to kilo.ai

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -171,7 +171,7 @@ export namespace Config {
         const wellknown = (await response.json()) as any
         const remoteConfig = wellknown.config ?? {}
         // Add $schema to prevent load() from trying to write back to a non-existent file
-        if (!remoteConfig.$schema) remoteConfig.$schema = "https://opencode.ai/config.json"
+        if (!remoteConfig.$schema) remoteConfig.$schema = "https://kilo.ai/config.json" // kilocode_change
         result = mergeConfigConcatArrays(
           result,
           await load(JSON.stringify(remoteConfig), `${key}/.well-known/opencode`),
@@ -1295,7 +1295,7 @@ export namespace Config {
         .then(async (mod) => {
           const { provider, model, ...rest } = mod.default
           if (provider && model) result.model = `${provider}/${model}`
-          result["$schema"] = "https://opencode.ai/config.json"
+          result["$schema"] = "https://kilo.ai/config.json" // kilocode_change
           result = mergeDeep(result, rest)
           await Bun.write(path.join(Global.Path.config, "config.json"), JSON.stringify(result, null, 2))
           await fs.unlink(legacy)
@@ -1388,9 +1388,9 @@ export namespace Config {
     const parsed = Info.safeParse(data)
     if (parsed.success) {
       if (!parsed.data.$schema) {
-        parsed.data.$schema = "https://opencode.ai/config.json"
+        parsed.data.$schema = "https://kilo.ai/config.json" // kilocode_change
         // Write the $schema to the original text to preserve variables like {env:VAR}
-        const updated = original.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
+        const updated = original.replace(/^\s*\{/, '{\n  "$schema": "https://kilo.ai/config.json",') // kilocode_change
         await Bun.write(configFilepath, updated).catch(() => {})
       }
       const data = parsed.data


### PR DESCRIPTION
## Summary

- Updates 4 hardcoded `opencode.ai/config.json` references to `kilo.ai/config.json` in `packages/opencode/src/config/config.ts`
- Affects: well-known remote config fallback, legacy TOML migration, and auto-schema-injection for configs missing a `$schema` field
- All changes marked with `// kilocode_change` for upstream merge tracking

Companion PR: https://github.com/Kilo-Org/cloud/pull/new/feat/config-schema-rewrite (adds rewrite rule so `app.kilo.ai/config.json` proxies to `opencode.ai/config.json`)