### PR TITLE
fix: webview background stays dark when switching to light theme

### DIFF
--- a/packages/kilo-ui/src/styles/vscode-bridge.css
+++ b/packages/kilo-ui/src/styles/vscode-bridge.css
@@ -11,6 +11,9 @@
  */
 
 html[data-theme="kilo-vscode"] {
+  /* Let VS Code control the color scheme instead of the OS preference */
+  color-scheme: normal;
+
   /* ===== Backgrounds ===== */
   --background-base: var(--vscode-editor-background);
   --background-weak: var(--vscode-sideBar-background, var(--vscode-editor-background));

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1227,6 +1227,7 @@ export class KiloProvider implements vscode.WebviewViewProvider {
 			overflow: hidden;
 		}
 		body {
+			background-color: var(--vscode-editor-background);
 			color: var(--vscode-foreground);
 			font-family: var(--vscode-font-family);
 		}


### PR DESCRIPTION
## Problem

When switching VS Code to a light theme, the extension's webview background stays black/dark. The rest of the UI adapts properly.

## Root Cause

Two issues:

1. The webview body element had no explicit `background-color` set, relying on browser defaults
2. kilo-ui's `theme.css` sets `color-scheme: dark` via `@media (prefers-color-scheme: dark)`, which follows the **OS** preference rather than VS Code's active theme. When the OS is in dark mode but VS Code is in light mode, the browser renders the page with a dark color scheme.

## Fix

1. **`KiloProvider.ts`**: Added `background-color: var(--vscode-editor-background)` to the body element in the webview HTML template
2. **`vscode-bridge.css`**: Added `color-scheme: normal` override in the `html[data-theme="kilo-vscode"]` selector so the OS dark mode preference doesn't affect the webview when VS Code is using a light theme

<img width="1750" height="2140" alt="CleanShot 2026-02-16 at 11 00 02@2x" src="https://github.com/user-attachments/assets/1a449d68-f48e-4b28-8166-6dab4a704dc4" />
