### PR TITLE
fix(vscode): track session status per-session so tab switching preserves busy state

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -580,6 +580,23 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         })
         .catch((err) => console.error("[Kilo New] KiloProvider: Failed to fetch session for tracking:", err))
 
+      // Fetch current session status so the webview has the correct busy/idle
+      // state after switching tabs (SSE events may have been missed).
+      this.httpClient
+        .getSessionStatuses(workspaceDir)
+        .then((statuses) => {
+          for (const [sid, info] of Object.entries(statuses)) {
+            if (!this.trackedSessionIds.has(sid)) continue
+            this.postMessage({
+              type: "sessionStatus",
+              sessionID: sid,
+              status: info.type,
+              ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+            })
+          }
+        })
+        .catch((err) => console.error("[Kilo New] KiloProvider: Failed to fetch session statuses:", err))
+
       // Convert to webview format, including cost/tokens for assistant messages
       const messages = messagesData.map((m) => ({
         id: m.info.id,
@@ -1360,13 +1377,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         })
         break
 
-      case "session.status":
+      case "session.status": {
+        const info = event.properties.status
         this.postMessage({
           type: "sessionStatus",
           sessionID: event.properties.sessionID,
-          status: event.properties.status.type,
+          status: info.type,
+          ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
         })
         break
+      }
 
       case "permission.asked":
         this.postMessage({

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -1,6 +1,7 @@
 import type {
   ServerConfig,
   SessionInfo,
+  SessionStatusInfo,
   MessageInfo,
   MessagePart,
   AgentInfo,
@@ -137,6 +138,14 @@ export class HttpClient {
    */
   async listSessions(directory: string): Promise<SessionInfo[]> {
     return this.request<SessionInfo[]>("GET", "/session", undefined, { directory })
+  }
+
+  /**
+   * Get the status of all sessions.
+   * Returns a map of sessionID → SessionStatusInfo.
+   */
+  async getSessionStatuses(directory: string): Promise<Record<string, SessionStatusInfo>> {
+    return this.request<Record<string, SessionStatusInfo>>("GET", "/session/status", undefined, { directory })
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixes Agent Manager tabs losing session busy/idle state when switching between them — the second tab always showed "send" instead of "abort" even when its session was running
- The root cause was a single global `statusInfo` signal shared across all tabs, which was reset to idle on every tab switch and silently dropped SSE events for non-active sessions

## Changes

**`webview-ui/src/context/session.tsx`** — Core fix
- Replace single `statusInfo`/`busySince` signals with per-session `createStore` maps (`statusMap`, `busySinceMap`)
- Derived accessors (`status()`, `statusInfo()`, `busySince()`) now read from the map using `currentSessionID()` as key — fully backwards compatible
- Remove `currentSessionID()` guard in `handleSessionStatus` so status events for all tracked sessions are recorded
- Remove unconditional `setStatusInfo({ type: "idle" })` resets in `selectSession()`, `clearCurrentSession()`, and `handleSessionDeleted()`

**`src/KiloProvider.ts`** — Fetch status on tab switch + forward retry info
- On `handleLoadMessages` (called during tab switch), fetch all session statuses from server via `GET /session/status` and push them to the webview — recovers any SSE events missed while a different tab was active
- Forward full retry fields (`attempt`, `message`, `next`) in SSE `session.status` events instead of just the type string

**`src/services/cli-backend/http-client.ts`** — New API method
- Add `getSessionStatuses(directory)` method that calls `GET /session/status` (existing server endpoint)