### PR TITLE
fix(vscode): pass workspace directory in MCP requests for browser tool registration

### DIFF
--- a/packages/kilo-vscode/src/services/browser-automation/browser-automation-service.ts
+++ b/packages/kilo-vscode/src/services/browser-automation/browser-automation-service.ts
@@ -92,12 +92,17 @@ export class BrowserAutomationService implements vscode.Disposable {
     }
 
     try {
-      const status = await httpClient.addMcpServer(BrowserAutomationService.MCP_SERVER_NAME, {
-        type: "local",
-        command,
-        enabled: true,
-        timeout: 60000,
-      })
+      const directory = this.getWorkspaceDirectory()
+      const status = await httpClient.addMcpServer(
+        BrowserAutomationService.MCP_SERVER_NAME,
+        {
+          type: "local",
+          command,
+          enabled: true,
+          timeout: 60000,
+        },
+        directory,
+      )
 
       const serverStatus = status[BrowserAutomationService.MCP_SERVER_NAME]
       if (serverStatus?.status === "connected") {
@@ -128,7 +133,8 @@ export class BrowserAutomationService implements vscode.Disposable {
     const httpClient = this.getHttpClient()
     if (httpClient) {
       try {
-        await httpClient.disconnectMcpServer(BrowserAutomationService.MCP_SERVER_NAME)
+        const directory = this.getWorkspaceDirectory()
+        await httpClient.disconnectMcpServer(BrowserAutomationService.MCP_SERVER_NAME, directory)
       } catch (error) {
         console.error("[Kilo New] BrowserAutomationService: Failed to disconnect MCP server:", error)
       }
@@ -147,7 +153,8 @@ export class BrowserAutomationService implements vscode.Disposable {
     }
 
     try {
-      const allStatus = await httpClient.getMcpStatus()
+      const directory = this.getWorkspaceDirectory()
+      const allStatus = await httpClient.getMcpStatus(directory)
       return allStatus[BrowserAutomationService.MCP_SERVER_NAME] ?? null
     } catch {
       return null
@@ -160,6 +167,14 @@ export class BrowserAutomationService implements vscode.Disposable {
     } catch {
       return null
     }
+  }
+
+  private getWorkspaceDirectory(): string {
+    const folders = vscode.workspace.workspaceFolders
+    if (folders && folders.length > 0) {
+      return folders[0].uri.fsPath
+    }
+    return process.cwd()
   }
 
   private setState(state: BrowserAutomationState): void {

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -476,28 +476,28 @@ export class HttpClient {
   /**
    * Get the status of all MCP servers.
    */
-  async getMcpStatus(): Promise<Record<string, McpStatus>> {
-    return this.request<Record<string, McpStatus>>("GET", "/mcp")
+  async getMcpStatus(directory: string): Promise<Record<string, McpStatus>> {
+    return this.request<Record<string, McpStatus>>("GET", "/mcp", undefined, { directory })
   }
 
   /**
    * Add or update an MCP server configuration.
    */
-  async addMcpServer(name: string, config: McpConfig): Promise<Record<string, McpStatus>> {
-    return this.request<Record<string, McpStatus>>("POST", "/mcp", { name, config })
+  async addMcpServer(name: string, config: McpConfig, directory: string): Promise<Record<string, McpStatus>> {
+    return this.request<Record<string, McpStatus>>("POST", "/mcp", { name, config }, { directory })
   }
 
   /**
    * Connect an MCP server by name.
    */
-  async connectMcpServer(name: string): Promise<boolean> {
-    return this.request<boolean>("POST", `/mcp/${encodeURIComponent(name)}/connect`)
+  async connectMcpServer(name: string, directory: string): Promise<boolean> {
+    return this.request<boolean>("POST", `/mcp/${encodeURIComponent(name)}/connect`, undefined, { directory })
   }
 
   /**
    * Disconnect an MCP server by name.
    */
-  async disconnectMcpServer(name: string): Promise<boolean> {
-    return this.request<boolean>("POST", `/mcp/${encodeURIComponent(name)}/disconnect`)
+  async disconnectMcpServer(name: string, directory: string): Promise<boolean> {
+    return this.request<boolean>("POST", `/mcp/${encodeURIComponent(name)}/disconnect`, undefined, { directory })
   }
 }


### PR DESCRIPTION
## Summary

- MCP HTTP methods were not sending the `x-opencode-directory` header, causing the Playwright MCP client to register in the wrong `Instance.state()` bucket (keyed by `process.cwd()` instead of the workspace directory)
- The browser tools appeared registered (`State → connected`) but were invisible to the agent because `MCP.tools()` looked up tools in a different per-project state
- Added `directory` parameter to all 4 MCP methods in `HttpClient` and resolved workspace directory in `BrowserAutomationService`

Fixes #292