### PR TITLE
feat(vscode): auto-rebuild CLI binary on opencode source changes + auto-start watchers

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,13 +5,16 @@
   "tasks": [
     {
       "label": "VSCode - Watch",
-      "dependsOn": ["VSCode - TSC", "VSCode - ESBuild"],
+      "dependsOn": ["VSCode - TSC", "VSCode - ESBuild", "VSCode - CLI Watch"],
       "presentation": {
         "reveal": "never"
       },
       "group": {
         "kind": "build",
         "isDefault": true
+      },
+      "runOptions": {
+        "runOn": "folderOpen"
       }
     },
     {
@@ -45,6 +48,22 @@
       "options": {
         "cwd": "${workspaceFolder}/packages/kilo-vscode"
       }
+    },
+    {
+      "label": "VSCode - CLI Watch",
+      "type": "shell",
+      "command": "bun",
+      "args": ["run", "watch:cli"],
+      "group": "build",
+      "isBackground": true,
+      "presentation": {
+        "group": "watch",
+        "reveal": "never"
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/packages/kilo-vscode"
+      },
+      "problemMatcher": []
     },
     {
       "label": "VSCode - Tests",

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -259,6 +259,7 @@
     "watch": "bun run --parallel watch:esbuild watch:tsc",
     "watch:esbuild": "bun run prepare:cli-binary && node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+    "watch:cli": "bun script/watch-cli.ts",
     "package": "bun run prepare:cli-binary && bun run check-types && bun run lint && node esbuild.js --production",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",

--- a/packages/kilo-vscode/script/watch-cli.ts
+++ b/packages/kilo-vscode/script/watch-cli.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+/**
+ * Watches packages/opencode/src/ for changes and rebuilds the CLI binary,
+ * then copies it into packages/kilo-vscode/bin/kilo.
+ *
+ * Used during development so the VS Code extension always has an up-to-date
+ * CLI backend without manual rebuild steps.
+ */
+import { watch, chmodSync } from "node:fs"
+import { join, relative } from "node:path"
+import { $ } from "bun"
+
+const kiloVscodeDir = join(import.meta.dir, "..")
+const packagesDir = join(kiloVscodeDir, "..")
+const opencodeDir = join(packagesDir, "opencode")
+const opencodeSrcDir = join(opencodeDir, "src")
+const targetBinDir = join(kiloVscodeDir, "bin")
+const targetBinPath = join(targetBinDir, "kilo")
+
+let building = false
+let pending = false
+let installed = false
+
+function log(msg: string) {
+  console.log(`[watch-cli] ${msg}`)
+}
+
+function sourceBinaryPath(): string {
+  return join(opencodeDir, "dist", `@kilocode/cli-${process.platform}-${process.arch}`, "bin", "kilo")
+}
+
+async function rebuild() {
+  if (building) {
+    pending = true
+    return
+  }
+  building = true
+  pending = false
+
+  try {
+    log("Rebuilding CLI binary...")
+    const start = performance.now()
+
+    const args = installed ? ["run", "build", "--single", "--skip-install"] : ["run", "build", "--single"]
+    const result = await $`bun ${args}`.cwd(opencodeDir).nothrow().quiet()
+    if (result.exitCode !== 0) {
+      log(`Build failed (exit ${result.exitCode}):\n${result.stderr.toString()}`)
+      return
+    }
+    installed = true
+
+    const source = sourceBinaryPath()
+    if (!await Bun.file(source).exists()) {
+      log(`ERROR: Build completed but no binary found at ${relative(packagesDir, source)}`)
+      return
+    }
+
+    await $`mkdir -p ${targetBinDir}`
+    await $`cp ${source} ${targetBinPath}`
+    chmodSync(targetBinPath, 0o755)
+
+    const elapsed = ((performance.now() - start) / 1000).toFixed(1)
+    log(`Binary updated (${elapsed}s): ${relative(packagesDir, source)} -> bin/kilo`)
+  } catch (err) {
+    log(`ERROR: ${err instanceof Error ? err.message : String(err)}`)
+  } finally {
+    building = false
+    if (pending) rebuild()
+  }
+}
+
+// Initial build
+await rebuild()
+
+// Watch for changes
+log(`Watching ${relative(kiloVscodeDir, opencodeSrcDir)}/ for changes...`)
+
+const debounce = 500
+let timer: ReturnType<typeof setTimeout> | null = null
+
+watch(opencodeSrcDir, { recursive: true }, (_event, filename) => {
+  if (!filename) return
+  // Skip non-source files and build-generated files
+  if (filename.endsWith(".test.ts") || filename.endsWith(".test.tsx")) return
+  if (filename.includes("models-snapshot")) return
+
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(() => {
+    log(`Change detected: ${filename}`)
+    rebuild()
+  }, debounce)
+})
+
+log("CLI watcher running. Press Ctrl+C to stop.")


### PR DESCRIPTION
## What

Adds a file watcher that automatically rebuilds the CLI binary when `packages/opencode/src/` files change during development, and configures all watch tasks to auto-start when opening the project.

## Why

Currently, when developing both the VS Code extension and the CLI backend, you need to manually run `bun run prepare:cli-binary --force` every time you change CLI code. This is easy to forget and slows down the dev loop.

## How

### CLI Watcher (`packages/kilo-vscode/script/watch-cli.ts`)
- Does an initial CLI build on startup (with dependency install)
- Watches `packages/opencode/src/` recursively for file changes
- Debounces changes (500ms) to avoid excessive rebuilds
- Runs `bun run build --single` in the opencode package (skips install after first successful build)
- Copies the resulting binary to `packages/kilo-vscode/bin/kilo`
- Queues rebuilds if a change arrives mid-build
- Ignores generated files (`models-snapshot.ts`) to prevent infinite loops
- Ignores test files

### npm script (`packages/kilo-vscode/package.json`)
- Added `watch:cli` script

### VS Code tasks (`.vscode/tasks.json`)
- Added "VSCode - CLI Watch" background task
- Included it in the composite "VSCode - Watch" task
- Added `runOptions.runOn: "folderOpen"` so all watchers (TSC, ESBuild, CLI) start automatically when opening the project

## Usage

All watchers start automatically when you open the project folder. You can also run the CLI watcher standalone:

```sh
cd packages/kilo-vscode
bun run watch:cli
```