### PR TITLE
feat(vscode): add reset all settings button to About tab

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -294,6 +294,9 @@ export class KiloProvider implements vscode.WebviewViewProvider {
         case "requestNotificationSettings":
           this.sendNotificationSettings()
           break
+        case "resetAllSettings":
+          await this.handleResetAllSettings()
+          break
       }
     })
   }
@@ -1072,6 +1075,45 @@ export class KiloProvider implements vscode.WebviewViewProvider {
     const config = vscode.workspace.getConfiguration(`kilo-code.new${section ? `.${section}` : ""}`)
     await config.update(leaf, value, vscode.ConfigurationTarget.Global)
   }
+
+  /**
+   * Reset all "kilo-code.new.*" extension settings to their defaults by reading
+   * contributes.configuration from the extension's package.json at runtime.
+   * Only resets settings under the "kilo-code.new." namespace to avoid touching
+   * settings from the previous version of the extension which shares the same
+   * extension ID and "kilo-code.*" namespace.
+   */
+  // kilocode_change start
+  private async handleResetAllSettings(): Promise<void> {
+    const confirmed = await vscode.window.showWarningMessage(
+      "Reset all Kilo Code extension settings to defaults?",
+      { modal: true },
+      "Reset",
+    )
+    if (confirmed !== "Reset") return
+
+    const prefix = "kilo-code.new."
+    const ext = vscode.extensions.getExtension("kilocode.kilo-code")
+    const properties = ext?.packageJSON?.contributes?.configuration?.properties as
+      | Record<string, unknown>
+      | undefined
+    if (!properties) return
+
+    for (const key of Object.keys(properties)) {
+      if (!key.startsWith(prefix)) continue
+      const parts = key.split(".")
+      const section = parts.slice(0, -1).join(".")
+      const leaf = parts[parts.length - 1]
+      const config = vscode.workspace.getConfiguration(section)
+      await config.update(leaf, undefined, vscode.ConfigurationTarget.Global)
+    }
+
+    // Re-send all settings to the webview so the UI reflects the reset
+    this.sendAutocompleteSettings()
+    this.sendBrowserSettings()
+    this.sendNotificationSettings()
+  }
+  // kilocode_change end
 
   /**
    * Read the current browser automation settings and push them to the webview.

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AboutKiloCodeTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AboutKiloCodeTab.tsx
@@ -130,7 +130,7 @@ const AboutKiloCodeTab: Component<AboutKiloCodeTabProps> = (props) => {
       </div>
 
       {/* CLI Server */}
-      <div style={{ ...sectionStyle, "margin-bottom": "0" }}>
+      <div style={sectionStyle}>
         <h4 style={headingStyle}>{language.t("settings.aboutKiloCode.cliServer")}</h4>
 
         {/* Connection Status */}
@@ -155,6 +155,36 @@ const AboutKiloCodeTab: Component<AboutKiloCodeTabProps> = (props) => {
           <span style={labelStyle}>{language.t("settings.aboutKiloCode.port.label")}</span>
           <span style={valueStyle}>{props.port !== null ? props.port : "—"}</span>
         </div>
+      </div>
+
+      {/* Reset Settings */}
+      <div style={{ ...sectionStyle, "margin-bottom": "0" }}>
+        <h4 style={headingStyle}>{language.t("settings.aboutKiloCode.resetSettings.title")}</h4>
+        <p
+          style={{
+            "font-size": "12px",
+            color: "var(--vscode-descriptionForeground)",
+            margin: "0 0 12px 0",
+            "line-height": "1.5",
+          }}
+        >
+          {language.t("settings.aboutKiloCode.resetSettings.description")}
+        </p>
+        <button
+          type="button"
+          onClick={() => vscode.postMessage({ type: "resetAllSettings" })}
+          style={{
+            background: "var(--vscode-button-background)",
+            color: "var(--vscode-button-foreground)",
+            border: "none",
+            padding: "6px 14px",
+            "border-radius": "2px",
+            cursor: "pointer",
+            "font-size": "12px",
+          }}
+        >
+          {language.t("settings.aboutKiloCode.resetSettings.button")}
+        </button>
       </div>
     </div>
   )

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -797,6 +797,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "إذا كان لديك أي أسئلة أو ملاحظات، لا تتردد في فتح مشكلة على",
   "settings.aboutKiloCode.feedback.or": "أو",
   "settings.aboutKiloCode.support.prefix": "لأسئلة الفوترة أو الحساب، تواصل مع دعم العملاء على",
