### PR TITLE
fix(vscode): remove preLaunchTask from launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,7 @@
       "type": "extensionHost",
       "request": "launch",
       "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}/packages/kilo-vscode"],
-      "outFiles": ["${workspaceFolder}/packages/kilo-vscode/dist/**/*.js"],
-      "preLaunchTask": "${defaultBuildTask}"
+      "outFiles": ["${workspaceFolder}/packages/kilo-vscode/dist/**/*.js"]
     },
     {
       "name": "VSCode - Run Extension (Local Backend)",
@@ -19,7 +18,6 @@
       "request": "launch",
       "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}/packages/kilo-vscode"],
       "outFiles": ["${workspaceFolder}/packages/kilo-vscode/dist/**/*.js"],
-      "preLaunchTask": "${defaultBuildTask}",
       "env": {
         "KILO_API_URL": "http://localhost:3000"
       }


### PR DESCRIPTION
## Summary

- Remove `preLaunchTask: "${defaultBuildTask}"` from both launch configurations in `.vscode/launch.json`

## Why

Background watch tasks now auto-start on folder open via `runOptions.runOn: "folderOpen"` (added in a recent PR). The `preLaunchTask` reference causes F5 to hang indefinitely because VS Code waits for the background watchers to "complete" — but they never do since they're long-running watch processes.

Since the watchers are already running when the user presses F5, `preLaunchTask` is no longer needed.