### PR TITLE
feat(cli): add interactive Ollama auth setup

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -369,6 +369,73 @@ export const AuthLoginCommand = cmd({
           )
         }
 
+        // kilocode_change start - Ollama special handling for host + API key
+        if (provider === "ollama") {
+          prompts.log.info("Ollama runs locally or on a remote server. Default: http://localhost:11434")
+
+          const host = await prompts.text({
+            message: "Enter Ollama host URL",
+            placeholder: "http://localhost:11434",
+            validate: (x) => {
+              if (!x) return undefined
+              try {
+                new URL(x)
+                return undefined
+              } catch {
+                return "Invalid URL format"
+              }
+            },
+          })
+          if (prompts.isCancel(host)) throw new UI.CancelledError()
+
+          const needsKey = await prompts.confirm({
+            message: "Does your Ollama instance require an API key?",
+            initialValue: false,
+          })
+          if (prompts.isCancel(needsKey)) throw new UI.CancelledError()
+
+          let apiKey: string | undefined
+          if (needsKey) {
+            const key = await prompts.password({
+              message: "Enter your API key",
+              validate: (x) => (x && x.length > 0 ? undefined : "Required"),
+            })
+            if (prompts.isCancel(key)) throw new UI.CancelledError()
+            apiKey = key
+          }
+
+          await Auth.set(provider, {
+            type: "api",
+            key: apiKey || "no-api-key",
+          })
+
+          if (host && host !== "http://localhost:11434") {
+            const configPath = path.join(Global.Path.config, "opencode.json")
+            const existingConfig = await Bun.file(configPath)
+              .json()
+              .catch(() => ({}))
+            const updatedConfig = {
+              ...existingConfig,
+              provider: {
+                ...(existingConfig.provider || {}),
+                ollama: {
+                  ...(existingConfig.provider?.ollama || {}),
+                  options: {
+                    ...(existingConfig.provider?.ollama?.options || {}),
+                    baseURL: host,
+                    ...(apiKey ? { apiKey } : {}),
+                  },
+                },
+              },
+            }
+            await Bun.write(configPath, JSON.stringify(updatedConfig, null, 2))
+          }
+
+          prompts.outro("Done")
+          return
+        }
+        // kilocode_change end
+
         const key = await prompts.password({
           message: "Enter your API key",
           validate: (x) => (x && x.length > 0 ? undefined : "Required"),


### PR DESCRIPTION
## Summary

Part 2 of Kilo-Org/kilocode#6326 - Adds interactive Ollama configuration

- `kilo auth login ollama` prompts for host URL and optional API key
- Saves host configuration to opencode.json
- Works with local (localhost:11434) and remote Ollama instances

## Changes

- `packages/opencode/src/cli/cmd/auth.ts` - Added Ollama-specific auth flow

## Usage

```bash
kilo auth login ollama
```

Prompts:
1. Enter Ollama host URL (default: http://localhost:11434)
2. Does your instance require an API key? (yes/no)
3. Enter API key (if yes)

## Testing

- Tested interactive flow locally

Fixes Kilo-Org/kilocode#6326 (part 2)