### PR TITLE
fix: add repository field to sdk and plugin packages for npm provenance

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -4,6 +4,11 @@
   "version": "1.0.19",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kilo-Org/kilo",
+    "directory": "packages/plugin"
+  },
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "tsc"

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -4,6 +4,11 @@
   "version": "1.0.19",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Kilo-Org/kilo",
+    "directory": "packages/sdk/js"
+  },
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "./script/build.ts"


### PR DESCRIPTION
## Summary

- Adds `repository` field to `@kilocode/sdk` and `@kilocode/plugin` `package.json` files
- Fixes npm publish E422 error caused by provenance verification requiring `repository.url` to match the GitHub Actions source repository
- The `@kilocode/cli` package and its binaries already had this field set correctly