### PR TITLE
fix: use absolute paths for release archive output and upload

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -188,11 +188,13 @@ if (Script.release) {
   for (const key of Object.keys(binaries)) {
     const archive = key.replace(pkg.name, "kilo") // kilocode_change
     if (key.includes("linux")) {
-      await $`tar -czf ../../${archive}.tar.gz *`.cwd(`dist/${key}/bin`) // kilocode_change
-      archives.push(`./dist/${archive}.tar.gz`) // kilocode_change
+      const out = path.resolve("dist", `${archive}.tar.gz`) // kilocode_change
+      await $`tar -czf ${out} *`.cwd(`dist/${key}/bin`) // kilocode_change
+      archives.push(out) // kilocode_change
     } else {
-      await $`zip -r ../../${archive}.zip *`.cwd(`dist/${key}/bin`) // kilocode_change
-      archives.push(`./dist/${archive}.zip`) // kilocode_change
+      const out = path.resolve("dist", `${archive}.zip`) // kilocode_change
+      await $`zip -r ${out} *`.cwd(`dist/${key}/bin`) // kilocode_change
+      archives.push(out) // kilocode_change
     }
   }
   await $`gh release upload v${Script.version} ${archives} --clobber` // kilocode_change


### PR DESCRIPTION
## Summary

- Fixes the release CI failure from #274 where archive output paths didn't match the collected upload paths
- The `tar`/`zip` commands wrote archives via relative `../../` paths (landing in `dist/@kilocode/`), but the upload paths pointed to `dist/` directly
- Uses `path.resolve("dist", ...)` for both writing and collecting archive paths, eliminating the mismatch