### PR TITLE
fix: override --font-family-sans in vscode theme to prevent serif fallback

### DIFF
--- a/packages/kilo-ui/src/styles/globals.css
+++ b/packages/kilo-ui/src/styles/globals.css
@@ -48,6 +48,7 @@
 /* ===== VS Code extension: inherit native styling ===== */
 
 html[data-theme="kilo-vscode"] {
+  --font-family-sans: var(--vscode-font-family);
   font-family: var(--vscode-font-family);
   font-size: var(--vscode-font-size);
   font-weight: var(--vscode-font-weight);


### PR DESCRIPTION
## Problem

The VSCode extension shows text in a serif font (Times New Roman) instead of the native VSCode UI font.

## Root Cause

The upstream UI package sets `--font-family-sans: "Inter", "Inter Fallback"` and `base.css` applies it globally via `font-family: var(--font-family-sans)`. The `Font` component loads Inter via `@font-face` and defines "Inter Fallback" as a local Arial alias — but this component **is not used** in the VSCode webview.

So the cascade becomes: `"Inter"` (not loaded) → `"Inter Fallback"` (no `@font-face` defined) → browser default serif font.

The existing `globals.css` did override `font-family` on `html[data-theme="kilo-vscode"]`, but didn't override the `--font-family-sans` CSS variable.

## Fix

Added `--font-family-sans: var(--vscode-font-family)` to the `html[data-theme="kilo-vscode"]` scope, so all CSS references to the sans font variable resolve to VSCode's native UI font.

| Before | after|
|---|---|
| <img width="1486" height="1682" alt="CleanShot 2026-02-17 at 10 20 35@2x" src="https://github.com/user-attachments/assets/bbffb1e8-f8c7-42df-adfe-183dfdef0503" /> | <img width="1422" height="1742" alt="CleanShot 2026-02-17 at 10 21 23@2x" src="https://github.com/user-attachments/assets/8cdf9fa4-7b95-4144-b6e6-f8157ffbdd70" /> |

