### PR TITLE
fix: auto-refresh balance when navigating to profile view

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createSignal, createMemo, createEffect } from "solid-js"
+import { Component, Show, createSignal, createMemo, createEffect, onMount } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Card } from "@kilocode/kilo-ui/card"
 import { Select } from "@kilocode/kilo-ui/select"
@@ -32,6 +32,11 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
   const vscode = useVSCode()
   const language = useLanguage()
   const [target, setTarget] = createSignal<string | null>(null)
+
+  // Always fetch fresh profile+balance when navigating to this view
+  onMount(() => {
+    vscode.postMessage({ type: "refreshProfile" })
+  })
 
   // Reset pending target whenever profileData changes (success or failure both send a fresh profile)
   createEffect(() => {


### PR DESCRIPTION
## Problem
Balance on the profile page was only fetched on initial webview mount (via `syncWebviewState`). Navigating to the profile tab didn't trigger a re-fetch, so the balance would be stale.

## Solution
Added an `onMount` hook to `ProfileView` that posts a `refreshProfile` message every time the component mounts. Since SolidJS's `<Switch>`/`<Match>` unmounts/remounts `ProfileView` on each navigation, the balance is always freshly fetched when the user opens the profile page.

This mirrors the kilocode-5 pattern where `useEffect` on mount fires `fetchBalanceDataRequest`.

fixes https://github.com/Kilo-Org/kilo/issues/350