### PR TITLE
fix: set worker format to es in kilo-ui storybook vite config

### DIFF
--- a/packages/kilo-ui/.storybook/main.ts
+++ b/packages/kilo-ui/.storybook/main.ts
@@ -17,6 +17,9 @@ const config: StorybookConfig = {
         jsxImportSource: "solid-js",
         jsx: "automatic",
       },
+      worker: {
+        format: "es",
+      },
     })
   },
 }


### PR DESCRIPTION
## Summary

- Fixes Storybook build failure in `packages/kilo-ui/` caused by `@pierre/diffs` worker being loaded via `?worker&url`
- Vite defaults worker format to `iife`, which is incompatible with code-splitting builds, resulting in: _"Invalid value 'iife' for option 'worker.format' - UMD and IIFE output formats are not supported for code-splitting builds"_
- Adds `worker: { format: "es" }` to the Vite config in `.storybook/main.ts` to resolve this