### PR TITLE
feat(kilo-vscode): map Escape key to cancel/abort when session is busy

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -256,6 +256,11 @@ export const PromptInput: Component = () => {
       dismissSuggestion()
       return
     }
+    if (e.key === "Escape" && isBusy()) {
+      e.preventDefault()
+      session.abort()
+      return
+    }
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault()
       dismissSuggestion()


### PR DESCRIPTION
## Summary

- Maps the Escape key to call `session.abort()` when the input textarea is focused and the session is busy, matching the behavior of the reference app (`packages/app`)
- Escape priority: mention dropdown close → ghost-text dismiss → **abort busy session** → no-op