### PR TITLE
fix: enable reasoning for thinking models via kilo-gateway

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -779,6 +779,16 @@ export namespace ProviderTransform {
       result["chat_template_args"] = { enable_thinking: true }
     }
 
+    // kilocode_change - some thinking models (e.g. moonshot) require reasoning enabled
+    // see test/provider/transform.test.ts "thinking models require reasoning enabled"
+    if (
+      input.model.api.npm === "@kilocode/kilo-gateway" &&
+      input.model.capabilities.reasoning &&
+      input.model.api.id.includes("thinking")
+    ) {
+      result["reasoning"] = { enabled: true }
+    }
+
     if (["zai", "zhipuai"].includes(input.model.providerID) && input.model.api.npm === "@ai-sdk/openai-compatible") {
       result["thinking"] = {
         type: "enabled",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2158,5 +2158,80 @@ describe("ProviderTransform.smallOptions", () => {
       expect(result).toEqual({ reasoning: { enabled: false } })
     })
   })
+
+  // Some thinking models via Kilo Gateway (observed with moonshot) require reasoning
+  // to be explicitly enabled. Use "thinking" in model name as heuristic rather than
+  // hard-coding provider/model names.
+  describe("thinking models require reasoning enabled", () => {
+    const sessionID = "test-session"
+
+    test("kimi-k2-thinking gets reasoning enabled", () => {
+      const model = createMockModel({
+        id: "kilo/moonshotai/kimi-k2-thinking",
+        providerID: "kilo",
+        reasoning: true,
+        api: {
+          id: "moonshotai/kimi-k2-thinking",
+          url: "https://gateway.kilo.ai",
+          npm: "@kilocode/kilo-gateway",
+        },
+      })
+      const result = ProviderTransform.options({ model, sessionID })
+      expect(result.reasoning).toEqual({ enabled: true })
+    })
+
+    test("any future -thinking model gets reasoning enabled", () => {
+      const model = createMockModel({
+        id: "kilo/someprovider/some-model-thinking",
+        providerID: "kilo",
+        reasoning: true,
+        api: {
+          id: "someprovider/some-model-thinking",
+          url: "https://gateway.kilo.ai",
+          npm: "@kilocode/kilo-gateway",
+        },
+      })
+      const result = ProviderTransform.options({ model, sessionID })
+      expect(result.reasoning).toEqual({ enabled: true })
+    })
+
+    test("non-thinking models do not get reasoning auto-enabled", () => {
+      const model = createMockModel({
+        id: "kilo/moonshotai/kimi-k2",
+        providerID: "kilo",
+        reasoning: true,
+        api: {
+          id: "moonshotai/kimi-k2",
+          url: "https://gateway.kilo.ai",
+          npm: "@kilocode/kilo-gateway",
+        },
+      })
+      const result = ProviderTransform.options({ model, sessionID })
+      expect(result.reasoning).toBeUndefined()
+    })
+
+    test("thinking model without reasoning capability does not get reasoning enabled", () => {
+      const model = createMockModel({
+        id: "kilo/someprovider/fake-thinking",
+        providerID: "kilo",
+        capabilities: {
+          temperature: true,
+          reasoning: false,
+          attachment: true,
+          toolcall: true,
+          input: { text: true, audio: false, image: true, video: false, pdf: false },
+          output: { text: true, audio: false, image: false, video: false, pdf: false },
+          interleaved: false,
+        },
+        api: {
+          id: "someprovider/fake-thinking",
+          url: "https://gateway.kilo.ai",
+          npm: "@kilocode/kilo-gateway",
+        },
+      })
+      const result = ProviderTransform.options({ model, sessionID })
+      expect(result.reasoning).toBeUndefined()
+    })
+  })
 })
 // kilocode_change end


### PR DESCRIPTION
## Summary
- Fixes bug where thinking models (e.g. `kimi-k2-thinking`) fail with "Reasoning is mandatory for this endpoint" when accessed via Kilo Gateway
- Adds automatic `reasoning: { enabled: true }` for models using `@kilocode/kilo-gateway` SDK that have reasoning capability and "thinking" in their model ID
- Adds tests for the fix

## Changes
- `packages/opencode/src/provider/transform.ts`: Add logic to enable reasoning for thinking models via Kilo Gateway
- `packages/opencode/test/provider/transform.test.ts`: Add tests

## Testing
Verified that `kimi-k2-thinking` now works:
- Before: 

```
% bun run dev -- run --model kilo/moonshotai/kimi-k2-thinking "Vad heter du?"
$ bun run --cwd packages/opencode --conditions=browser src/index.ts run --model "kilo/moonshotai/kimi-k2-thinking" "Vad heter du?"

> code · moonshotai/kimi-k2-thinking

Error: Reasoning is mandatory for this endpoint and cannot be disabled.
^C
```

- After:

```
% bun run dev -- run --model kilo/moonshotai/kimi-k2-thinking "Vad heter du?"                                                                                                     [130]
$ bun run --cwd packages/opencode --conditions=browser src/index.ts run --model "kilo/moonshotai/kimi-k2-thinking" "Vad heter du?"

> code · moonshotai/kimi-k2-thinking

Kilo

```

Fixes Kilo-Org/kilocode#6297