### PR TITLE
test(kilo-vscode): add architecture tests for agent manager CSS prefix and consistency

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Architecture tests: Agent Manager
+ *
+ * The agent manager runs in the same webview context as other UI.
+ * All its CSS classes must be prefixed with "am-" to avoid conflicts.
+ * These tests also verify consistency between CSS definitions and TSX usage.
+ */
+
+import { describe, it, expect } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const ROOT = path.resolve(import.meta.dir, "../..")
+const CSS_FILE = path.join(ROOT, "webview-ui/agent-manager/agent-manager.css")
+const TSX_FILE = path.join(ROOT, "webview-ui/agent-manager/AgentManagerApp.tsx")
+
+describe("Agent Manager CSS Prefix", () => {
+  it("all class selectors should use am- prefix", () => {
+    const css = fs.readFileSync(CSS_FILE, "utf-8")
+    const matches = [...css.matchAll(/\.([a-z][a-z0-9-]*)/gi)]
+    const names = [...new Set(matches.map((m) => m[1]))]
+
+    const invalid = names.filter((n) => !n!.startsWith("am-"))
+
+    expect(invalid, `Classes missing "am-" prefix: ${invalid.join(", ")}`).toEqual([])
+  })
+
+  it("all CSS custom properties should use am- prefix", () => {
+    const css = fs.readFileSync(CSS_FILE, "utf-8")
+    const matches = [...css.matchAll(/--([a-z][a-z0-9-]*)\s*:/gi)]
+    const names = [...new Set(matches.map((m) => m[1]))]
+
+    // Allow kilo-ui design tokens and vscode theme variables used as fallbacks
+    const allowed = ["am-", "vscode-", "surface-", "text-", "border-"]
+    const invalid = names.filter((n) => !allowed.some((p) => n!.startsWith(p)))
+
+    expect(invalid, `CSS properties missing allowed prefix: ${invalid.join(", ")}`).toEqual([])
+  })
+
+  it("all @keyframes should use am- prefix", () => {
+    const css = fs.readFileSync(CSS_FILE, "utf-8")
+    const matches = [...css.matchAll(/@keyframes\s+([a-z][a-z0-9-]*)/gi)]
+    const names = matches.map((m) => m[1])
+
+    const invalid = names.filter((n) => !n!.startsWith("am-"))
+
+    expect(invalid, `Keyframes missing "am-" prefix: ${invalid.join(", ")}`).toEqual([])
+  })
+})
+
+describe("Agent Manager CSS/TSX Consistency", () => {
+  it("all classes used in TSX should be defined in CSS", () => {
+    const css = fs.readFileSync(CSS_FILE, "utf-8")
+    const tsx = fs.readFileSync(TSX_FILE, "utf-8")
+
+    // Extract am- classes defined in CSS
+    const cssMatches = [...css.matchAll(/\.([a-z][a-z0-9-]*)/gi)]
+    const defined = new Set(cssMatches.map((m) => m[1]))
+
+    // Extract am- classes referenced in TSX (class="am-..." or `am-...`)
+    const tsxMatches = [...tsx.matchAll(/\bam-[a-z0-9-]+/g)]
+    const used = [...new Set(tsxMatches.map((m) => m[0]))]
+
+    const missing = used.filter((c) => !defined.has(c))
+
+    expect(missing, `Classes used in TSX but not defined in CSS: ${missing.join(", ")}`).toEqual([])
+  })
+
+  it("all am- classes defined in CSS should be used in TSX", () => {
+    const css = fs.readFileSync(CSS_FILE, "utf-8")
+    const tsx = fs.readFileSync(TSX_FILE, "utf-8")
+
+    // Extract am- classes defined in CSS
+    const cssMatches = [...css.matchAll(/\.([a-z][a-z0-9-]*)/gi)]
+    const defined = [...new Set(cssMatches.map((m) => m[1]!).filter((n) => n.startsWith("am-")))]
+
+    const unused = defined.filter((c) => !tsx.includes(c!))
+
+    expect(unused, `Classes defined in CSS but not used in TSX: ${unused.join(", ")}`).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds architecture tests that enforce the `am-` prefix convention on all CSS classes, custom properties, and `@keyframes` in the agent manager stylesheet — preventing naming collisions in the shared webview context
- Adds CSS/TSX consistency tests that catch undefined class references and dead CSS between `agent-manager.css` and `AgentManagerApp.tsx`

## Tests

5 tests across 2 describe blocks in `packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts`:

| Test | What it catches |
| --- | --- |
| Class selectors use `am-` prefix | Unprefixed classes that could collide with other webview UI |
| CSS custom properties use `am-` prefix | Unprefixed custom properties (allows `vscode-` and kilo-ui design tokens) |
| `@keyframes` use `am-` prefix | Unprefixed animation names |
| TSX classes defined in CSS | References to classes that don't exist in the stylesheet |
| CSS classes used in TSX | Dead CSS that should be cleaned up |