### PR TITLE
fix(vscode): use session directory for @ file search in agent manager worktrees

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -369,7 +369,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "requestFileSearch": {
           const client = this.httpClient
           if (client) {
-            const dir = this.getWorkspaceDirectory()
+            const dir = this.getWorkspaceDirectory(this.currentSession?.id)
             void client
               .findFiles(message.query, dir)
               .then((paths) => {


### PR DESCRIPTION
## Summary

- `requestFileSearch` in `KiloProvider.ts` called `getWorkspaceDirectory()` without a `sessionId`, so `@` file mentions in Agent Manager worktree sessions always searched the main workspace root instead of the worktree directory
- Files only existing in the worktree branch (e.g. newly created by the agent) were not found by `@` search, and shared files could resolve to the wrong copy
- Passes `this.currentSession?.id` to match the pattern every other handler already follows

## Changes

One-line fix in `packages/kilo-vscode/src/KiloProvider.ts:372`:

```diff
- const dir = this.getWorkspaceDirectory()
+ const dir = this.getWorkspaceDirectory(this.currentSession?.id)
```