### PR TITLE
feat: emit LLM_COMPLETION telemetry event after each LLM stream finishes

### DIFF
--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -142,6 +142,8 @@ export namespace Telemetry {
     outputTokens?: number
     cacheReadTokens?: number
     cacheWriteTokens?: number
+    cost?: number
+    completionTime?: number
     duration?: number
   }) {
     track(TelemetryEvent.LLM_COMPLETION, properties)


### PR DESCRIPTION
## Summary

Implements the `llm-completion-telemetry.md` plan — fires `LLM_COMPLETION` telemetry from the core CLI session processor so it works for both the CLI and VS Code extension.

## Changes

- **`packages/opencode/src/session/processor.ts`**: Imports `Telemetry` and calls `Telemetry.trackLlmCompletion()` in the `finish-step` handler after `Session.getUsage()` runs. Records step start time at `start-step` and computes `completionTime`. Guard: only fires if at least one token count > 0.
- **`packages/kilo-telemetry/src/telemetry.ts`**: Adds `cost` and `completionTime` properties to `trackLlmCompletion()`.

## Properties emitted

| Property | Source |
|---|---|
| `sessionId` | `input.sessionID` |
| `provider` | `input.model.providerID` |
| `model` | `input.model.id` |
| `inputTokens` | `usage.tokens.input` (normalized) |
| `outputTokens` | `usage.tokens.output` |
| `cacheReadTokens` | `usage.tokens.cache.read` |
| `cacheWriteTokens` | `usage.tokens.cache.write` |
| `cost` | `usage.cost` (USD, from `Session.getUsage`) |
| `completionTime` | ms from `start-step` to `finish-step` |