### PR TITLE
fix(vscode): restrict webview file URLs to file:// scheme

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -155,7 +155,7 @@ export class KiloProvider implements vscode.WebviewViewProvider {
           break
         case "sendMessage": {
           const files = z
-            .array(z.object({ mime: z.string(), url: z.string() }))
+            .array(z.object({ mime: z.string(), url: z.string().startsWith("file://") }))
             .optional()
             .catch(undefined)
             .parse(message.files)


### PR DESCRIPTION
## Summary

- Adds `startsWith("file://")` constraint to the zod schema validating `files` from webview messages
- Prevents non-file schemes (`http:`, `command:`, `vscode-remote:`, etc.) from being forwarded to the CLI backend

Addresses review comment from #307: https://github.com/Kilo-Org/kilo/pull/307/files/48bbd8df9329d1a21ab4b56685bde046c200bbe8#r2804654953