### PR TITLE
chore: update config schema URL from opencode.ai to app.kilo.ai

### DIFF
--- a/.opencode/agent/translator.md
+++ b/.opencode/agent/translator.md
@@ -811,7 +811,7 @@ model: "anthropic/claude-sonnet-4-5"
 modes/
 node_modules/
 openai/gpt-4.1
-opencode.ai/config.json
+app.kilo.ai/config.json
 opencode/<model-id>
 opencode/gpt-5.1-codex
 opencode/gpt-5.2-codex

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://opencode.ai/config.json",
+  "$schema": "https://app.kilo.ai/config.json",
   // "enterprise": {
   //   "url": "https://enterprise.dev.opencode.ai",
   // },

--- a/packages/opencode/test/config/agent-color.test.ts
+++ b/packages/opencode/test/config/agent-color.test.ts
@@ -12,7 +12,7 @@ test("agent color parsed from project config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             code: { color: "#FFA500" }, // kilocode_change
             plan: { color: "primary" },
@@ -37,7 +37,7 @@ test("Agent.get includes color from config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             plan: { color: "#A855F7" },
             build: { color: "accent" },

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -39,7 +39,7 @@ test("loads JSON config file", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         model: "test/model",
         username: "testuser",
       })
@@ -62,7 +62,7 @@ test("loads JSONC config file", async () => {
         path.join(dir, "opencode.jsonc"),
         `{
         // This is a comment
-        "$schema": "https://opencode.ai/config.json",
+        "$schema": "https://app.kilo.ai/config.json",
         "model": "test/model",
         "username": "testuser"
       }`,
@@ -85,14 +85,14 @@ test("merges multiple config files with correct precedence", async () => {
       await writeConfig(
         dir,
         {
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           model: "base",
           username: "base",
         },
         "opencode.jsonc",
       )
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         model: "override",
       })
     },
@@ -115,7 +115,7 @@ test("handles environment variable substitution", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         await writeConfig(dir, {
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           theme: "{env:TEST_VAR}",
         })
       },
@@ -179,7 +179,7 @@ test("handles file inclusion substitution", async () => {
     init: async (dir) => {
       await Bun.write(path.join(dir, "included.txt"), "test_theme")
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         theme: "{file:included.txt}",
       })
     },
@@ -198,7 +198,7 @@ test("handles file inclusion with replacement tokens", async () => {
     init: async (dir) => {
       await Bun.write(path.join(dir, "included.md"), "const out = await Bun.$`echo hi`")
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         theme: "{file:included.md}",
       })
     },
@@ -216,7 +216,7 @@ test("validates config schema and throws on invalid fields", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         invalid_field: "should cause error",
       })
     },
