### PR TITLE
feat: implement notification service for SSE events

### DIFF
--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -5,6 +5,7 @@ import { EXTENSION_DISPLAY_NAME } from "./constants"
 import { KiloConnectionService } from "./services/cli-backend"
 import { registerAutocompleteProvider } from "./services/autocomplete"
 import { BrowserAutomationService } from "./services/browser-automation"
+import { NotificationService } from "./services/notification-service"
 
 export function activate(context: vscode.ExtensionContext) {
   console.log("Kilo Code extension is now active")
@@ -15,6 +16,9 @@ export function activate(context: vscode.ExtensionContext) {
   // Create browser automation service (manages Playwright MCP registration)
   const browserAutomationService = new BrowserAutomationService(connectionService)
   browserAutomationService.syncWithSettings()
+
+  // Create notification service (shows VS Code notifications for SSE events)
+  const notificationService = new NotificationService(connectionService)
 
   // Re-register browser automation MCP server on CLI backend reconnect
   const unsubscribeStateChange = connectionService.onStateChange((state) => {
@@ -65,6 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push({
     dispose: () => {
       unsubscribeStateChange()
+      notificationService.dispose()
       browserAutomationService.dispose()
       provider.dispose()
       connectionService.dispose()

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -128,6 +128,7 @@ export class KiloConnectionService {
         return event.properties.info.id
       case "session.status":
       case "session.idle":
+      case "session.error":
       case "todo.updated":
         return event.properties.sessionID
       case "message.updated":

--- a/packages/kilo-vscode/src/services/cli-backend/types.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/types.ts
@@ -74,6 +74,7 @@ export type SSEEvent =
   | { type: "session.updated"; properties: { info: SessionInfo } }
   | { type: "session.status"; properties: { sessionID: string; status: SessionStatusInfo } }
   | { type: "session.idle"; properties: { sessionID: string } }
+  | { type: "session.error"; properties: { sessionID?: string; error?: unknown } }
   | { type: "message.updated"; properties: { info: MessageInfo } }
   | { type: "message.part.updated"; properties: { part: MessagePart; delta?: string } }
   | { type: "permission.asked"; properties: PermissionRequest }

--- a/packages/kilo-vscode/src/services/notification-service.ts
+++ b/packages/kilo-vscode/src/services/notification-service.ts
@@ -1,0 +1,105 @@
+import * as vscode from "vscode"
+import type { KiloConnectionService } from "./cli-backend/connection-service"
+import type { SessionInfo, SSEEvent } from "./cli-backend/types"
+
+const CONFIG_SECTION = "kilo-code.new"
+const PERMISSION_COOLDOWN_MS = 5000
+
+/**
+ * Watches SSE events and shows VS Code notifications based on user settings.
+ * Mirrors the desktop app's notification behaviour for agent completion,
+ * session errors, and permission requests.
+ */
+export class NotificationService {
+  private readonly unsubscribe: () => void
+  private readonly sessionCache = new Map<string, SessionInfo>()
+  private readonly permissionCooldowns = new Map<string, number>()
+
+  constructor(private readonly connectionService: KiloConnectionService) {
+    this.unsubscribe = connectionService.onEvent((event) => {
+      this.handleEvent(event)
+    })
+  }
+
+  dispose(): void {
+    this.unsubscribe()
+    this.sessionCache.clear()
+    this.permissionCooldowns.clear()
+  }
+
+  private handleEvent(event: SSEEvent): void {
+    // Cache session info so we can check parentID later
+    if (event.type === "session.created" || event.type === "session.updated") {
+      this.sessionCache.set(event.properties.info.id, event.properties.info)
+      return
+    }
+
+    switch (event.type) {
+      case "session.idle":
+        this.handleSessionIdle(event.properties.sessionID)
+        break
+      case "session.error":
+        this.handleSessionError(event.properties.sessionID)
+        break
+      case "permission.asked":
+        this.handlePermissionAsked(event.properties.sessionID)
+        break
+    }
+  }
+
+  private handleSessionIdle(sessionId: string): void {
+    if (this.isChildSession(sessionId)) {
+      return
+    }
+
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION)
+    if (!config.get<boolean>("notifications.agent")) {
+      return
+    }
+
+    console.log("[Kilo New] Showing agent completion notification")
+    void vscode.window.showInformationMessage("Kilo: Agent completed task")
+  }
+
+  private handleSessionError(sessionId: string | undefined): void {
+    if (sessionId && this.isChildSession(sessionId)) {
+      return
+    }
+
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION)
+    if (!config.get<boolean>("notifications.errors")) {
+      return
+    }
+
+    console.log("[Kilo New] Showing session error notification")
+    void vscode.window.showWarningMessage("Kilo: Session error occurred")
+  }
+
+  private handlePermissionAsked(sessionId: string): void {
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION)
+    if (!config.get<boolean>("notifications.permissions")) {
+      return
+    }
+
+    // Cooldown per session to avoid flooding
+    const now = Date.now()
+    const last = this.permissionCooldowns.get(sessionId) ?? 0
+    if (now - last < PERMISSION_COOLDOWN_MS) {
+      return
+    }
+    this.permissionCooldowns.set(sessionId, now)
+
+    console.log("[Kilo New] Showing permission request notification")
+    void vscode.window.showInformationMessage("Kilo: Permission requested", "Go to Session").then((selection) => {
+      if (selection !== "Go to Session") {
+        return
+      }
+      void vscode.commands.executeCommand("kilo-code.new.sidebarView.focus")
+    })
+  }
+
+  private isChildSession(sessionId: string): boolean {
+    const info = this.sessionCache.get(sessionId)
+    return !!info?.parentID
+  }
+}


### PR DESCRIPTION
Implements VS Code notifications for agent completion, errors, and permission requests based on user settings.

## Changes

### New: `src/services/notification-service.ts`
- `NotificationService` class that subscribes to SSE events via `KiloConnectionService.onEvent()`
- Reads notification settings from VS Code configuration (`kilo-code.new.notifications.*`)
- **`session.idle`** → shows info notification when agent completes (skips child sessions)
- **`session.error`** → shows warning notification on session errors (skips child sessions)  
- **`permission.asked`** → shows info notification with "Go to Session" action button (5s cooldown per session)
- Caches `SessionInfo` from `session.created`/`session.updated` events to resolve `parentID`

### Modified: `src/services/cli-backend/types.ts`
- Added `session.error` event type to `SSEEvent` union

### Modified: `src/services/cli-backend/connection-service.ts`
- Added `session.error` to `resolveEventSessionId()` switch

### Modified: `src/extension.ts`
- Instantiates `NotificationService` and adds it to dispose chain

## Settings consumed (already defined in package.json)
- `kilo-code.new.notifications.agent` — notify on agent completion
- `kilo-code.new.notifications.permissions` — notify on permission requests
- `kilo-code.new.notifications.errors` — notify on errors

Sound settings (`sounds.*`) are not consumed — VS Code has no native sound API.