+  "settings.aboutKiloCode.resetSettings.title": "إعادة تعيين الإعدادات",
+  "settings.aboutKiloCode.resetSettings.description":
+    "إعادة تعيين جميع إعدادات إضافة Kilo Code إلى قيمها الافتراضية. لا يؤثر هذا على تكوين CLI أو الواجهة الخلفية.",
+  "settings.aboutKiloCode.resetSettings.button": "إعادة تعيين جميع الإعدادات",
 
   "settings.agentBehaviour.subtab.modes": "الأوضاع",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -805,6 +805,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.or": "ou",
   "settings.aboutKiloCode.support.prefix":
     "Para questões de cobrança ou conta, entre em contato com o Suporte ao Cliente em",
+  "settings.aboutKiloCode.resetSettings.title": "Redefinir Configurações",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Redefinir todas as configurações da extensão Kilo Code para os valores padrão. Isso não afeta a configuração do CLI ou do backend.",
+  "settings.aboutKiloCode.resetSettings.button": "Redefinir Todas as Configurações",
 
   "settings.agentBehaviour.subtab.modes": "Modos",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -831,6 +831,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "Ako imate pitanja ili povratne informacije, slobodno otvorite issue na",
   "settings.aboutKiloCode.feedback.or": "ili",
   "settings.aboutKiloCode.support.prefix": "Za pitanja o naplati ili računu, kontaktirajte korisničku podršku na",
