### PR TITLE
fix: add .vscode-test/ to kilo-vscode gitignore

### DIFF
--- a/packages/kilo-vscode/.gitignore
+++ b/packages/kilo-vscode/.gitignore
@@ -1,2 +1,3 @@
 bin/
 out/
+.vscode-test/


### PR DESCRIPTION
## Summary

- Adds `.vscode-test/` to `packages/kilo-vscode/.gitignore` to prevent VS Code test runner artifacts from appearing in git diffs
- The `@vscode/test-cli` downloads a full VS Code Electron binary (1000+ files) into `.vscode-test/` when running extension tests — this directory was not gitignored, causing test artifacts to pollute diffs