### PR TITLE
reorder publish bump options to default to patch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ on:
         required: false
         type: choice
         options:
-          - major
-          - minor
           - patch
+          - minor
+          - major
       version:
         description: "Override version (optional)"
         required: false


### PR DESCRIPTION
## Summary
- Reorders the version bump dropdown in the publish workflow from `major/minor/patch` to `patch/minor/major`
- `patch` is now pre-selected by default, reducing the risk of accidental major or minor releases