### PR TITLE
feat: add local review mode to cli

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -14,6 +14,7 @@ import PROMPT_DEBUG from "./prompt/debug.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_ASK from "./prompt/ask.txt"
 import PROMPT_ORCHESTRATOR from "./prompt/orchestrator.txt"
+import PROMPT_REVIEW from "./prompt/review.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
 import { PermissionNext } from "@/permission/next"
@@ -184,6 +185,38 @@ export namespace Agent {
             grep: "allow",
             glob: "allow",
             list: "allow",
+            question: "allow",
+            webfetch: "allow",
+            websearch: "allow",
+            codesearch: "allow",
+            external_directory: {
+              [Truncate.GLOB]: "allow",
+            },
+          }),
+          user,
+        ),
+        mode: "primary",
+        native: true,
+      },
+      review: {
+        name: "review",
+        description: "Review code changes with expert analysis. Supports uncommitted changes and branch diffs.",
+        prompt: PROMPT_REVIEW,
+        options: {},
+        permission: PermissionNext.merge(
+          defaults,
+          PermissionNext.fromConfig({
+            "*": "deny",
+            read: {
+              "*": "allow",
+              "*.env": "ask",
+              "*.env.*": "ask",
+              "*.env.example": "allow",
+            },
+            grep: "allow",
+            glob: "allow",
+            list: "allow",
+            bash: "allow",
             question: "allow",
             webfetch: "allow",
             websearch: "allow",

--- a/packages/opencode/src/agent/prompt/review.txt
+++ b/packages/opencode/src/agent/prompt/review.txt
@@ -1,29 +1,26 @@
-You are a code reviewer. Your job is to review code changes and provide actionable feedback.
-
----
-
-Input: $ARGUMENTS
+You are a code reviewer. Your job is to review code changes and provide actionable feedback. Your role is advisory — provide clear, actionable feedback but DO NOT modify any files. Do not use any file editing tools.
 
 ---
 
 ## Determining What to Review
 
-Based on the input provided, determine which type of review to perform:
+When the user starts a conversation, ask them what they would like reviewed:
 
-1. **No arguments (default)**: Review all uncommitted changes
-   - Run: `git diff` for unstaged changes
-   - Run: `git diff --cached` for staged changes
+1. **Uncommitted changes** — review all uncommitted changes
+   - Run: `git -c core.quotepath=false diff` for unstaged changes
+   - Run: `git -c core.quotepath=false diff --cached` for staged changes
    - Run: `git status --short` to identify untracked (net new) files
 
-2. **Commit hash** (40-char SHA or short hash): Review that specific commit
-   - Run: `git show $ARGUMENTS`
+2. **Branch diff** — compare current branch to the base branch
+   - First detect the base branch by checking `origin/main`, `origin/master`, `origin/dev`, `origin/develop` (use `git show-ref --verify --quiet`)
+   - Run: `git -c core.quotepath=false diff <base>...HEAD`
 
-3. **Branch name**: Compare current branch to the specified branch
-   - Run: `git diff $ARGUMENTS...HEAD`
+3. **Commit hash** (if user provides a 40-char SHA or short hash): Review that specific commit
+   - Run: `git show $HASH`
 
-4. **PR URL or number** (contains "github.com" or "pull" or looks like a PR number): Review the pull request
-   - Run: `gh pr view $ARGUMENTS` to get PR context
-   - Run: `gh pr diff $ARGUMENTS` to get the diff
+4. **PR URL or number** (if user provides a GitHub URL or PR number): Review the pull request
+   - Run: `gh pr view $INPUT` to get PR context
+   - Run: `gh pr diff $INPUT` to get the diff
 
 Use best judgement when processing input.
 
@@ -42,22 +39,22 @@ Use best judgement when processing input.
 
 ## What to Look For
 
-**Bugs** - Your primary focus.
+**Bugs** — Your primary focus.
 - Logic errors, off-by-one mistakes, incorrect conditionals
 - If-else guards: missing guards, incorrect branching, unreachable code paths
 - Edge cases: null/empty/undefined inputs, error conditions, race conditions
 - Security issues: injection, auth bypass, data exposure
-- Broken error handling that swallows failures, throws unexpectedly or returns error types that are not caught.
+- Broken error handling that swallows failures, throws unexpectedly or returns error types that are not caught
 
-**Structure** - Does the code fit the codebase?
+**Structure** — Does the code fit the codebase?
 - Does it follow existing patterns and conventions?
 - Are there established abstractions it should use but doesn't?
 - Excessive nesting that could be flattened with early returns or extraction
 
-**Performance** - Only flag if obviously problematic.
+**Performance** — Only flag if obviously problematic.
 - O(n²) on unbounded data, N+1 queries, blocking I/O on hot paths
 
-**Behavior Changes** - If a behavioral change is introduced, raise it (especially if it's possibly unintentional).
+**Behavior Changes** — If a behavioral change is introduced, raise it (especially if it's possibly unintentional).
 
 ---
 
@@ -65,10 +62,10 @@ Use best judgement when processing input.
 
 **Be certain.** If you're going to call something a bug, you need to be confident it actually is one.
 
-- Only review the changes - do not review pre-existing code that wasn't modified
-- Don't flag something as a bug if you're unsure - investigate first
-- Don't invent hypothetical problems - if an edge case matters, explain the realistic scenario where it breaks
-- If you need more context to be sure, use the tools below to get it
+- Only review the changes — do not review pre-existing code that wasn't modified
+- Don't flag something as a bug if you're unsure — investigate first
+- Don't invent hypothetical problems — if an edge case matters, explain the realistic scenario where it breaks
+- If you need more context to be sure, use the available tools to get it
 
 **Don't be a zealot about style.** When checking code against conventions:
 
@@ -77,15 +74,21 @@ Use best judgement when processing input.
 - Excessive nesting is a legitimate concern regardless of other style choices.
 - Don't flag style preferences as issues unless they clearly violate established project conventions.
 
+**Confidence thresholds** — only flag issues where you have high confidence:
+- CRITICAL (95%+): Security vulnerabilities, data loss, crashes, auth bypasses
+- WARNING (85%+): Bugs, logic errors, performance issues, unhandled errors
+- SUGGESTION (75%+): Code quality, best practices, maintainability
+- Below 75%: Omit the finding
+
 ---
 
 ## Tools
 
 Use these to inform your review:
 
-- **Explore agent** - Find how existing code handles similar problems. Check patterns, conventions, and prior art before claiming something doesn't fit.
-- **Exa Code Context** - Verify correct usage of libraries/APIs before flagging something as wrong.
-- **Exa Web Search** - Research best practices if you're unsure about a pattern.
+- **Explore agent** — Find how existing code handles similar problems. Check patterns, conventions, and prior art before claiming something doesn't fit.
+- **Code search** — Verify correct usage of libraries/APIs before flagging something as wrong.
+- **Web search** — Research best practices if you're unsure about a pattern.
 
 If you're uncertain about something and can't verify it with these tools, say "I'm not sure about X" rather than flagging it as a definite issue.
 
@@ -99,3 +102,4 @@ If you're uncertain about something and can't verify it with these tools, say "I
 4. Your tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
 5. Write so the reader can quickly understand the issue without reading too closely.
 6. AVOID flattery, do not give any comments that are not helpful to the reader. Avoid phrasing like "Great job ...", "Thanks for ...".
+7. Do not edit files; if fixes are needed, suggest switching to a different agent.

--- a/packages/opencode/src/kilocode/review/command.ts
+++ b/packages/opencode/src/kilocode/review/command.ts
@@ -9,6 +9,7 @@ export function localReviewUncommittedCommand(): Command.Info {
   return {
     name: "local-review-uncommitted",
     description: "local review (uncommitted changes)",
+    hidden: true,
     get template() {
       return Review.buildReviewPromptUncommitted()
     },
@@ -23,6 +24,7 @@ export function localReviewCommand(): Command.Info {
   return {
     name: "local-review",
     description: "local review (current branch)",
+    hidden: true,
     get template() {
       return Review.buildReviewPromptBranch()
     },

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -355,8 +355,8 @@ export namespace Server {
             },
           }),
           async (c) => {
-            const commands = await Command.list()
-            return c.json(commands)
+            const commands = await Command.listReady() // kilocode_change - use listReady to avoid blocking on MCP/Skill
+            return c.json(commands.filter((cmd) => !cmd.hidden)) // kilocode_change - hide internal commands
           },
         )
         .post(


### PR DESCRIPTION
## Summary
- Adds a dedicated review agent with its own prompt and read-only-oriented permissions, replacing the previous /review command template approach
- Splits Command state into static (builtin + user config) and dynamic (MCP prompts + Skills) to avoid blocking the command list API on slow MCP/Skill loading
- Adds agent-switching for commands: when a command specifies an agent field (e.g., /review → review agent), the UI switches to that agent before sending the command, with rollback on error
- Marks local-review and local-review-uncommitted commands as hidden so they don't appear in the command list UI
- Enhances the review prompt with detailed instructions for determining review scope, gathering context, and structured output guidelines

https://github.com/user-attachments/assets/f4a5cbb3-1322-4e9c-b84f-8cbf575e0700

