### PR TITLE
fix(vscode): add extension icon for marketplace

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -4,6 +4,7 @@
   "description": "Kilo Code AI Agent & Autocomplete",
   "version": "7.0.23",
   "publisher": "kilocode",
+  "icon": "assets/icons/kilo-light.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/Kilo-Org/kilo.git",


### PR DESCRIPTION
## Summary

The extension was missing the top-level `icon` field in `package.json` which VS Code uses for the extension icon in the marketplace and sidebar.

## Problem

- Extension showed default VS Code icon instead of Kilo branding
- Users couldn't identify the extension by its icon

## Solution

Added `"icon": "assets/icons/kilo-light.png"` to `package.json`

## Testing

- Icon already exists at `assets/icons/kilo-light.png` (256x256 PNG)
- Sidebar icons were already configured correctly

Fixes Kilo-Org/kilocode#6314