### PR TITLE
feat: clickable filenames in tool results to open files in VS Code

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -216,6 +216,7 @@
       },
       "peerDependencies": {
         "@opencode-ai/ui": "workspace:*",
+        "@opencode-ai/util": "workspace:*",
         "solid-js": "catalog:",
       },
     },

--- a/packages/kilo-ui/package.json
+++ b/packages/kilo-ui/package.json
@@ -78,6 +78,7 @@
   },
   "peerDependencies": {
     "@opencode-ai/ui": "workspace:*",
+    "@opencode-ai/util": "workspace:*",
     "solid-js": "catalog:"
   },
   "devDependencies": {

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -5,4 +5,68 @@
   [data-slot="text-part-body"] {
     margin-top: 0;
   }
+
+  &[data-has-open-file] [data-slot="text-part-body"] code:not(pre code) {
+    cursor: pointer;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: var(--text-strong);
+    }
+  }
+}
+
+[data-slot="message-part-title-filename"] {
+  &.clickable {
+    cursor: pointer;
+    text-decoration: underline;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: var(--text-strong);
+    }
+  }
+}
+
+[data-component="tool-loaded-file"] {
+  .clickable {
+    cursor: pointer;
+    text-decoration: underline;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: var(--text-base);
+    }
+  }
+}
+
+[data-component="clickable-file-output"] {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+
+  [data-slot="file-output-line"] {
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-small);
+    line-height: var(--line-height-large);
+    color: var(--text-weak);
+    white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &.clickable {
+      cursor: pointer;
+      text-decoration: underline;
+      text-decoration-color: transparent;
+      transition:
+        color 0.15s ease,
+        text-decoration-color 0.15s ease;
+
+      &:hover {
+        color: var(--text-base);
+        text-decoration-color: var(--text-base);
+      }
+    }
+  }
 }

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1,2 +1,469 @@
 // kilocode_change - new file
 export * from "@opencode-ai/ui/message-part"