+  "settings.aboutKiloCode.resetSettings.title": "Resetovanje postavki",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Resetujte sve postavke Kilo Code ekstenzije na zadane vrijednosti. Ovo ne utiče na CLI ili backend konfiguraciju.",
+  "settings.aboutKiloCode.resetSettings.button": "Resetuj sve postavke",
 
   "settings.agentBehaviour.subtab.modes": "Modovi",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -804,6 +804,10 @@ export const dict = {
     "Hvis du har spørgsmål eller feedback, er du velkommen til at åbne en issue på",
   "settings.aboutKiloCode.feedback.or": "eller",
   "settings.aboutKiloCode.support.prefix": "For fakturerings- eller kontospørgsmål, kontakt kundesupport på",
+  "settings.aboutKiloCode.resetSettings.title": "Nulstil indstillinger",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Nulstil alle Kilo Code-udvidelsesindstillinger til standardværdierne. Dette påvirker ikke CLI- eller backend-konfiguration.",
+  "settings.aboutKiloCode.resetSettings.button": "Nulstil alle indstillinger",
 
   "settings.agentBehaviour.subtab.modes": "Tilstande",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -810,6 +810,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.or": "oder",
   "settings.aboutKiloCode.support.prefix":
     "Bei Abrechnungs- oder Kontofragen wenden Sie sich an den Kundensupport unter",
+  "settings.aboutKiloCode.resetSettings.title": "Einstellungen zurücksetzen",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Alle Kilo Code-Erweiterungseinstellungen auf Standardwerte zurücksetzen. Dies hat keinen Einfluss auf die CLI- oder Backend-Konfiguration.",
+  "settings.aboutKiloCode.resetSettings.button": "Alle Einstellungen zurücksetzen",
 
   "settings.agentBehaviour.subtab.modes": "Modi",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -836,6 +836,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "If you have any questions or feedback, feel free to open an issue on",
   "settings.aboutKiloCode.feedback.or": "or",
   "settings.aboutKiloCode.support.prefix": "For billing or account questions, contact Customer Support at",
+  "settings.aboutKiloCode.resetSettings.title": "Reset Settings",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Reset all Kilo Code extension settings to their default values. This does not affect CLI or backend configuration.",
+  "settings.aboutKiloCode.resetSettings.button": "Reset All Settings",
 
   "settings.agentBehaviour.subtab.modes": "Modes",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -809,6 +809,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "Si tienes preguntas o comentarios, abre un issue en",
   "settings.aboutKiloCode.feedback.or": "o",
   "settings.aboutKiloCode.support.prefix": "Para preguntas de facturación o cuenta, contacta al Soporte al Cliente en",
+  "settings.aboutKiloCode.resetSettings.title": "Restablecer configuración",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Restablecer todas las configuraciones de la extensión Kilo Code a sus valores predeterminados. Esto no afecta la configuración del CLI o del backend.",
+  "settings.aboutKiloCode.resetSettings.button": "Restablecer toda la configuración",
 
   "settings.agentBehaviour.subtab.modes": "Modos",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -815,6 +815,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.or": "ou",
   "settings.aboutKiloCode.support.prefix":
     "Pour les questions de facturation ou de compte, contactez le support client à",
+  "settings.aboutKiloCode.resetSettings.title": "Réinitialiser les paramètres",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Réinitialiser tous les paramètres de l'extension Kilo Code à leurs valeurs par défaut. Cela n'affecte pas la configuration CLI ou backend.",
+  "settings.aboutKiloCode.resetSettings.button": "Réinitialiser tous les paramètres",
 
   "settings.agentBehaviour.subtab.modes": "Modes",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -798,6 +798,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.or": "または",
   "settings.aboutKiloCode.support.prefix":
     "請求やアカウントに関するご質問は、カスタマーサポートまでお問い合わせください",
+  "settings.aboutKiloCode.resetSettings.title": "設定をリセット",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Kilo Code拡張機能のすべての設定をデフォルト値にリセットします。CLIやバックエンドの設定には影響しません。",
+  "settings.aboutKiloCode.resetSettings.button": "すべての設定をリセット",
 
   "settings.agentBehaviour.subtab.modes": "モード",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -802,6 +802,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "질문이나 피드백이 있으시면 다음에서 이슈를 열어주세요",
   "settings.aboutKiloCode.feedback.or": "또는",
   "settings.aboutKiloCode.support.prefix": "결제 또는 계정 관련 문의는 고객 지원팀에 문의하세요",
+  "settings.aboutKiloCode.resetSettings.title": "설정 초기화",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Kilo Code 확장 프로그램의 모든 설정을 기본값으로 초기화합니다. CLI 또는 백엔드 구성에는 영향을 미치지 않습니다.",
+  "settings.aboutKiloCode.resetSettings.button": "모든 설정 초기화",
 
   "settings.agentBehaviour.subtab.modes": "모드",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -806,6 +806,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "Hvis du har spørsmål eller tilbakemeldinger, åpne gjerne en issue på",
   "settings.aboutKiloCode.feedback.or": "eller",
   "settings.aboutKiloCode.support.prefix": "For fakturerings- eller kontospørsmål, kontakt kundestøtte på",
+  "settings.aboutKiloCode.resetSettings.title": "Tilbakestill innstillinger",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Tilbakestill alle Kilo Code-utvidelsesinnstillinger til standardverdier. Dette påvirker ikke CLI- eller backend-konfigurasjon.",
+  "settings.aboutKiloCode.resetSettings.button": "Tilbakestill alle innstillinger",
 
   "settings.agentBehaviour.subtab.modes": "Moduser",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -806,6 +806,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.or": "lub",
   "settings.aboutKiloCode.support.prefix":
     "W sprawach rozliczeń lub konta skontaktuj się z obsługą klienta pod adresem",
+  "settings.aboutKiloCode.resetSettings.title": "Resetuj ustawienia",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Zresetuj wszystkie ustawienia rozszerzenia Kilo Code do wartości domyślnych. Nie wpływa to na konfigurację CLI ani backendu.",
+  "settings.aboutKiloCode.resetSettings.button": "Resetuj wszystkie ustawienia",
 
   "settings.agentBehaviour.subtab.modes": "Tryby",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -809,6 +809,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "Если у вас есть вопросы или отзывы, создайте issue на",
   "settings.aboutKiloCode.feedback.or": "или",
   "settings.aboutKiloCode.support.prefix": "По вопросам оплаты или аккаунта обращайтесь в службу поддержки по адресу",
+  "settings.aboutKiloCode.resetSettings.title": "Сброс настроек",
+  "settings.aboutKiloCode.resetSettings.description":
+    "Сбросить все настройки расширения Kilo Code до значений по умолчанию. Это не влияет на конфигурацию CLI или бэкенда.",
+  "settings.aboutKiloCode.resetSettings.button": "Сбросить все настройки",
 
   "settings.agentBehaviour.subtab.modes": "Режимы",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -794,6 +794,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "หากคุณมีคำถามหรือข้อเสนอแนะ สามารถเปิด issue ได้ที่",
   "settings.aboutKiloCode.feedback.or": "หรือ",
   "settings.aboutKiloCode.support.prefix": "สำหรับคำถามเกี่ยวกับการเรียกเก็บเงินหรือบัญชี ติดต่อฝ่ายสนับสนุนลูกค้าที่",
+  "settings.aboutKiloCode.resetSettings.title": "รีเซ็ตการตั้งค่า",
+  "settings.aboutKiloCode.resetSettings.description":
+    "รีเซ็ตการตั้งค่าส่วนขยาย Kilo Code ทั้งหมดเป็นค่าเริ่มต้น ไม่ส่งผลกระทบต่อการกำหนดค่า CLI หรือแบ็กเอนด์",
+  "settings.aboutKiloCode.resetSettings.button": "รีเซ็ตการตั้งค่าทั้งหมด",
 
   "settings.agentBehaviour.subtab.modes": "โหมด",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -797,6 +797,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "如果您有任何问题或反馈，欢迎在以下平台提交 issue",
   "settings.aboutKiloCode.feedback.or": "或",
   "settings.aboutKiloCode.support.prefix": "如有账单或账户问题，请联系客户支持",
+  "settings.aboutKiloCode.resetSettings.title": "重置设置",
+  "settings.aboutKiloCode.resetSettings.description":
+    "将所有 Kilo Code 扩展设置重置为默认值。这不会影响 CLI 或后端配置。",
+  "settings.aboutKiloCode.resetSettings.button": "重置所有设置",
 
   "settings.agentBehaviour.subtab.modes": "模式",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -794,6 +794,10 @@ export const dict = {
   "settings.aboutKiloCode.feedback.prefix": "如果您有任何問題或回饋，歡迎在以下平台提交 issue",
   "settings.aboutKiloCode.feedback.or": "或",
   "settings.aboutKiloCode.support.prefix": "如有帳單或帳戶問題，請聯繫客戶支援",
+  "settings.aboutKiloCode.resetSettings.title": "重置設定",
+  "settings.aboutKiloCode.resetSettings.description":
+    "將所有 Kilo Code 擴充功能設定重置為預設值。這不會影響 CLI 或後端配置。",
+  "settings.aboutKiloCode.resetSettings.button": "重置所有設定",
 
   "settings.agentBehaviour.subtab.modes": "模式",
   "settings.agentBehaviour.subtab.agents": "Agents",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -690,6 +690,10 @@ export interface RequestNotificationSettingsMessage {
   type: "requestNotificationSettings"
 }
 
+export interface ResetAllSettingsRequest {
+  type: "resetAllSettings"
+}
+
 export type WebviewMessage =
   | SendMessageRequest
   | AbortRequest
@@ -722,6 +726,7 @@ export type WebviewMessage =
   | RequestConfigMessage
   | UpdateConfigMessage
   | RequestNotificationSettingsMessage
+  | ResetAllSettingsRequest
 
 // ============================================
 // VS Code API type


### PR DESCRIPTION
## Summary

Adds a **Reset All Settings** button in the About tab of the VS Code extension settings.

## How it works

The reset is fully generic — it reads the extension's `contributes.configuration.properties` from `package.json` at runtime and calls `config.update(key, undefined, ConfigurationTarget.Global)` for each setting, restoring defaults without any hardcoded settings list.

A native VS Code confirmation dialog is shown before resetting.

## Changes

- **`messages.ts`**: New `ResetAllSettingsRequest` message type
- **`KiloProvider.ts`**: `handleResetAllSettings()` handler that generically discovers and resets all `kilo-code.new.*` settings
- **`AboutKiloCodeTab.tsx`**: Reset button UI at the bottom of the About tab
- **i18n**: Translations added for all 16 supported languages