@@ -248,7 +248,7 @@ test("handles agent configuration", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         agent: {
           test_agent: {
             model: "test/model",
@@ -278,7 +278,7 @@ test("treats agent variant as model-scoped setting (not provider option)", async
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         agent: {
           test_agent: {
             model: "openai/gpt-5.2",
@@ -309,7 +309,7 @@ test("handles command configuration", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         command: {
           test_command: {
             template: "test template",
@@ -339,7 +339,7 @@ test("migrates autoshare to share field", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           autoshare: true,
         }),
       )
@@ -361,7 +361,7 @@ test("migrates mode field to agent field", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mode: {
             test_mode: {
               model: "test/model",
@@ -676,7 +676,7 @@ test("resolves scoped npm plugins in config", async () => {
 
       await Bun.write(
         path.join(dir, "opencode.json"),
-        JSON.stringify({ $schema: "https://opencode.ai/config.json", plugin: ["@scope/plugin"] }, null, 2),
+        JSON.stringify({ $schema: "https://app.kilo.ai/config.json", plugin: ["@scope/plugin"] }, null, 2),
       )
     },
   })
@@ -711,7 +711,7 @@ test("merges plugin arrays from global and local configs", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           plugin: ["global-plugin-1", "global-plugin-2"],
         }),
       )
@@ -720,7 +720,7 @@ test("merges plugin arrays from global and local configs", async () => {
       await Bun.write(
         path.join(opencodeDir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           plugin: ["local-plugin-1"],
         }),
       )
@@ -787,7 +787,7 @@ test("merges instructions arrays from global and local configs", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           instructions: ["global-instructions.md", "shared-rules.md"],
         }),
       )
@@ -795,7 +795,7 @@ test("merges instructions arrays from global and local configs", async () => {
       await Bun.write(
         path.join(opencodeDir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           instructions: ["local-instructions.md"],
         }),
       )
@@ -826,7 +826,7 @@ test("deduplicates duplicate instructions from global and local configs", async 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           instructions: ["duplicate.md", "global-only.md"],
         }),
       )
@@ -834,7 +834,7 @@ test("deduplicates duplicate instructions from global and local configs", async 
       await Bun.write(
         path.join(opencodeDir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           instructions: ["duplicate.md", "local-only.md"],
         }),
       )
@@ -870,7 +870,7 @@ test("deduplicates duplicate plugins from global and local configs", async () =>
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           plugin: ["duplicate-plugin", "global-plugin-1"],
         }),
       )
@@ -879,7 +879,7 @@ test("deduplicates duplicate plugins from global and local configs", async () =>
       await Bun.write(
         path.join(opencodeDir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           plugin: ["duplicate-plugin", "local-plugin-1"],
         }),
       )
@@ -918,7 +918,7 @@ test("migrates legacy tools config to permissions - allow", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               tools: {
@@ -949,7 +949,7 @@ test("migrates legacy tools config to permissions - deny", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               tools: {
@@ -980,7 +980,7 @@ test("migrates legacy write tool to edit permission", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               tools: {
@@ -1010,7 +1010,7 @@ test("managed settings override user settings", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         model: "user/model",
         share: "auto",
         username: "testuser",
@@ -1019,7 +1019,7 @@ test("managed settings override user settings", async () => {
   })
 
   await writeManagedSettings({
-    $schema: "https://opencode.ai/config.json",
+    $schema: "https://app.kilo.ai/config.json",
     model: "managed/model",
     share: "disabled",
   })
@@ -1039,7 +1039,7 @@ test("managed settings override project settings", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         autoupdate: true,
         disabled_providers: [],
         theme: "dark",
@@ -1048,7 +1048,7 @@ test("managed settings override project settings", async () => {
   })
 
   await writeManagedSettings({
-    $schema: "https://opencode.ai/config.json",
+    $schema: "https://app.kilo.ai/config.json",
     autoupdate: false,
     disabled_providers: ["openai"],
   })
@@ -1068,7 +1068,7 @@ test("missing managed settings file is not an error", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await writeConfig(dir, {
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         model: "user/model",
       })
     },
@@ -1089,7 +1089,7 @@ test("migrates legacy edit tool to edit permission", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               tools: {
@@ -1118,7 +1118,7 @@ test("migrates legacy patch tool to edit permission", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               tools: {
@@ -1147,7 +1147,7 @@ test("migrates legacy multiedit tool to edit permission", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               tools: {
@@ -1176,7 +1176,7 @@ test("migrates mixed legacy tools config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               tools: {
@@ -1211,7 +1211,7 @@ test("merges legacy tools with existing permission config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           agent: {
             test: {
               permission: {
@@ -1244,7 +1244,7 @@ test("permission config preserves key order", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           permission: {
             "*": "deny",
             edit: "ask",
@@ -1292,7 +1292,7 @@ test("project config can override MCP server enabled status", async () => {
       await Bun.write(
         path.join(dir, "opencode.jsonc"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             jira: {
               type: "remote",
@@ -1311,7 +1311,7 @@ test("project config can override MCP server enabled status", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             jira: {
               type: "remote",
@@ -1350,7 +1350,7 @@ test("MCP config deep merges preserving base config properties", async () => {
       await Bun.write(
         path.join(dir, "opencode.jsonc"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             myserver: {
               type: "remote",
@@ -1367,7 +1367,7 @@ test("MCP config deep merges preserving base config properties", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             myserver: {
               type: "remote",
@@ -1402,7 +1402,7 @@ test("local .opencode config can override MCP from project config", async () => 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             docs: {
               type: "remote",
@@ -1418,7 +1418,7 @@ test("local .opencode config can override MCP from project config", async () => 
       await Bun.write(
         path.join(opencodeDir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             docs: {
               type: "remote",
@@ -1486,7 +1486,7 @@ test("project config overrides remote well-known config", async () => {
         await Bun.write(
           path.join(dir, "opencode.json"),
           JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
+            $schema: "https://app.kilo.ai/config.json",
             mcp: {
               jira: {
                 type: "remote",
@@ -1579,7 +1579,7 @@ describe("deduplicatePlugins", () => {
         await Bun.write(
           path.join(dir, "opencode.json"),
           JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
+            $schema: "https://app.kilo.ai/config.json",
             plugin: ["my-plugin@1.0.0"],
           }),
         )
@@ -1614,7 +1614,7 @@ describe("KILO_DISABLE_PROJECT_CONFIG", () => {
           await Bun.write(
             path.join(dir, "opencode.json"),
             JSON.stringify({
-              $schema: "https://opencode.ai/config.json",
+              $schema: "https://app.kilo.ai/config.json",
               model: "project/model",
               username: "project-user",
             }),
@@ -1709,7 +1709,7 @@ describe("KILO_DISABLE_PROJECT_CONFIG", () => {
           await Bun.write(
             path.join(dir, "opencode.json"),
             JSON.stringify({
-              $schema: "https://opencode.ai/config.json",
+              $schema: "https://app.kilo.ai/config.json",
               instructions: ["./CUSTOM.md"],
             }),
           )
@@ -1755,7 +1755,7 @@ describe("KILO_DISABLE_PROJECT_CONFIG", () => {
           await Bun.write(
             path.join(dir, "opencode.json"),
             JSON.stringify({
-              $schema: "https://opencode.ai/config.json",
+              $schema: "https://app.kilo.ai/config.json",
               model: "configdir/model",
             }),
           )
@@ -1768,7 +1768,7 @@ describe("KILO_DISABLE_PROJECT_CONFIG", () => {
           await Bun.write(
             path.join(dir, "opencode.json"),
             JSON.stringify({
-              $schema: "https://opencode.ai/config.json",
+              $schema: "https://app.kilo.ai/config.json",
               model: "project/model",
             }),
           )

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -26,7 +26,7 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
     await Bun.write(
       path.join(dirpath, "opencode.json"),
       JSON.stringify({
-        $schema: "https://opencode.ai/config.json",
+        $schema: "https://app.kilo.ai/config.json",
         ...options.config,
       }),
     )

--- a/packages/opencode/test/kilocode/model-cache-org.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-org.test.ts
@@ -55,7 +55,7 @@ test("model fetch uses accountId from OAuth auth as kilocodeOrganizationId", asy
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -94,7 +94,7 @@ test("model fetch without OAuth accountId does not set kilocodeOrganizationId", 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },

--- a/packages/opencode/test/mcp/headers.test.ts
+++ b/packages/opencode/test/mcp/headers.test.ts
@@ -53,7 +53,7 @@ test("headers are passed to transports when oauth is enabled (default)", async (
       await Bun.write(
         `${dir}/opencode.json`,
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             "test-server": {
               type: "remote",

--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -111,7 +111,7 @@ test("BrowserOpenFailed event is published when open() throws", async () => {
       await Bun.write(
         `${dir}/opencode.json`,
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             "test-oauth-server": {
               type: "remote",
@@ -162,7 +162,7 @@ test("BrowserOpenFailed event is NOT published when open() succeeds", async () =
       await Bun.write(
         `${dir}/opencode.json`,
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             "test-oauth-server-2": {
               type: "remote",
@@ -211,7 +211,7 @@ test("open() is called with the authorization URL", async () => {
       await Bun.write(
         `${dir}/opencode.json`,
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           mcp: {
             "test-oauth-server-3": {
               type: "remote",

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -14,7 +14,7 @@ test("Bedrock: config region takes precedence over AWS_REGION env var", async ()
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -46,7 +46,7 @@ test("Bedrock: falls back to AWS_REGION env var when no config region", async ()
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -71,7 +71,7 @@ test("Bedrock: loads when bearer token from auth.json is present", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -139,7 +139,7 @@ test("Bedrock: config profile takes precedence over AWS_PROFILE env var", async 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -172,7 +172,7 @@ test("Bedrock: includes custom endpoint in options when specified", async () => 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -205,7 +205,7 @@ test("Bedrock: autoloads when AWS_WEB_IDENTITY_TOKEN_FILE is present", async () 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -243,7 +243,7 @@ test("Bedrock: model with us. prefix should not be double-prefixed", async () =>
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -280,7 +280,7 @@ test("Bedrock: model with global. prefix should not be prefixed", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -316,7 +316,7 @@ test("Bedrock: model with eu. prefix should not be double-prefixed", async () =>
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {
@@ -352,7 +352,7 @@ test("Bedrock: model without prefix in US region should get us. prefix added", a
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "amazon-bedrock": {
               options: {

--- a/packages/opencode/test/provider/gitlab-duo.test.ts
+++ b/packages/opencode/test/provider/gitlab-duo.test.ts
@@ -13,7 +13,7 @@ test("GitLab Duo: loads provider with API key from environment", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -37,7 +37,7 @@ test("GitLab Duo: config instanceUrl option sets baseURL", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             gitlab: {
               options: {
@@ -69,7 +69,7 @@ test("GitLab Duo: loads with OAuth token from auth.json", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -106,7 +106,7 @@ test("GitLab Duo: loads with Personal Access Token from auth.json", async () => 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -142,7 +142,7 @@ test("GitLab Duo: supports self-hosted instance configuration", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             gitlab: {
               options: {
@@ -174,7 +174,7 @@ test("GitLab Duo: config apiKey takes precedence over environment variable", asy
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             gitlab: {
               options: {
@@ -204,7 +204,7 @@ test("GitLab Duo: supports feature flags configuration", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             gitlab: {
               options: {
@@ -239,7 +239,7 @@ test("GitLab Duo: has multiple agentic chat models available", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -12,7 +12,7 @@ test("provider loaded from env variable", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -39,7 +39,7 @@ test("provider loaded from config with apiKey option", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               options: {
@@ -66,7 +66,7 @@ test("disabled_providers excludes provider", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           disabled_providers: ["anthropic"],
         }),
       )
@@ -90,7 +90,7 @@ test("enabled_providers restricts to only listed providers", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           enabled_providers: ["anthropic"],
         }),
       )
@@ -116,7 +116,7 @@ test("model whitelist filters models for provider", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               whitelist: ["claude-sonnet-4-20250514"],
@@ -147,7 +147,7 @@ test("model blacklist excludes specific models", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               blacklist: ["claude-sonnet-4-20250514"],
@@ -177,7 +177,7 @@ test("custom model alias via config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -212,7 +212,7 @@ test("custom provider with npm package", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "custom-provider": {
               name: "Custom Provider",
@@ -255,7 +255,7 @@ test("env variable takes precedence, config merges options", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               options: {
@@ -287,7 +287,7 @@ test("getModel returns model for valid provider/model", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -314,7 +314,7 @@ test("getModel throws ModelNotFoundError for invalid model", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -336,7 +336,7 @@ test("getModel throws ModelNotFoundError for invalid provider", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -367,7 +367,7 @@ test("defaultModel returns first available model when no config set", async () =
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -391,7 +391,7 @@ test("defaultModel respects config model setting", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           model: "anthropic/claude-sonnet-4-20250514",
         }),
       )
@@ -416,7 +416,7 @@ test("provider with baseURL from config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "custom-openai": {
               name: "Custom OpenAI",
@@ -455,7 +455,7 @@ test("model cost defaults to zero when not specified", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "test-provider": {
               name: "Test Provider",
@@ -496,7 +496,7 @@ test("model options are merged from existing model", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -531,7 +531,7 @@ test("provider removed when all models filtered out", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               whitelist: ["nonexistent-model"],
@@ -559,7 +559,7 @@ test("closest finds model by partial match", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -584,7 +584,7 @@ test("closest returns undefined for nonexistent provider", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -604,7 +604,7 @@ test("getModel uses realIdByKey for aliased models", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -642,7 +642,7 @@ test("provider api field sets model api.url", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "custom-api": {
               name: "Custom API",
@@ -681,7 +681,7 @@ test("explicit baseURL overrides api field", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "custom-api": {
               name: "Custom API",
@@ -720,7 +720,7 @@ test("model inherits properties from existing database model", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -756,7 +756,7 @@ test("disabled_providers prevents loading even with env var", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           disabled_providers: ["openai"],
         }),
       )
@@ -780,7 +780,7 @@ test("enabled_providers with empty array allows no providers", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           enabled_providers: [],
         }),
       )
@@ -805,7 +805,7 @@ test("whitelist and blacklist can be combined", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               whitelist: ["claude-sonnet-4-20250514", "claude-opus-4-20250514"],
@@ -838,7 +838,7 @@ test("model modalities default correctly", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "test-provider": {
               name: "Test",
@@ -875,7 +875,7 @@ test("model with custom cost values", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "test-provider": {
               name: "Test",
@@ -920,7 +920,7 @@ test("getSmallModel returns appropriate small model", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -944,7 +944,7 @@ test("getSmallModel respects config small_model override", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           small_model: "anthropic/claude-sonnet-4-20250514",
         }),
       )
@@ -985,7 +985,7 @@ test("multiple providers can be configured simultaneously", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               options: { timeout: 30000 },
@@ -1020,7 +1020,7 @@ test("provider with custom npm package", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "local-llm": {
               name: "Local LLM",
@@ -1062,7 +1062,7 @@ test("model alias name defaults to alias key when id differs", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -1095,7 +1095,7 @@ test("provider with multiple env var options only includes apiKey when single en
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "multi-env": {
               name: "Multi Env Provider",
@@ -1137,7 +1137,7 @@ test("provider with single env var includes apiKey automatically", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "single-env": {
               name: "Single Env Provider",
@@ -1179,7 +1179,7 @@ test("model cost overrides existing cost values", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -1216,7 +1216,7 @@ test("completely new provider not in database can be configured", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "brand-new-provider": {
               name: "Brand New",
@@ -1266,7 +1266,7 @@ test("disabled_providers and enabled_providers interaction", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           // enabled_providers takes precedence - only these are considered
           enabled_providers: ["anthropic", "openai"],
           // Then disabled_providers filters from the enabled set
@@ -1300,7 +1300,7 @@ test("model with tool_call false", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "no-tools": {
               name: "No Tools Provider",
@@ -1335,7 +1335,7 @@ test("model defaults tool_call to true when not specified", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "default-tools": {
               name: "Default Tools Provider",
@@ -1370,7 +1370,7 @@ test("model headers are preserved", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "headers-provider": {
               name: "Headers Provider",
@@ -1413,7 +1413,7 @@ test("provider env fallback - second env var used if first missing", async () =>
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "fallback-env": {
               name: "Fallback Env Provider",
@@ -1453,7 +1453,7 @@ test("getModel returns consistent results", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1479,7 +1479,7 @@ test("provider name defaults to id when not in database", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "my-custom-id": {
               // no name specified
@@ -1514,7 +1514,7 @@ test("ModelNotFoundError includes suggestions for typos", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1542,7 +1542,7 @@ test("ModelNotFoundError for provider includes suggestions", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1570,7 +1570,7 @@ test("getProvider returns undefined for nonexistent provider", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1590,7 +1590,7 @@ test("getProvider returns provider info", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1614,7 +1614,7 @@ test("closest returns undefined when no partial match found", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1637,7 +1637,7 @@ test("closest checks multiple query terms in order", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1662,7 +1662,7 @@ test("model limit defaults to zero when not specified", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "no-limit": {
               name: "No Limit Provider",
@@ -1699,7 +1699,7 @@ test("provider options are deeply merged", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               options: {
@@ -1736,7 +1736,7 @@ test("custom model inherits npm package from models.dev provider config", async 
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             openai: {
               models: {
@@ -1772,7 +1772,7 @@ test("custom model inherits api.url from models.dev provider", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             openrouter: {
               models: {
@@ -1816,7 +1816,7 @@ test("model variants are generated for reasoning models", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
         }),
       )
     },
@@ -1843,7 +1843,7 @@ test("model variants can be disabled via config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -1881,7 +1881,7 @@ test("model variants can be customized via config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -1922,7 +1922,7 @@ test("disabled key is stripped from variant config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -1962,7 +1962,7 @@ test("all variants can be disabled via config", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -1999,7 +1999,7 @@ test("variant config merges with generated variants", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             anthropic: {
               models: {
@@ -2039,7 +2039,7 @@ test("variants filtered in second pass for database models", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             openai: {
               models: {
@@ -2077,7 +2077,7 @@ test("custom model with variants enabled and disabled", async () => {
       await Bun.write(
         path.join(dir, "opencode.json"),
         JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
+          $schema: "https://app.kilo.ai/config.json",
           provider: {
             "custom-reasoning": {
               name: "Custom Reasoning Provider",

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -245,7 +245,7 @@ describe("session.llm.stream", () => {
         await Bun.write(
           path.join(dir, "opencode.json"),
           JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
+            $schema: "https://app.kilo.ai/config.json",
             enabled_providers: [providerID],
             provider: {
               [providerID]: {
@@ -369,7 +369,7 @@ describe("session.llm.stream", () => {
         await Bun.write(
           path.join(dir, "opencode.json"),
           JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
+            $schema: "https://app.kilo.ai/config.json",
             enabled_providers: ["openai"],
             provider: {
               openai: {
@@ -498,7 +498,7 @@ describe("session.llm.stream", () => {
         await Bun.write(
           path.join(dir, "opencode.json"),
           JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
+            $schema: "https://app.kilo.ai/config.json",
             enabled_providers: [providerID],
             provider: {
               [providerID]: {
@@ -599,7 +599,7 @@ describe("session.llm.stream", () => {
         await Bun.write(
           path.join(dir, "opencode.json"),
           JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
+            $schema: "https://app.kilo.ai/config.json",
             enabled_providers: [providerID],
             provider: {
               [providerID]: {


### PR DESCRIPTION
## Summary

- Replaces all references to `https://opencode.ai/config.json` with `https://app.kilo.ai/config.json` across 12 files (144 occurrences)
- Affects test files, `.opencode/opencode.jsonc`, and translator agent config