### PR TITLE
fix(vscode): display sub-agent task tool list in webview

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -50,19 +50,14 @@ export const DataBridge: Component<{ children: any }> = (props) => {
 
   const data = createMemo(() => {
     const id = session.currentSessionID()
+    const msgs = session.allMessages()
+    const parts = session.allParts()
     return {
-      session: session.sessions().map((s) => ({ ...s, id: s.id, role: "user" as const })),
+      session: session.sessions().map((s) => ({ ...s, id: s.id, role: "user" as const })) as unknown as any[],
       session_status: {} as Record<string, any>,
       session_diff: {} as Record<string, any[]>,
-      message: id ? { [id]: session.messages() as unknown as SDKMessage[] } : {},
-      part: id
-        ? Object.fromEntries(
-            session
-              .messages()
-              .map((msg) => [msg.id, session.getParts(msg.id) as unknown as SDKPart[]])
-              .filter(([, parts]) => (parts as SDKPart[]).length > 0),
-          )
-        : {},
+      message: msgs as unknown as Record<string, SDKMessage[]>,
+      part: parts as unknown as Record<string, SDKPart[]>,
       permission: id ? { [id]: session.permissions() as unknown as any[] } : {},
     }
   })
@@ -71,8 +66,12 @@ export const DataBridge: Component<{ children: any }> = (props) => {
     session.respondToPermission(input.permissionID, input.response)
   }
 
+  const sync = (sessionID: string) => {
+    session.syncSession(sessionID)
+  }
+
   return (
-    <DataProvider data={data()} directory="" onPermissionRespond={respond}>
+    <DataProvider data={data()} directory="" onPermissionRespond={respond} onSyncSession={sync}>
       {props.children}
     </DataProvider>
   )

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -102,6 +102,12 @@ interface SessionContextValue {
   // Messages for current session
   messages: Accessor<Message[]>
 
+  // All messages keyed by sessionID (includes child sessions)
+  allMessages: () => Record<string, Message[]>
+
+  // All parts keyed by messageID (includes child sessions)
+  allParts: () => Record<string, Part[]>
+
   // Parts for a specific message
   getParts: (messageID: string) => Part[]
 
@@ -143,6 +149,7 @@ interface SessionContextValue {
   selectSession: (id: string) => void
   deleteSession: (id: string) => void
   renameSession: (id: string, title: string) => void
+  syncSession: (sessionID: string) => void
 }
 
 const SessionContext = createContext<SessionContextValue>()
@@ -790,6 +797,14 @@ export const SessionProvider: ParentComponent = (props) => {
     return store.parts[messageID] || []
   }
 
+  const allMessages = () => store.messages
+
+  const allParts = () => store.parts
+
+  function syncSession(sessionID: string) {
+    vscode.postMessage({ type: "syncSession", sessionID })
+  }
+
   const todos = () => {
     const id = currentSessionID()
     return id ? store.todos[id] || [] : []
@@ -865,6 +880,8 @@ export const SessionProvider: ParentComponent = (props) => {
     selectAgent,
     getSessionAgent: (sessionID: string) => store.agentSelections[sessionID] ?? defaultAgent(),
     getSessionModel: (sessionID: string) => store.modelSelections[sessionID] ?? provider.defaultSelection(),
+    allMessages,
+    allParts,
     sendMessage,
     abort,
     compact,
@@ -877,6 +894,7 @@ export const SessionProvider: ParentComponent = (props) => {
     selectSession,
     deleteSession,
     renameSession,
+    syncSession,
   }
 
   return <SessionContext.Provider value={value}>{props.children}</SessionContext.Provider>

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -729,6 +729,11 @@ export interface ResetAllSettingsRequest {
   type: "resetAllSettings"
 }
 
+export interface SyncSessionRequest {
+  type: "syncSession"
+  sessionID: string
+}
+
 // Agent Manager worktree messages
 export interface CreateWorktreeSessionRequest {
   type: "agentManager.createWorktreeSession"
@@ -772,6 +777,7 @@ export type WebviewMessage =
   | UpdateConfigMessage
   | RequestNotificationSettingsMessage
   | ResetAllSettingsRequest
+  | SyncSessionRequest
   | CreateWorktreeSessionRequest
 
 // ============================================


### PR DESCRIPTION
## Context

Resolve: #351

The sub-agent task tool list was not displaying in the VSCode webview. When a task tool spawns a child session, the tool output panel showed an empty `data-component="task-tools"` container instead of the list of tool calls the sub-agent executed.

The app (`packages/app`) worked correctly because it has a full sync system that fetches child session data on demand.

## Implementation

Two root causes were identified and fixed:

**Root cause 1 — `DataBridge` only mapped the current session's data**

`App.tsx`'s `DataBridge` built the `DataProvider` store with only the current session's messages and parts (`{ [id]: session.messages() }`). The shared `message-part.tsx` renderer calls `getSessionToolParts(store, childSessionId)` which looks up `store.message[childSessionId]` — always empty because only the parent session ID was keyed.

**Fix:** `DataBridge` now uses `session.allMessages()` and `session.allParts()` which expose the full store (all sessions), so child session data is visible once loaded.

**Root cause 2 — No `syncSession` callback**

The task tool renderer in `message-part.tsx` has a `createEffect` that calls `data.syncSession(childSessionId)` to trigger loading child session data. `DataProvider` was instantiated without `onSyncSession`, so the effect was a no-op.

**Fix:** A new `syncSession` message round-trip was added:
1. `DataBridge` provides `onSyncSession` → calls `session.syncSession(sessionID)` 
2. Session context posts `{ type: "syncSession", sessionID }` to the extension
3. `KiloProvider.handleSyncSession()` adds the child session ID to `trackedSessionIds` (so future SSE `message.part.updated` events are forwarded) and fetches messages via HTTP, sending them back as `messagesLoaded`
4. The session context's existing `handleMessagesLoaded` stores them under the child session ID, which the `DataBridge` now includes in the store

### Files changed

- `packages/kilo-vscode/webview-ui/src/types/messages.ts` — new `SyncSessionRequest` type
- `packages/kilo-vscode/src/KiloProvider.ts` — new `handleSyncSession` method
- `packages/kilo-vscode/webview-ui/src/context/session.tsx` — `allMessages`, `allParts`, `syncSession` additions
- `packages/kilo-vscode/webview-ui/src/App.tsx` — updated `DataBridge` to use full store + wire `onSyncSession`

## Screenshots

<img width="840" height="961" alt="image" src="https://github.com/user-attachments/assets/adc223bb-00bd-4444-9d5c-679d6e5cf84c" />

## How to Test

1. Open the Kilo VSCode extension sidebar
2. Send a message that triggers a sub-agent via the task tool (e.g. "Use the explore agent to search for X")
3. Expand the task tool output panel in the chat
4. **Before:** the panel is empty
5. **After:** the panel shows the list of tools the sub-agent called (matching what the web app shows)
