### PR TITLE
fix: resolve @opencode-ai/ui module resolution in vscode extension build

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -292,6 +292,7 @@
     "@kilocode/kilo-i18n": "file:../kilo-i18n",
     "@kilocode/kilo-ui": "file:../kilo-ui",
     "@kilocode/sdk": "file:../sdk/js",
+    "@opencode-ai/ui": "file:../ui",
     "diff": "^7.0.0",
     "dotenv": "^16.4.7",
     "eventsource": "^2.0.2",


### PR DESCRIPTION
## Summary

- Fixes module resolution errors during VSCode extension build where esbuild could not resolve `@opencode-ai/ui` subpath imports
- Adds `@opencode-ai/ui` as a direct `file:../ui` dependency to `packages/kilo-vscode/package.json`

## Problem

The `@kilocode/kilo-ui` package declares `@opencode-ai/ui` as a peer dependency using `workspace:*` protocol. When `pnpm install` runs in `packages/kilo-vscode/` during CI, it cannot resolve the `workspace:*` peer dependency in isolation, causing esbuild to fail with 45 "Could not resolve" errors for all `@opencode-ai/ui` subpath imports.

## Solution

Add `@opencode-ai/ui` as a direct dependency using the `file:` protocol, following the same pattern already used for `@kilocode/kilo-ui`, `@kilocode/kilo-i18n`, and `@kilocode/sdk`. This ensures the package is available in `node_modules` when esbuild bundles the webview.

## Testing

- Fixes the `publish-vscode.yml` workflow failure
- No runtime changes—just ensures dependency resolution during build