### PR TITLE
fix: preserve repository field in SDK and plugin packages for npm provenance

### DIFF
--- a/packages/plugin/script/publish.ts
+++ b/packages/plugin/script/publish.ts
@@ -17,5 +17,7 @@ for (const [key, value] of Object.entries(pkg.exports)) {
   }
 }
 await Bun.write("package.json", JSON.stringify(pkg, null, 2))
+await Bun.write("dist/package.json", JSON.stringify(pkg, null, 2))
 await $`bun pm pack && npm publish *.tgz --tag ${Script.channel} --access public --provenance` // kilocode_change
 await Bun.write("package.json", JSON.stringify(original, null, 2))
+await $`rm -f dist/package.json`.nothrow()

--- a/packages/sdk/js/script/publish.ts
+++ b/packages/sdk/js/script/publish.ts
@@ -16,6 +16,8 @@ for (const [key, value] of Object.entries(pkg.exports)) {
   }
 }
 await Bun.write("package.json", JSON.stringify(pkg, null, 2))
+await Bun.write("dist/package.json", JSON.stringify(pkg, null, 2))
 await $`bun pm pack`
 await $`npm publish *.tgz --tag ${Script.channel} --access public --provenance` // kilocode_change
 await Bun.write("package.json", JSON.stringify(original, null, 2))
+await $`rm -f dist/package.json`.nothrow()


### PR DESCRIPTION
## Summary

- Fixes npm provenance verification failure when publishing SDK and plugin packages
- Ensures `repository.url` is preserved in the published tarball by writing the complete `package.json` to `dist/` before packing
- Tested locally by building and packing both packages, verifying `repository` field is present in tarball

## Details

When publishing with `--provenance`, npm's sigstore verification expects `package.json` to have `repository.url` matching the GitHub Actions provenance. The SDK package uses `publishConfig.directory: "dist"`, causing `bun pm pack` to pack from `dist/` where no `package.json` exists, so Bun generates a minimal one without the `repository` field.

This fix writes the transformed `package.json` (which includes all fields including `repository`) into `dist/package.json` before packing, ensuring the complete metadata is included in the published tarball.

Applied the same fix to the plugin package for consistency and to prevent future issues.