### PR TITLE
Add closed-for-contributions GitHub Action

### DIFF
--- a/.github/workflows/closed-for-contributions.yml
+++ b/.github/workflows/closed-for-contributions.yml
@@ -9,5 +9,5 @@ jobs:
     steps:
       - name: Repository closed for contributions
         run: |
-          echo "::error::This repository is closed for contributions. Please use the kilocode repo instead: https://github.com/kilocode/kilocode"
+          echo "::error::This repository is closed for contributions. Please use the kilocode repo instead: https://github.com/Kilo-Org/kilocode"
           exit 1


### PR DESCRIPTION
Adds a GitHub Action workflow that triggers on all pull requests and always fails with a message directing contributors to use the kilocode repo instead.

This is in preparation for closing this repo for contributions.