### PR TITLE
fix(vscode): use default model from backend instead of hardcoded kilo/auto

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -603,8 +603,11 @@ export class KiloProvider implements vscode.WebviewViewProvider {
       }
 
       const config = vscode.workspace.getConfiguration("kilo-code.new.model")
-      const providerID = config.get<string>("providerID", "kilo")
-      const modelID = config.get<string>("modelID", "kilo/auto")
+      const configProviderID = config.get<string>("providerID")
+      const configModelID = config.get<string>("modelID")
+
+      const providerID = configProviderID || Object.keys(response.default)[0] || "kilo"
+      const modelID = configModelID || response.default[providerID] || "kilo/auto"
 
       const message = {
         type: "providersLoaded",


### PR DESCRIPTION
## Summary

The extension was hardcoded to use `kilo/auto` as the default model. Now it uses the default model from the backend response, falling back to `kilo/auto` only when no default is available.

## Problem

- Default model was hardcoded to `kilo/auto`
- Users couldn't use their configured default model from CLI

## Solution

Changed from:
```ts
const providerID = config.get<string>("providerID", "kilo")
const modelID = config.get<string>("modelID", "kilo/auto")
```

To:
```ts
const providerID = configProviderID || Object.keys(response.default)[0] || "kilo"
const modelID = configModelID || response.default[providerID] || "kilo/auto"
```

Now uses:
1. User's config if set
2. Backend's default model for the provider
3. Falls back to `kilo/auto` only as last resort

Fixes Kilo-Org/kilocode#6074