### PR TITLE
fix: add preLaunchTask to VS Code launch configs for reliable F5 builds

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
       "type": "extensionHost",
       "request": "launch",
       "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}/packages/kilo-vscode"],
-      "outFiles": ["${workspaceFolder}/packages/kilo-vscode/dist/**/*.js"]
+      "outFiles": ["${workspaceFolder}/packages/kilo-vscode/dist/**/*.js"],
+      "preLaunchTask": "VSCode - Compile"
     },
     {
       "name": "VSCode - Run Extension (Local Backend)",
@@ -18,6 +19,7 @@
       "request": "launch",
       "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}/packages/kilo-vscode"],
       "outFiles": ["${workspaceFolder}/packages/kilo-vscode/dist/**/*.js"],
+      "preLaunchTask": "VSCode - Compile",
       "env": {
         "KILO_API_URL": "http://localhost:3000"
       }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,6 +66,20 @@
       "problemMatcher": []
     },
     {
+      "label": "VSCode - Compile",
+      "type": "shell",
+      "command": "bun",
+      "args": ["run", "compile"],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/packages/kilo-vscode"
+      },
+      "problemMatcher": ["$tsc", "$eslint-stylish"]
+    },
+    {
       "label": "VSCode - Tests",
       "type": "shell",
       "command": "bun",


### PR DESCRIPTION
## Summary

- Adds a one-shot `VSCode - Compile` task in `.vscode/tasks.json` that runs `bun run compile` in `packages/kilo-vscode`
- Wires both launch configurations in `.vscode/launch.json` to use `preLaunchTask: "VSCode - Compile"` so pressing F5 always compiles before launching

## Problem

The existing `runOn: folderOpen` watch tasks are unreliable — VS Code can silently skip them (e.g. if the user dismisses the "allow automatic tasks" prompt). This meant you'd sometimes have to manually run `bun run compile` before F5 would work.

## Solution

A finite compile task as `preLaunchTask` guarantees a clean build before every launch, independent of whether the background watchers started. The watch tasks remain for incremental rebuilds during development.