### PR TITLE
docs: add MCP config file path (~/.config/kilo/opencode.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you're coming from the Kilo Code VS Code extension, your configurations are a
 | Workflows (`.kilocode/workflows/`)           | Converted to commands                        |
 | MCP servers                                  | Migrated to `mcp` config                     |
 
-MCP servers are configured in **`~/.config/kilo/opencode.json`** (or `%USERPROFILE%\.config\kilo\opencode.json` on Windows) under the top-level `"mcp"` object. Each entry is a server name with `type: "local"` and `command: ["executable", "arg1", ...]`. Restart the CLI after editing for changes to take effect.
+MCP servers are configured in **`~/.config/kilo/opencode.json`** (or `opencode.jsonc`; on Windows the config directory may be under `%USERPROFILE%` depending on your environment). Use a top-level `"mcp"` object: each key is a server name, value is `type: "local"` and `command: ["executable", "arg1", ...]`. Optional per-server: `environment`, `enabled`, `timeout`. Restart the CLI after editing for changes to take effect. (Path from [`packages/opencode/src/global/index.ts`](packages/opencode/src/global/index.ts); schema in [`config.ts`](packages/opencode/src/config/config.ts) `McpLocal`.)
 
 **Default mode mappings:**
 

--- a/packages/opencode/src/kilocode/docs/migration.md
+++ b/packages/opencode/src/kilocode/docs/migration.md
@@ -335,12 +335,12 @@ Kilocode MCP server configurations are migrated to Opencode's `mcp` config. See 
 
 ## Config file location
 
-MCP servers are configured in:
+The CLI reads global config from `~/.config/kilo/` (see [`global/index.ts`](../../global/index.ts): `Global.Path.config` = `xdgConfig` + `"kilo"`). It merges, in order, `config.json`, `opencode.json`, and `opencode.jsonc` in that directory. You can put MCP config in **`opencode.json`** or **`opencode.jsonc`**.
 
-- **macOS / Linux:** `~/.config/kilo/opencode.json`
-- **Windows:** `%USERPROFILE%\.config\kilo\opencode.json`
+- **macOS / Linux:** `~/.config/kilo/opencode.json` (or `opencode.jsonc`)
+- **Windows:** Config directory depends on `xdg-basedir` (often under `%LOCALAPPDATA%` or `%USERPROFILE%`); filename is still `opencode.json` or `opencode.jsonc`.
 
-Use a top-level `"mcp"` object. Each key is the server name; value is `type: "local"` and `command: ["executable", "arg1", ...]`. Restart the CLI after editing.
+Use a top-level `"mcp"` object. Each key is the server name. For a local server, value must have `type: "local"` and `command: ["executable", "arg1", ...]`. Optional: `environment` (env vars), `enabled` (boolean), `timeout` (ms). See `Config.McpLocal` in [`config.ts`](../../config/config.ts). Restart the CLI after editing.
 
 ## Source Location (migration from Kilocode)
 


### PR DESCRIPTION
## Context

Users who install Kilo CLI via `npm install -g @kilocode/cli` (1.0.x) need the config file path and format for MCP. This PR documents `~/.config/kilo/opencode.json` (or `opencode.jsonc`) and the `"mcp"` object format.

## Implementation

- **README.md**: After the migration table, add paragraph: MCP in `~/.config/kilo/opencode.json` (or `opencode.jsonc`), top-level `"mcp"`, `type: "local"`, `command: ["executable", ...]`, optional `environment`, `enabled`, `timeout`. Link to `global/index.ts` and `config.ts` (McpLocal).
- **packages/opencode/src/kilocode/docs/migration.md**: In MCP Migration, add "Config file location" — CLI merges `config.json`, `opencode.json`, `opencode.jsonc` in `~/.config/kilo/`; paths for macOS/Linux/Windows; pointer to `Config.McpLocal`.

Docs only.

## Screenshots

| before | after |
| ------ | ----- |
| No path for MCP config | README and migration.md state path and format |

## How to Test

1. Install Kilo CLI 1.0.x, create or edit `~/.config/kilo/opencode.json`, add `"mcp": { "myserver": { "type": "local", "command": ["node", "/path/to/server.js"] } }`.
2. Restart CLI; status bar should show MCP count.
3. Confirm README and migration doc match.
