### PR TITLE
fix: use Kilo logo for vscode extension sidebar icon

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -23,7 +23,8 @@
         {
           "id": "kilo-code-sidebar",
           "title": "Kilo Code (NEW)",
-          "icon": "$(code)"
+          "icon": "assets/icons/kilo-light.png",
+          "darkIcon": "assets/icons/kilo-dark.png"
         }
       ]
     },


### PR DESCRIPTION
Replace the generic `$(code)` codicon with the actual Kilo logo PNGs for the activity bar icon in the kilo-vscode extension, matching the kilocode-5 extension configuration.

- `icon`: `assets/icons/kilo-light.png` (light theme)
- `darkIcon`: `assets/icons/kilo-dark.png` (dark theme)