### PR TITLE
fix(vscode): retain sidebar webview context when switching panels

### DIFF
--- a/packages/kilo-vscode/AGENTS.md
+++ b/packages/kilo-vscode/AGENTS.md
@@ -103,6 +103,10 @@ New webview features must use **`@kilocode/kilo-ui`** components instead of raw 
 
 While the old extension coexists, runtime labels append `(NEW)` — controlled by the flag in [`constants.ts`](src/constants.ts). Static labels in `package.json` must be updated separately. Remove this convention once the old extension is retired.
 
+## Kilocode Change Markers
+
+This package is entirely Kilo-specific — `kilocode_change` markers are NOT needed in any files under `packages/kilo-vscode/`. The markers are only necessary when modifying shared upstream opencode files.
+
 ## Style
 
 Follow monorepo root AGENTS.md style guide:

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -26,8 +26,13 @@ export function activate(context: vscode.ExtensionContext) {
   // Create the provider with shared service
   const provider = new KiloProvider(context.extensionUri, connectionService)
 
-  // Register the webview view provider for the sidebar
-  context.subscriptions.push(vscode.window.registerWebviewViewProvider(KiloProvider.viewType, provider))
+  // Register the webview view provider for the sidebar.
+  // retainContextWhenHidden keeps the webview alive when switching to other sidebar panels.
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(KiloProvider.viewType, provider, {
+      webviewOptions: { retainContextWhenHidden: true },
+    }),
+  )
 
   // Create Agent Manager provider for editor panel
   const agentManagerProvider = new AgentManagerProvider(context.extensionUri)


### PR DESCRIPTION
## Problem

When users had the Kilo extension in the left sidebar and switched to the file explorer (or any other sidebar view) and back, the webview was destroyed and recreated by VS Code. This caused:
- Active session lost
- Connection re-initialized
- All chat history disappeared

## Root Cause

The sidebar `WebviewViewProvider` was registered without `retainContextWhenHidden: true`. Without this option, VS Code destroys the webview DOM when the view becomes hidden, and calls `resolveWebviewView()` again when it becomes visible — resetting all state.

The tab panel (`openKiloInNewTab`) already had this option set correctly, so this only affected the sidebar.

## Fix

Added `{ webviewOptions: { retainContextWhenHidden: true } }` to the `registerWebviewViewProvider` call in `extension.ts`. This keeps the webview alive in the background when the user navigates to other sidebar views, preserving all session state.

The `+` button continues to work as before — it posts a `plusButtonClicked` action to the (now preserved) webview.