### PR TITLE
fix: filter [REDACTED] from reasoning parts in UI

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -711,7 +711,11 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
 
 PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
   const part = props.part as ReasoningPart
-  const text = () => part.text.trim()
+  // kilocode_change start
+  // Filter out redacted reasoning chunks from OpenRouter
+  // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
+  const text = () => part.text.replace("[REDACTED]", "").trim()
+  // kilocode_change end
   const throttledText = createThrottledValue(text)
 
   return (


### PR DESCRIPTION
## Problem

When using models via OpenRouter that have extended thinking (like Claude), the API returns `redacted_thinking` content blocks containing encrypted reasoning data. These appear as literal `[REDACTED]` text in reasoning parts shown in the chat.

The TUI already strips these at [`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:1347`](https://github.com/Kilo-Org/kilo/blob/dev/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx#L1347), but the shared `packages/ui` component (used by both the vscode extension and packages/app) rendered them as-is.

## Fix

Strip `[REDACTED]` from reasoning part text before rendering in `packages/ui/src/components/message-part.tsx`, matching the existing TUI behavior.