### PR TITLE
fix: rename opencode references to kilo in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,10 +20,10 @@ body:
       required: false
 
   - type: input
-    id: opencode-version
+    id: kilo-version
     attributes:
-      label: OpenCode version
-      description: What version of OpenCode are you using?
+      label: Kilo version
+      description: What version of Kilo are you using?
     validations:
       required: false
 


### PR DESCRIPTION
Renames remaining `opencode` references to `kilo` in the bug report issue template (`.github/ISSUE_TEMPLATE/bug-report.yml`).