+
+import {
+  createMemo,
+  createSignal,
+  For,
+  Show,
+  onCleanup,
+  createEffect,
+} from "solid-js"
+import { Dynamic } from "solid-js/web"
+import type { TextPart, ToolPart } from "@kilocode/sdk/v2"
+import { ToolRegistry, PART_MAPPING } from "@opencode-ai/ui/message-part"
+import { BasicTool } from "@opencode-ai/ui/basic-tool"
+import { Icon } from "@opencode-ai/ui/icon"
+import { Markdown } from "@opencode-ai/ui/markdown"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { DiffChanges } from "@opencode-ai/ui/diff-changes"
+import { useData } from "@opencode-ai/ui/context/data"
+import { useI18n } from "@opencode-ai/ui/context/i18n"
+import { useDiffComponent } from "@opencode-ai/ui/context/diff"
+import { useCodeComponent } from "@opencode-ai/ui/context/code"
+import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/path"
+import { checksum } from "@opencode-ai/util/encode"
+import type { OpenFileFn } from "@opencode-ai/ui/context/data"
+
+function relativizeProjectPaths(text: string, directory?: string) {
+  if (!text) return ""
+  if (!directory) return text
+  return text.split(directory).join("")
+}
+
+function getDirectory(path: string | undefined) {
+  const data = useData()
+  return relativizeProjectPaths(_getDirectory(path), data.directory)
+}
+
+interface Diagnostic {
+  range: {
+    start: { line: number; character: number }
+    end: { line: number; character: number }
+  }
+  message: string
+  severity?: number
+}
+
+function getDiagnostics(
+  diagnosticsByFile: Record<string, Diagnostic[]> | undefined,
+  filePath: string | undefined,
+): Diagnostic[] {
+  if (!diagnosticsByFile || !filePath) return []
+  const diagnostics = diagnosticsByFile[filePath] ?? []
+  return diagnostics.filter((d) => d.severity === 1).slice(0, 3)
+}
+
+function DiagnosticsDisplay(props: { diagnostics: Diagnostic[] }) {
+  const i18n = useI18n()
+  return (
+    <Show when={props.diagnostics.length > 0}>
+      <div data-component="diagnostics">
+        <For each={props.diagnostics}>
+          {(diagnostic) => (
+            <div data-slot="diagnostic">
+              <span data-slot="diagnostic-label">{i18n.t("ui.messagePart.diagnostic.error")}</span>
+              <span data-slot="diagnostic-location">
+                [{diagnostic.range.start.line + 1}:{diagnostic.range.start.character + 1}]
+              </span>
+              <span data-slot="diagnostic-message">{diagnostic.message}</span>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  )
+}
+
+/** Check if text looks like a file path (contains / and has a file extension) */
+const FILE_PATH_RE = /^\.{0,2}\/.*\.\w+$|^[a-zA-Z]:\\.*\.\w+$|^\w[\w.-]*\/.*\.\w+$/
+
+function isFilePath(text: string): boolean {
+  return FILE_PATH_RE.test(text.trim())
+}
+
+/**
+ * Renders tool output text with file paths as clickable elements.
+ * Lines that look like file paths become clickable to open the file in the editor.
+ */
+function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; directory?: string }) {
+  const lines = createMemo(() => props.text.split("\n").filter((l) => l.trim()))
+  const hasClickable = () => !!props.openFile
+
+  return (
+    <div data-component="clickable-file-output">
+      <For each={lines()}>
+        {(line) => {
+          const trimmed = line.trim()
+          const displayPath = props.directory ? relativizeProjectPaths(trimmed, props.directory) : trimmed
+          return (
+            <Show
+              when={hasClickable() && isFilePath(trimmed)}
+              fallback={<div data-slot="file-output-line">{displayPath}</div>}
+            >
+              <div
+                data-slot="file-output-line"
+                class="clickable"
+                onClick={() => props.openFile!(trimmed)}
+              >
+                {displayPath}
+              </div>
+            </Show>
+          )
+        }}
+      </For>
+    </div>
+  )
+}
+
+const TEXT_RENDER_THROTTLE_MS = 100
+
+function createThrottledValue(getValue: () => string) {
+  const [value, setValue] = createSignal(getValue())
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let last = 0
+
+  createEffect(() => {
+    const next = getValue()
+    const now = Date.now()
+    const remaining = TEXT_RENDER_THROTTLE_MS - (now - last)
+    if (remaining <= 0) {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = undefined
+      }
+      last = now
+      setValue(next)
+      return
+    }
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(() => {
+      last = Date.now()
+      setValue(next)
+      timeout = undefined
+    }, remaining)
+  })
+
+  onCleanup(() => {
+    if (timeout) clearTimeout(timeout)
+  })
+
+  return value
+}
+
+// Override TextPartDisplay to make inline code file paths clickable
+PART_MAPPING["text"] = function TextPartDisplay(props) {
+  const data = useData()
+  const i18n = useI18n()
+  const part = props.part as TextPart
+  const displayText = () => relativizeProjectPaths((part.text ?? "").trim(), data.directory)
+  const throttledText = createThrottledValue(displayText)
+  const [copied, setCopied] = createSignal(false)
+
+  const handleCopy = async () => {
+    const content = displayText()
+    if (!content) return
+    await navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleCodeClick = (e: MouseEvent) => {
+    if (!data.openFile) return
+    const target = e.target as HTMLElement
+    const code = target.closest("code")
+    if (!code || code.closest("pre")) return
+    const text = code.textContent?.trim()
+    if (!text || !isFilePath(text)) return
+    e.preventDefault()
+    e.stopPropagation()
+    data.openFile(text)
+  }
+
+  return (
+    <Show when={throttledText()}>
+      <div data-component="text-part" data-has-open-file={!!data.openFile || undefined}>
+        <div data-slot="text-part-body" onClick={handleCodeClick}>
+          <Markdown text={throttledText()} cacheKey={part.id} />
+          <div data-slot="text-part-copy-wrapper">
+            <Tooltip
+              value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+              placement="top"
+              gutter={8}
+            >
+              <IconButton
+                icon={copied() ? "check" : "copy"}
+                size="small"
+                variant="secondary"
+                onMouseDown={(e: MouseEvent) => e.preventDefault()}
+                onClick={handleCopy}
+                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+              />
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+    </Show>
+  )
+}
+
+// Override read tool to add clickable subtitle and loaded file paths
+ToolRegistry.register({
+  name: "read",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const args: string[] = []
+    if (props.input.offset) args.push("offset=" + props.input.offset)
+    if (props.input.limit) args.push("limit=" + props.input.limit)
+    const loaded = createMemo(() => {
+      if (props.status !== "completed") return []
+      const value = props.metadata.loaded
+      if (!value || !Array.isArray(value)) return []
+      return value.filter((p): p is string => typeof p === "string")
+    })
+    const openFile = () => {
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
+    return (
+      <>
+        <BasicTool
+          {...props}
+          icon="glasses"
+          trigger={{
+            title: i18n.t("ui.tool.read"),
+            subtitle: props.input.filePath ? getFilename(props.input.filePath) : "",
+            args,
+          }}
+          onSubtitleClick={props.input.filePath ? openFile : undefined}
+        />
+        <For each={loaded()}>
+          {(filepath) => (
+            <div data-component="tool-loaded-file">
+              <Icon name="enter" size="small" />
+              <span
+                classList={{ clickable: !!data.openFile }}
+                onClick={(e) => {
+                  if (data.openFile) {
+                    e.stopPropagation()
+                    data.openFile(filepath)
+                  }
+                }}
+              >
+                {i18n.t("ui.tool.loaded")} {relativizeProjectPaths(filepath, data.directory)}
+              </span>
+            </div>
+          )}
+        </For>
+      </>
+    )
+  },
+})
+
+// Override list tool to use clickable file output
+ToolRegistry.register({
+  name: "list",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    return (
+      <BasicTool
+        {...props}
+        icon="bullet-list"
+        trigger={{ title: i18n.t("ui.tool.list"), subtitle: getDirectory(props.input.path || "/") }}
+      >
+        <Show when={props.output}>
+          {(output) => (
+            <div data-component="tool-output" data-scrollable>
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+            </div>
+          )}
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+// Override glob tool to use clickable file output
+ToolRegistry.register({
+  name: "glob",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    return (
+      <BasicTool
+        {...props}
+        icon="magnifying-glass-menu"
+        trigger={{
+          title: i18n.t("ui.tool.glob"),
+          subtitle: getDirectory(props.input.path || "/"),
+          args: props.input.pattern ? ["pattern=" + props.input.pattern] : [],
+        }}
+      >
+        <Show when={props.output}>
+          {(output) => (
+            <div data-component="tool-output" data-scrollable>
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+            </div>
+          )}
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+// Override grep tool to use clickable file output
+ToolRegistry.register({
+  name: "grep",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const args: string[] = []
+    if (props.input.pattern) args.push("pattern=" + props.input.pattern)
+    if (props.input.include) args.push("include=" + props.input.include)
+    return (
+      <BasicTool
+        {...props}
+        icon="magnifying-glass-menu"
+        trigger={{
+          title: i18n.t("ui.tool.grep"),
+          subtitle: getDirectory(props.input.path || "/"),
+          args,
+        }}
+      >
+        <Show when={props.output}>
+          {(output) => (
+            <div data-component="tool-output" data-scrollable>
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+            </div>
+          )}
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+// Override edit tool to add clickable filename
+ToolRegistry.register({
+  name: "edit",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const diffComponent = useDiffComponent()
+    const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
+    const filename = () => getFilename(props.input.filePath ?? "")
+    const openFile = (e: MouseEvent) => {
+      e.stopPropagation()
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
+    return (
+      <BasicTool
+        {...props}
+        icon="code-lines"
+        trigger={
+          <div data-component="edit-trigger">
+            <div data-slot="message-part-title-area">
+              <div data-slot="message-part-title">
+                <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.edit")}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
+                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
+                >
+                  {filename()}
+                </span>
+              </div>
+              <Show when={props.input.filePath?.includes("/")}>
+                <div data-slot="message-part-path">
+                  <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                </div>
+              </Show>
+            </div>
+            <div data-slot="message-part-actions">
+              <Show when={props.metadata.filediff}>
+                <DiffChanges changes={props.metadata.filediff} />
+              </Show>
+            </div>
+          </div>
+        }
+      >
+        <Show when={props.metadata.filediff?.path || props.input.filePath}>
+          <div data-component="edit-content">
+            <Dynamic
+              component={diffComponent}
+              before={{
+                name: props.metadata?.filediff?.file || props.input.filePath,
+                contents: props.metadata?.filediff?.before || props.input.oldString,
+              }}
+              after={{
+                name: props.metadata?.filediff?.file || props.input.filePath,
+                contents: props.metadata?.filediff?.after || props.input.newString,
+              }}
+            />
+          </div>
+        </Show>
+        <DiagnosticsDisplay diagnostics={diagnostics()} />
+      </BasicTool>
+    )
+  },
+})
+
+// Override write tool to add clickable filename
+ToolRegistry.register({
+  name: "write",
+  render(props) {
+    const data = useData()
+    const i18n = useI18n()
+    const codeComponent = useCodeComponent()
+    const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
+    const filename = () => getFilename(props.input.filePath ?? "")
+    const openFile = (e: MouseEvent) => {
+      e.stopPropagation()
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
+    return (
+      <BasicTool
+        {...props}
+        icon="code-lines"
+        trigger={
+          <div data-component="write-trigger">
+            <div data-slot="message-part-title-area">
+              <div data-slot="message-part-title">
+                <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.write")}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
+                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
+                >
+                  {filename()}
+                </span>
+              </div>
+              <Show when={props.input.filePath?.includes("/")}>
+                <div data-slot="message-part-path">
+                  <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                </div>
+              </Show>
+            </div>
+            <div data-slot="message-part-actions">{/* placeholder */}</div>
+          </div>
+        }
+      >
+        <Show when={props.input.content}>
+          <div data-component="write-content">
+            <Dynamic
+              component={codeComponent}
+              file={{
+                name: props.input.filePath,
+                contents: props.input.content,
+                cacheKey: checksum(props.input.content),
+              }}
+              overflow="scroll"
+            />
+          </div>
+        </Show>
+        <DiagnosticsDisplay diagnostics={diagnostics()} />
+      </BasicTool>
+    )
+  },
+})

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -318,7 +318,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "openFile":
           if (message.path) {
-            await vscode.window.showTextDocument(vscode.Uri.file(message.path))
+            const uri = message.path.startsWith("/")
+              ? vscode.Uri.file(message.path)
+              : vscode.Uri.joinPath(vscode.workspace.workspaceFolders?.[0]?.uri ?? vscode.Uri.file(""), message.path)
+            await vscode.window.showTextDocument(uri)
           }
           break
         case "requestProviders":

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -316,6 +316,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             vscode.env.openExternal(vscode.Uri.parse(message.url))
           }
           break
+        case "openFile":
+          if (message.path) {
+            await vscode.window.showTextDocument(vscode.Uri.file(message.path))
+          }
+          break
         case "requestProviders":
           await this.fetchAndSendProviders()
           break

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -10,7 +10,7 @@ import { DataProvider } from "@kilocode/kilo-ui/context/data"
 import { Toast } from "@kilocode/kilo-ui/toast"
 import Settings from "./components/Settings"
 import ProfileView from "./components/ProfileView"
-import { VSCodeProvider } from "./context/vscode"
+import { VSCodeProvider, useVSCode } from "./context/vscode"
 import { ServerProvider, useServer } from "./context/server"
 import { ProviderProvider } from "./context/provider"
 import { ConfigProvider } from "./context/config"
@@ -47,6 +47,7 @@ const DummyView: Component<{ title: string }> = (props) => {
  */
 export const DataBridge: Component<{ children: any }> = (props) => {
   const session = useSession()
+  const vscode = useVSCode()
 
   const data = createMemo(() => {
     const id = session.currentSessionID()
@@ -70,8 +71,12 @@ export const DataBridge: Component<{ children: any }> = (props) => {
     session.syncSession(sessionID)
   }
 
+  const openFile = (path: string) => {
+    vscode.postMessage({ type: "openFile", path })
+  }
+
   return (
-    <DataProvider data={data()} directory="" onPermissionRespond={respond} onSyncSession={sync}>
+    <DataProvider data={data()} directory="" onPermissionRespond={respond} onSyncSession={sync} onOpenFile={openFile}>
       {props.children}
     </DataProvider>
   )

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -651,6 +651,11 @@ export interface OpenExternalRequest {
   url: string
 }
 
+export interface OpenFileRequest {
+  type: "openFile"
+  path: string
+}
+
 export interface CancelLoginRequest {
   type: "cancelLogin"
 }
@@ -825,6 +830,7 @@ export type WebviewMessage =
   | LogoutRequest
   | RefreshProfileRequest
   | OpenExternalRequest
+  | OpenFileRequest
   | CancelLoginRequest
   | SetOrganizationRequest
   | WebviewReadyRequest

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -843,4 +843,45 @@
     flex-shrink: 0;
     color: var(--icon-weak);
   }
+
+  .clickable {
+    cursor: pointer;
+    text-decoration: underline;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: var(--text-base);
+    }
+  }
+}
+
+[data-component="clickable-file-output"] {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+
+  [data-slot="file-output-line"] {
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-small);
+    line-height: var(--line-height-large);
+    color: var(--text-weak);
+    white-space: pre;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &.clickable {
+      cursor: pointer;
+      text-decoration: underline;
+      text-decoration-color: transparent;
+      transition:
+        color 0.15s ease,
+        text-decoration-color 0.15s ease;
+
+      &:hover {
+        color: var(--text-base);
+        text-decoration-color: var(--text-base);
+      }
+    }
+  }
 }

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -274,6 +274,16 @@
 
   [data-slot="message-part-title-filename"] {
     /* No text-transform - preserve original filename casing */
+
+    &.clickable {
+      cursor: pointer;
+      text-decoration: underline;
+      transition: color 0.15s ease;
+
+      &:hover {
+        color: var(--text-strong);
+      }
+    }
   }
 
   [data-slot="message-part-path"] {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -114,15 +114,6 @@
 [data-component="text-part"] {
   width: 100%;
 
-  &[data-has-open-file] [data-slot="text-part-body"] code:not(pre code) {
-    cursor: pointer;
-    transition: color 0.15s ease;
-
-    &:hover {
-      color: var(--text-strong);
-    }
-  }
-
   [data-slot="text-part-body"] {
     position: relative;
     margin-top: 32px;
@@ -283,16 +274,6 @@
 
   [data-slot="message-part-title-filename"] {
     /* No text-transform - preserve original filename casing */
-
-    &.clickable {
-      cursor: pointer;
-      text-decoration: underline;
-      transition: color 0.15s ease;
-
-      &:hover {
-        color: var(--text-strong);
-      }
-    }
   }
 
   [data-slot="message-part-path"] {
@@ -851,46 +832,5 @@
   [data-component="icon"] {
     flex-shrink: 0;
     color: var(--icon-weak);
-  }
-
-  .clickable {
-    cursor: pointer;
-    text-decoration: underline;
-    transition: color 0.15s ease;
-
-    &:hover {
-      color: var(--text-base);
-    }
-  }
-}
-
-[data-component="clickable-file-output"] {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  min-width: 0;
-
-  [data-slot="file-output-line"] {
-    font-family: var(--font-family-mono);
-    font-size: var(--font-size-small);
-    line-height: var(--line-height-large);
-    color: var(--text-weak);
-    white-space: pre;
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    &.clickable {
-      cursor: pointer;
-      text-decoration: underline;
-      text-decoration-color: transparent;
-      transition:
-        color 0.15s ease,
-        text-decoration-color 0.15s ease;
-
-      &:hover {
-        color: var(--text-base);
-        text-decoration-color: var(--text-base);
-      }
-    }
   }
 }

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -114,6 +114,15 @@
 [data-component="text-part"] {
   width: 100%;
 
+  &[data-has-open-file] [data-slot="text-part-body"] code:not(pre code) {
+    cursor: pointer;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: var(--text-strong);
+    }
+  }
+
   [data-slot="text-part-body"] {
     position: relative;
     margin-top: 32px;

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -59,6 +59,10 @@ interface Diagnostic {
   severity?: number
 }
 
+// kilocode_change start - export for kilo-ui overrides
+export { type Diagnostic, getDiagnostics, DiagnosticsDisplay, relativizeProjectPaths, getDirectory, createThrottledValue }
+// kilocode_change end
+
 function getDiagnostics(
   diagnosticsByFile: Record<string, Diagnostic[]> | undefined,
   filePath: string | undefined,

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -533,10 +533,16 @@ export const ToolRegistry = {
   render: getTool,
 }
 
+/** Check if text looks like a file path (contains / and has a file extension) */
+const FILE_PATH_RE = /^\.{0,2}\/.*\.\w+$|^[a-zA-Z]:\\.*\.\w+$|^\w[\w.-]*\/.*\.\w+$/
+
+function isFilePath(text: string): boolean {
+  return FILE_PATH_RE.test(text.trim())
+}
+
 /**
  * Renders tool output text with file paths as clickable elements.
- * Lines that look like file paths (start with / or contain common path patterns)
- * become clickable to open the file in the editor.
+ * Lines that look like file paths become clickable to open the file in the editor.
  */
 function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; directory?: string }) {
   const lines = createMemo(() => props.text.split("\n").filter((l) => l.trim()))
@@ -547,11 +553,10 @@ function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; direc
       <For each={lines()}>
         {(line) => {
           const trimmed = line.trim()
-          const isPath = trimmed.startsWith("/") || trimmed.match(/^[a-zA-Z]:\\/) || trimmed.match(/^\w[\w.-]*\//)
           const displayPath = props.directory ? relativizeProjectPaths(trimmed, props.directory) : trimmed
           return (
             <Show
-              when={hasClickable() && isPath}
+              when={hasClickable() && isFilePath(trimmed)}
               fallback={<div data-slot="file-output-line">{displayPath}</div>}
             >
               <div
@@ -701,13 +706,6 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
       <Show when={showQuestion() && questionRequest()}>{(request) => <QuestionPrompt request={request()} />}</Show>
     </div>
   )
-}
-
-/** Check if text looks like a file path (contains / and has a file extension) */
-const FILE_PATH_RE = /^\.{0,2}\/.*\.\w+$|^[a-zA-Z]:\\.*\.\w+$|^\w[\w.-]*\/.*\.\w+$/
-
-function isFilePath(text: string): boolean {
-  return FILE_PATH_RE.test(text.trim())
 }
 
 PART_MAPPING["text"] = function TextPartDisplay(props) {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -741,6 +741,9 @@ ToolRegistry.register({
       if (!value || !Array.isArray(value)) return []
       return value.filter((p): p is string => typeof p === "string")
     })
+    const openFile = () => {
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
     return (
       <>
         <BasicTool
@@ -751,6 +754,7 @@ ToolRegistry.register({
             subtitle: props.input.filePath ? getFilename(props.input.filePath) : "",
             args,
           }}
+          onSubtitleClick={props.input.filePath ? openFile : undefined}
         />
         <For each={loaded()}>
           {(filepath) => (
@@ -1106,10 +1110,15 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "edit",
   render(props) {
+    const data = useData()
     const i18n = useI18n()
     const diffComponent = useDiffComponent()
     const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
     const filename = () => getFilename(props.input.filePath ?? "")
+    const openFile = (e: MouseEvent) => {
+      e.stopPropagation()
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
     return (
       <BasicTool
         {...props}
@@ -1119,7 +1128,13 @@ ToolRegistry.register({
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
                 <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.edit")}</span>
-                <span data-slot="message-part-title-filename">{filename()}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
+                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
+                >
+                  {filename()}
+                </span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">
@@ -1159,10 +1174,15 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "write",
   render(props) {
+    const data = useData()
     const i18n = useI18n()
     const codeComponent = useCodeComponent()
     const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
     const filename = () => getFilename(props.input.filePath ?? "")
+    const openFile = (e: MouseEvent) => {
+      e.stopPropagation()
+      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
+    }
     return (
       <BasicTool
         {...props}
@@ -1172,7 +1192,13 @@ ToolRegistry.register({
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
                 <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.write")}</span>
-                <span data-slot="message-part-title-filename">{filename()}</span>
+                <span
+                  data-slot="message-part-title-filename"
+                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
+                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
+                >
+                  {filename()}
+                </span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -173,6 +173,7 @@ export function getSessionToolParts(store: ReturnType<typeof useData>["store"], 
   return parts
 }
 
+import type { OpenFileFn } from "../context/data"
 import type { IconProps } from "./icon"
 
 export type ToolInfo = {
@@ -532,6 +533,42 @@ export const ToolRegistry = {
   render: getTool,
 }
 
+/**
+ * Renders tool output text with file paths as clickable elements.
+ * Lines that look like file paths (start with / or contain common path patterns)
+ * become clickable to open the file in the editor.
+ */
+function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; directory?: string }) {
+  const lines = createMemo(() => props.text.split("\n").filter((l) => l.trim()))
+  const hasClickable = () => !!props.openFile
+
+  return (
+    <div data-component="clickable-file-output">
+      <For each={lines()}>
+        {(line) => {
+          const trimmed = line.trim()
+          const isPath = trimmed.startsWith("/") || trimmed.match(/^[a-zA-Z]:\\/) || trimmed.match(/^\w[\w.-]*\//)
+          const displayPath = props.directory ? relativizeProjectPaths(trimmed, props.directory) : trimmed
+          return (
+            <Show
+              when={hasClickable() && isPath}
+              fallback={<div data-slot="file-output-line">{displayPath}</div>}
+            >
+              <div
+                data-slot="file-output-line"
+                class="clickable"
+                onClick={() => props.openFile!(trimmed)}
+              >
+                {displayPath}
+              </div>
+            </Show>
+          )
+        }}
+      </For>
+    </div>
+  )
+}
+
 PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   const data = useData()
   const i18n = useI18n()
@@ -760,7 +797,15 @@ ToolRegistry.register({
           {(filepath) => (
             <div data-component="tool-loaded-file">
               <Icon name="enter" size="small" />
-              <span>
+              <span
+                classList={{ clickable: !!data.openFile }}
+                onClick={(e) => {
+                  if (data.openFile) {
+                    e.stopPropagation()
+                    data.openFile(filepath)
+                  }
+                }}
+              >
                 {i18n.t("ui.tool.loaded")} {relativizeProjectPaths(filepath, data.directory)}
               </span>
             </div>
@@ -774,6 +819,7 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "list",
   render(props) {
+    const data = useData()
     const i18n = useI18n()
     return (
       <BasicTool
@@ -784,7 +830,7 @@ ToolRegistry.register({
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>
-              <Markdown text={output()} />
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
             </div>
           )}
         </Show>
@@ -796,6 +842,7 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "glob",
   render(props) {
+    const data = useData()
     const i18n = useI18n()
     return (
       <BasicTool
@@ -810,7 +857,7 @@ ToolRegistry.register({
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>
-              <Markdown text={output()} />
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
             </div>
           )}
         </Show>
@@ -822,6 +869,7 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "grep",
   render(props) {
+    const data = useData()
     const i18n = useI18n()
     const args: string[] = []
     if (props.input.pattern) args.push("pattern=" + props.input.pattern)
@@ -839,7 +887,7 @@ ToolRegistry.register({
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>
-              <Markdown text={output()} />
+              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
             </div>
           )}
         </Show>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -173,7 +173,6 @@ export function getSessionToolParts(store: ReturnType<typeof useData>["store"], 
   return parts
 }
 
-import type { OpenFileFn } from "../context/data"
 import type { IconProps } from "./icon"
 
 export type ToolInfo = {
@@ -533,47 +532,6 @@ export const ToolRegistry = {
   render: getTool,
 }
 
-/** Check if text looks like a file path (contains / and has a file extension) */
-const FILE_PATH_RE = /^\.{0,2}\/.*\.\w+$|^[a-zA-Z]:\\.*\.\w+$|^\w[\w.-]*\/.*\.\w+$/
-
-function isFilePath(text: string): boolean {
-  return FILE_PATH_RE.test(text.trim())
-}
-
-/**
- * Renders tool output text with file paths as clickable elements.
- * Lines that look like file paths become clickable to open the file in the editor.
- */
-function ClickableFileOutput(props: { text: string; openFile?: OpenFileFn; directory?: string }) {
-  const lines = createMemo(() => props.text.split("\n").filter((l) => l.trim()))
-  const hasClickable = () => !!props.openFile
-
-  return (
-    <div data-component="clickable-file-output">
-      <For each={lines()}>
-        {(line) => {
-          const trimmed = line.trim()
-          const displayPath = props.directory ? relativizeProjectPaths(trimmed, props.directory) : trimmed
-          return (
-            <Show
-              when={hasClickable() && isFilePath(trimmed)}
-              fallback={<div data-slot="file-output-line">{displayPath}</div>}
-            >
-              <div
-                data-slot="file-output-line"
-                class="clickable"
-                onClick={() => props.openFile!(trimmed)}
-              >
-                {displayPath}
-              </div>
-            </Show>
-          )
-        }}
-      </For>
-    </div>
-  )
-}
-
 PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   const data = useData()
   const i18n = useI18n()
@@ -724,22 +682,10 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  const handleCodeClick = (e: MouseEvent) => {
-    if (!data.openFile) return
-    const target = e.target as HTMLElement
-    const code = target.closest("code")
-    if (!code || code.closest("pre")) return
-    const text = code.textContent?.trim()
-    if (!text || !isFilePath(text)) return
-    e.preventDefault()
-    e.stopPropagation()
-    data.openFile(text)
-  }
-
   return (
     <Show when={throttledText()}>
-      <div data-component="text-part" data-has-open-file={!!data.openFile || undefined}>
-        <div data-slot="text-part-body" onClick={handleCodeClick}>
+      <div data-component="text-part">
+        <div data-slot="text-part-body">
           <Markdown text={throttledText()} cacheKey={part.id} />
           <div data-slot="text-part-copy-wrapper">
             <Tooltip
@@ -795,9 +741,6 @@ ToolRegistry.register({
       if (!value || !Array.isArray(value)) return []
       return value.filter((p): p is string => typeof p === "string")
     })
-    const openFile = () => {
-      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
-    }
     return (
       <>
         <BasicTool
@@ -808,21 +751,12 @@ ToolRegistry.register({
             subtitle: props.input.filePath ? getFilename(props.input.filePath) : "",
             args,
           }}
-          onSubtitleClick={props.input.filePath ? openFile : undefined}
         />
         <For each={loaded()}>
           {(filepath) => (
             <div data-component="tool-loaded-file">
               <Icon name="enter" size="small" />
-              <span
-                classList={{ clickable: !!data.openFile }}
-                onClick={(e) => {
-                  if (data.openFile) {
-                    e.stopPropagation()
-                    data.openFile(filepath)
-                  }
-                }}
-              >
+              <span>
                 {i18n.t("ui.tool.loaded")} {relativizeProjectPaths(filepath, data.directory)}
               </span>
             </div>
@@ -836,7 +770,6 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "list",
   render(props) {
-    const data = useData()
     const i18n = useI18n()
     return (
       <BasicTool
@@ -847,7 +780,7 @@ ToolRegistry.register({
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>
-              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+              <Markdown text={output()} />
             </div>
           )}
         </Show>
@@ -859,7 +792,6 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "glob",
   render(props) {
-    const data = useData()
     const i18n = useI18n()
     return (
       <BasicTool
@@ -874,7 +806,7 @@ ToolRegistry.register({
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>
-              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+              <Markdown text={output()} />
             </div>
           )}
         </Show>
@@ -886,7 +818,6 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "grep",
   render(props) {
-    const data = useData()
     const i18n = useI18n()
     const args: string[] = []
     if (props.input.pattern) args.push("pattern=" + props.input.pattern)
@@ -904,7 +835,7 @@ ToolRegistry.register({
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>
-              <ClickableFileOutput text={output()} openFile={data.openFile} directory={data.directory} />
+              <Markdown text={output()} />
             </div>
           )}
         </Show>
@@ -1175,15 +1106,10 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "edit",
   render(props) {
-    const data = useData()
     const i18n = useI18n()
     const diffComponent = useDiffComponent()
     const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
     const filename = () => getFilename(props.input.filePath ?? "")
-    const openFile = (e: MouseEvent) => {
-      e.stopPropagation()
-      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
-    }
     return (
       <BasicTool
         {...props}
@@ -1193,13 +1119,7 @@ ToolRegistry.register({
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
                 <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.edit")}</span>
-                <span
-                  data-slot="message-part-title-filename"
-                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
-                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
-                >
-                  {filename()}
-                </span>
+                <span data-slot="message-part-title-filename">{filename()}</span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">
@@ -1239,15 +1159,10 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "write",
   render(props) {
-    const data = useData()
     const i18n = useI18n()
     const codeComponent = useCodeComponent()
     const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
     const filename = () => getFilename(props.input.filePath ?? "")
-    const openFile = (e: MouseEvent) => {
-      e.stopPropagation()
-      if (props.input.filePath && data.openFile) data.openFile(props.input.filePath)
-    }
     return (
       <BasicTool
         {...props}
@@ -1257,13 +1172,7 @@ ToolRegistry.register({
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
                 <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.write")}</span>
-                <span
-                  data-slot="message-part-title-filename"
-                  classList={{ clickable: !!data.openFile && !!props.input.filePath }}
-                  onClick={data.openFile && props.input.filePath ? openFile : undefined}
-                >
-                  {filename()}
-                </span>
+                <span data-slot="message-part-title-filename">{filename()}</span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -703,6 +703,13 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   )
 }
 
+/** Check if text looks like a file path (contains / and has a file extension) */
+const FILE_PATH_RE = /^\.{0,2}\/.*\.\w+$|^[a-zA-Z]:\\.*\.\w+$|^\w[\w.-]*\/.*\.\w+$/
+
+function isFilePath(text: string): boolean {
+  return FILE_PATH_RE.test(text.trim())
+}
+
 PART_MAPPING["text"] = function TextPartDisplay(props) {
   const data = useData()
   const i18n = useI18n()
@@ -719,10 +726,22 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     setTimeout(() => setCopied(false), 2000)
   }
 
+  const handleCodeClick = (e: MouseEvent) => {
+    if (!data.openFile) return
+    const target = e.target as HTMLElement
+    const code = target.closest("code")
+    if (!code || code.closest("pre")) return
+    const text = code.textContent?.trim()
+    if (!text || !isFilePath(text)) return
+    e.preventDefault()
+    e.stopPropagation()
+    data.openFile(text)
+  }
+
   return (
     <Show when={throttledText()}>
-      <div data-component="text-part">
-        <div data-slot="text-part-body">
+      <div data-component="text-part" data-has-open-file={!!data.openFile || undefined}>
+        <div data-slot="text-part-body" onClick={handleCodeClick}>
           <Markdown text={throttledText()} cacheKey={part.id} />
           <div data-slot="text-part-copy-wrapper">
             <Tooltip

--- a/packages/ui/src/context/data.tsx
+++ b/packages/ui/src/context/data.tsx
@@ -52,6 +52,8 @@ export type SessionHrefFn = (sessionID: string) => string
 
 export type SyncSessionFn = (sessionID: string) => void | Promise<void>
 
+export type OpenFileFn = (path: string) => void
+
 export const { use: useData, provider: DataProvider } = createSimpleContext({
   name: "Data",
   init: (props: {
@@ -63,6 +65,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     onNavigateToSession?: NavigateToSessionFn
     onSessionHref?: SessionHrefFn
     onSyncSession?: SyncSessionFn
+    onOpenFile?: OpenFileFn
   }) => {
     return {
       get store() {
@@ -77,6 +80,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       navigateToSession: props.onNavigateToSession,
       sessionHref: props.onSessionHref,
       syncSession: props.onSyncSession,
+      openFile: props.onOpenFile,
     }
   },
 })

--- a/packages/ui/src/context/data.tsx
+++ b/packages/ui/src/context/data.tsx
@@ -52,7 +52,9 @@ export type SessionHrefFn = (sessionID: string) => string
 
 export type SyncSessionFn = (sessionID: string) => void | Promise<void>
 
+// kilocode_change start
 export type OpenFileFn = (path: string) => void
+// kilocode_change end
 
 export const { use: useData, provider: DataProvider } = createSimpleContext({
   name: "Data",
@@ -65,7 +67,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     onNavigateToSession?: NavigateToSessionFn
     onSessionHref?: SessionHrefFn
     onSyncSession?: SyncSessionFn
-    onOpenFile?: OpenFileFn
+    onOpenFile?: OpenFileFn // kilocode_change
   }) => {
     return {
       get store() {
@@ -80,7 +82,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       navigateToSession: props.onNavigateToSession,
       sessionHref: props.onSessionHref,
       syncSession: props.onSyncSession,
-      openFile: props.onOpenFile,
+      openFile: props.onOpenFile, // kilocode_change
     }
   },
 })


### PR DESCRIPTION
## Summary

Makes filenames in tool results (read, edit, write) clickable in the VS Code extension webview. Clicking a filename opens that file in the VS Code editor.

## Changes

### VS Code Extension
- **`KiloProvider.ts`**: New `openFile` message handler that calls `vscode.window.showTextDocument`
- **`App.tsx`**: `DataBridge` wires `onOpenFile` callback through `useVSCode().postMessage`
- **`messages.ts`**: New `OpenFileRequest` type added to `WebviewMessage` union

### Shared UI (`packages/ui`)
- **`data.tsx`**: New `OpenFileFn` type and `onOpenFile` prop on `DataProvider` context
- **`message-part.tsx`**: Filenames in `read`, `edit`, and `write` tool renders are now clickable
- **`message-part.css`**: `.clickable` styles on filename elements (pointer cursor, underline, hover color)

## How it works

1. User clicks a filename in a tool result in the webview
2. The click handler calls `data.openFile(filePath)`
3. `DataBridge` posts an `openFile` message to the VS Code host
4. `KiloProvider` receives the message and opens the file via `showTextDocument`
