### PR TITLE
fix: remove conflicting --target flag from vsce publish

### DIFF
--- a/packages/kilo-vscode/script/publish.ts
+++ b/packages/kilo-vscode/script/publish.ts
@@ -113,7 +113,7 @@ for (const config of targets) {
 
   // Publish for this target
   console.log(`  🚀 Publishing to VS Code Marketplace for ${config.target}...`)
-  await $`vsce publish --pre-release --target ${config.target} --packagePath ${vsixPath}`
+  await $`vsce publish --pre-release --packagePath ${vsixPath}`
   console.log(`  ✅ Published ${config.target}`)
 
   // Note: Open VSX publishing is commented out as it doesn't support prereleases


### PR DESCRIPTION
## Summary
- Removes `--target` flag from `vsce publish` command in `packages/kilo-vscode/script/publish.ts`
- The `.vsix` file already contains target platform metadata from the `vsce package --target` step
- Fixes error: "Both options not supported simultaneously: 'packagePath' and 'target'"