### PR TITLE
fix: match scoped package dirs in publish script glob

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -188,11 +188,13 @@ if (Script.release) {
   for (const key of Object.keys(binaries)) {
     const archive = key.replace(pkg.name, "kilo") // kilocode_change
     if (key.includes("linux")) {
-      await $`tar -czf ../../${archive}.tar.gz *`.cwd(`dist/${key}/bin`) // kilocode_change
-      archives.push(`./dist/${archive}.tar.gz`) // kilocode_change
+      const out = path.resolve("dist", `${archive}.tar.gz`) // kilocode_change
+      await $`tar -czf ${out} *`.cwd(`dist/${key}/bin`) // kilocode_change
+      archives.push(out) // kilocode_change
     } else {
-      await $`zip -r ../../${archive}.zip *`.cwd(`dist/${key}/bin`) // kilocode_change
-      archives.push(`./dist/${archive}.zip`) // kilocode_change
+      const out = path.resolve("dist", `${archive}.zip`) // kilocode_change
+      await $`zip -r ${out} *`.cwd(`dist/${key}/bin`) // kilocode_change
+      archives.push(out) // kilocode_change
     }
   }
   await $`gh release upload v${Script.version} ${archives} --clobber` // kilocode_change

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -8,7 +8,8 @@ const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)
 
 const binaries: Record<string, string> = {}
-for (const filepath of new Bun.Glob("*/package.json").scanSync({ cwd: "./dist" })) {
+for (const filepath of new Bun.Glob("*/*/package.json").scanSync({ cwd: "./dist" })) {
+  // kilocode_change
   const pkg = await Bun.file(`./dist/${filepath}`).json()
   binaries[pkg.name] = pkg.version
 }


### PR DESCRIPTION
## Summary

- Fixes the publish step failing with `binaries {}` and `package.json must have name and version fields`
- The binary packages live at `dist/@kilocode/cli-*/package.json` (two directory levels) but the glob was `*/package.json` (one level), so it never matched anything
- Changes glob from `*/package.json` to `*/*/package.json`