### PR TITLE
fix(kilo-vscode): make prompt input per-session in agent manager

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -3,7 +3,7 @@
  * Text input with send/abort buttons and ghost-text autocomplete for the chat interface
  */
 
-import { Component, createSignal, createEffect, onCleanup, Show } from "solid-js"
+import { Component, createSignal, createEffect, on, onCleanup, Show, untrack } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useSession } from "../../context/session"
@@ -32,25 +32,24 @@ export const PromptInput: Component = () => {
   let textareaRef: HTMLTextAreaElement | undefined
   let debounceTimer: ReturnType<typeof setTimeout> | undefined
   let requestCounter = 0
-  let prevKey: string | undefined
-
-  // Save/restore input text when switching sessions
-  createEffect(() => {
-    const key = sessionKey()
-    if (prevKey !== undefined && prevKey !== key) {
-      drafts.set(prevKey, text())
-    }
-    const draft = drafts.get(key) ?? ""
-    setText(draft)
-    setGhostText("")
-    if (textareaRef) {
-      textareaRef.value = draft
-      // Reset height then adjust
-      textareaRef.style.height = "auto"
-      textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 200)}px`
-    }
-    prevKey = key
-  })
+  // Save/restore input text when switching sessions.
+  // Uses `on()` to track only sessionKey — avoids re-running on every keystroke.
+  createEffect(
+    on(sessionKey, (key, prev) => {
+      if (prev !== undefined && prev !== key) {
+        drafts.set(prev, untrack(text))
+      }
+      const draft = drafts.get(key) ?? ""
+      setText(draft)
+      setGhostText("")
+      if (textareaRef) {
+        textareaRef.value = draft
+        // Reset height then adjust
+        textareaRef.style.height = "auto"
+        textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 200)}px`
+      }
+    }),
+  )
 
   const isBusy = () => session.status() === "busy"
   const isDisabled = () => !server.isConnected()


### PR DESCRIPTION
## Summary

- Fix shared prompt input state in the Agent Manager — each session now maintains its own independent input draft

## Problem

The `PromptInput` component stored text in a single `createSignal`, so switching between sessions in the Agent Manager carried over whatever was typed in the input field.

## Solution

- Added a module-level `Map<string, string>` (`drafts`) keyed by session ID to store per-session input text
- Added a `createEffect` that saves the current draft when leaving a session and restores the draft when entering a new one
- Clears the draft entry when a message is sent
- Persists the draft on component cleanup (the component remounts when permissions/questions appear)
- The map is module-level rather than component-level so drafts survive remounts through `<Show>` toggling

## Testing

- Type text in session A, switch to session B — session B input should be empty
- Switch back to session A — typed text should be restored
- Send a message — draft should be cleared
- Permission/question dock appearing and disappearing should not lose the draft