### PR TITLE
feat: The Governed Agent Protocol — hard safety layer for destructive commands

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -11,6 +11,7 @@ export namespace Flag {
   export declare const KILO_CONFIG_DIR: string | undefined
   export const KILO_CONFIG_CONTENT = process.env["KILO_CONFIG_CONTENT"]
   export const KILO_DISABLE_AUTOUPDATE = truthy("KILO_DISABLE_AUTOUPDATE")
+  export const KILO_DISABLE_GOVERNANCE = truthy("KILO_DISABLE_GOVERNANCE")
   export const KILO_DISABLE_PRUNE = truthy("KILO_DISABLE_PRUNE")
   export const KILO_DISABLE_TERMINAL_TITLE = truthy("KILO_DISABLE_TERMINAL_TITLE")
   export const KILO_PERMISSION = process.env["KILO_PERMISSION"]

--- a/packages/opencode/src/governance/detector.ts
+++ b/packages/opencode/src/governance/detector.ts
@@ -1,0 +1,102 @@
+import type { Governance } from "./types"
+import { GovernancePatterns } from "./patterns"
+
+export namespace GovernanceDetector {
+  /**
+   * Check a bash command against all destructive patterns.
+   *
+   * @param command  Raw command string
+   * @param tokenSets  Token arrays extracted from tree-sitter AST (one per command in a pipeline/chain)
+   */
+  export function checkBashCommand(
+    command: string,
+    tokenSets: string[][],
+  ): Governance.CheckResult {
+    const verdicts: Governance.Verdict[] = []
+
+    for (const tokens of tokenSets) {
+      for (const pattern of GovernancePatterns.ALL) {
+        if (pattern.test(command, tokens)) {
+          verdicts.push({
+            blocked: pattern.severity === "critical" || pattern.severity === "high",
+            severity: pattern.severity,
+            category: pattern.category,
+            command: tokens.join(" "),
+            pattern: pattern.reason.split(".")[0],
+            reason: pattern.reason,
+            suggestion: pattern.suggestion,
+          })
+        }
+      }
+    }
+
+    const deduped = deduplicateVerdicts(verdicts)
+    const hasBlocking = deduped.some((v) => v.blocked)
+
+    return {
+      allowed: !hasBlocking,
+      verdicts: deduped,
+    }
+  }
+
+  function deduplicateVerdicts(verdicts: Governance.Verdict[]): Governance.Verdict[] {
+    const ORDER: Record<string, number> = { critical: 3, high: 2, medium: 1 }
+    const seen = new Map<string, Governance.Verdict>()
+
+    for (const v of verdicts) {
+      const key = `${v.category}:${v.command}`
+      const existing = seen.get(key)
+      if (!existing || ORDER[v.severity]! > ORDER[existing.severity]!) {
+        seen.set(key, v)
+      }
+    }
+    return Array.from(seen.values())
+  }
+
+  /**
+   * Format blocked verdicts into a human-readable rejection message.
+   *
+   * Following the Governed Agent Protocol:
+   * "Refusal is honest engagement, not withdrawal."
+   */
+  export function formatRejection(verdicts: Governance.Verdict[]): string {
+    const blocked = verdicts.filter((v) => v.blocked)
+    if (blocked.length === 0) return ""
+
+    const lines: string[] = [
+      "[governance] Command blocked by the Governed Agent Protocol",
+      "",
+    ]
+
+    for (const v of blocked) {
+      lines.push(`  Severity:  ${v.severity.toUpperCase()}`)
+      lines.push(`  Category:  ${v.category}`)
+      lines.push(`  Reason:    ${v.reason}`)
+      if (v.suggestion) {
+        lines.push(`  Suggest:   ${v.suggestion}`)
+      }
+      lines.push("")
+    }
+
+    lines.push("This safety check cannot be bypassed by permission settings.")
+    lines.push("If you believe this is a false positive, set KILO_DISABLE_GOVERNANCE=1.")
+
+    return lines.join("\n")
+  }
+
+  /**
+   * Format medium-severity warnings to append to tool output.
+   */
+  export function formatWarnings(verdicts: Governance.Verdict[]): string {
+    const warnings = verdicts.filter((v) => v.severity === "medium")
+    if (warnings.length === 0) return ""
+
+    const lines = ["", "<governance_warning>"]
+    for (const w of warnings) {
+      lines.push(`  Warning: ${w.reason}`)
+      if (w.suggestion) lines.push(`  Suggestion: ${w.suggestion}`)
+    }
+    lines.push("</governance_warning>")
+    return lines.join("\n")
+  }
+}

--- a/packages/opencode/src/governance/index.ts
+++ b/packages/opencode/src/governance/index.ts
@@ -1,0 +1,5 @@
+export { GovernanceIntegration } from "./integration"
+export { GovernanceDetector } from "./detector"
+export { GovernancePatterns } from "./patterns"
+export { PathGuard } from "./path-guard"
+export { Governance } from "./types"

--- a/packages/opencode/src/governance/integration.ts
+++ b/packages/opencode/src/governance/integration.ts
@@ -1,0 +1,58 @@
+import { GovernanceDetector } from "./detector"
+import { PathGuard } from "./path-guard"
+
+export namespace GovernanceIntegration {
+  export function isEnabled(): boolean {
+    return process.env.KILO_DISABLE_GOVERNANCE !== "1"
+  }
+
+  export interface ToolCheckResult {
+    allowed: boolean
+    output?: string
+    warnings?: string
+  }
+
+  /**
+   * Pre-check for bash tool execution.
+   * Called before permission checks — governance overrides permissions.
+   */
+  export function checkBash(
+    command: string,
+    tokenSets: string[][],
+  ): ToolCheckResult {
+    if (!isEnabled()) return { allowed: true }
+
+    const result = GovernanceDetector.checkBashCommand(command, tokenSets)
+
+    if (!result.allowed) {
+      return {
+        allowed: false,
+        output: GovernanceDetector.formatRejection(result.verdicts),
+      }
+    }
+
+    const warnings = GovernanceDetector.formatWarnings(result.verdicts)
+    return { allowed: true, warnings: warnings || undefined }
+  }
+
+  /**
+   * Pre-check for write/edit tool execution.
+   */
+  export function checkWritePath(
+    filepath: string,
+    projectRoot: string,
+  ): ToolCheckResult {
+    if (!isEnabled()) return { allowed: true }
+
+    const result = PathGuard.checkWritePath(filepath, projectRoot)
+
+    if (!result.allowed) {
+      return {
+        allowed: false,
+        output: GovernanceDetector.formatRejection(result.verdicts),
+      }
+    }
+
+    return { allowed: true }
+  }
+}

--- a/packages/opencode/src/governance/path-guard.ts
+++ b/packages/opencode/src/governance/path-guard.ts
@@ -1,0 +1,103 @@
+import path from "path"
+import type { Governance } from "./types"
+
+export namespace PathGuard {
+  const UNIX_SYSTEM_PATHS = [
+    "/etc", "/usr", "/boot", "/bin", "/sbin", "/lib", "/lib64",
+    "/opt", "/var/lib", "/var/log", "/proc", "/sys", "/dev",
+    "/System", "/Library",
+  ]
+
+  const WINDOWS_SYSTEM_PATHS = [
+    "C:\\Windows",
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+    "C:\\ProgramData",
+  ]
+
+  const SYSTEM_PATHS =
+    process.platform === "win32"
+      ? [...WINDOWS_SYSTEM_PATHS, ...UNIX_SYSTEM_PATHS]
+      : UNIX_SYSTEM_PATHS
+
+  const CREDENTIAL_FILES = new Set([
+    ".env", ".env.local", ".env.production", ".env.staging",
+    "id_rsa", "id_ed25519", "id_dsa", "id_ecdsa",
+    "id_rsa.pub", "id_ed25519.pub",
+    "credentials.json", "service-account.json",
+    ".npmrc", ".pypirc",
+    "secrets.yml", "secrets.yaml", "secrets.json",
+    "vault.json", "keystore.jks",
+    ".htpasswd", "shadow", "passwd",
+    "private.pem", "private.key",
+    "master.key", "credentials.yml.enc",
+    "token.json", "auth.json",
+  ])
+
+  const CREDENTIAL_DIRS = new Set([
+    ".ssh", ".gnupg", ".aws", ".azure", ".gcloud", ".kube", ".docker",
+  ])
+
+  export function checkWritePath(
+    filepath: string,
+    projectRoot: string,
+  ): Governance.CheckResult {
+    const verdicts: Governance.Verdict[] = []
+    const normalized = path.resolve(filepath)
+    const basename = path.basename(normalized)
+    const parts = normalized.split(path.sep)
+
+    // System paths
+    for (const sysPath of SYSTEM_PATHS) {
+      const normalizedSys = path.resolve(sysPath)
+      if (normalized.startsWith(normalizedSys + path.sep) || normalized === normalizedSys) {
+        verdicts.push({
+          blocked: true,
+          severity: "critical",
+          category: "system_path_write",
+          command: `write ${filepath}`,
+          pattern: "system_path",
+          reason: `Writing to system path '${sysPath}' is blocked. This could corrupt the operating system.`,
+          suggestion: "Write to a location within your project directory instead.",
+        })
+        break
+      }
+    }
+
+    // Credential files
+    if (CREDENTIAL_FILES.has(basename)) {
+      verdicts.push({
+        blocked: true,
+        severity: "high",
+        category: "credential_exposure",
+        command: `write ${filepath}`,
+        pattern: "credential_file",
+        reason: `Writing to credential file '${basename}' is blocked. This file may contain secrets.`,
+        suggestion: "Use environment variables or a secrets manager instead.",
+      })
+    }
+
+    // Credential directories
+    for (const dir of parts) {
+      if (CREDENTIAL_DIRS.has(dir)) {
+        verdicts.push({
+          blocked: true,
+          severity: "high",
+          category: "credential_exposure",
+          command: `write ${filepath}`,
+          pattern: "credential_directory",
+          reason: `Writing to credential directory '${dir}' is blocked.`,
+          suggestion: "Manage credential files manually, not through automated agents.",
+        })
+        break
+      }
+    }
+
+    const hasBlocking = verdicts.some((v) => v.blocked)
+
+    return {
+      allowed: !hasBlocking,
+      verdicts,
+    }
+  }
+}

--- a/packages/opencode/src/governance/patterns.ts
+++ b/packages/opencode/src/governance/patterns.ts
@@ -1,0 +1,242 @@
+import type { Governance } from "./types"
+
+export namespace GovernancePatterns {
+  export interface Pattern {
+    test: (command: string, tokens: string[]) => boolean
+    severity: Governance.Severity
+    category: Governance.Category
+    reason: string
+    suggestion?: string
+  }
+
+  // ---- CRITICAL: always blocked, no override ----
+
+  export const CRITICAL: Pattern[] = [
+    {
+      test: (cmd) => /:\(\)\s*\{.*\|.*&\s*\}\s*;?\s*:/.test(cmd),
+      severity: "critical",
+      category: "fork_bomb",
+      reason: "Fork bomb detected. This would spawn infinite processes and crash the system.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "rm") return false
+        const hasRf = tokens.some((t) => /^-[a-z]*r[a-z]*f|^-[a-z]*f[a-z]*r/.test(t))
+        const hasRoot = tokens.some((t) => t === "/" || t === "/*" || t === "/.")
+        return hasRf && hasRoot
+      },
+      severity: "critical",
+      category: "recursive_delete",
+      reason: "Recursive deletion of filesystem root. This would destroy the entire filesystem.",
+      suggestion: "Specify an explicit subdirectory instead of '/'.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "rm") return false
+        const hasRf = tokens.some((t) => /^-[a-z]*r[a-z]*f|^-[a-z]*f[a-z]*r/.test(t))
+        const hasHome = tokens.some((t) => t === "~" || t === "$HOME" || t === "~/")
+        return hasRf && hasHome
+      },
+      severity: "critical",
+      category: "recursive_delete",
+      reason: "Recursive deletion of home directory detected.",
+      suggestion: "Target specific files or directories instead of the entire home directory.",
+    },
+    {
+      test: (cmd) => /\bdd\b.*\bof=\/dev\/[sh]d[a-z]/.test(cmd),
+      severity: "critical",
+      category: "disk_wipe",
+      reason: "Direct write to block device detected. This would overwrite disk data.",
+      suggestion: "Use file-level operations instead of raw device writes.",
+    },
+    {
+      test: (cmd) => /\bdd\b.*if=\/dev\/(zero|urandom|random).*of=/.test(cmd),
+      severity: "critical",
+      category: "disk_wipe",
+      reason: "Disk wipe pattern detected (dd from /dev/zero or /dev/urandom).",
+      suggestion: "Use 'shred' on specific files if secure deletion is needed.",
+    },
+    {
+      test: (cmd) => /\bmkfs(\.\w+)?\s/.test(cmd),
+      severity: "critical",
+      category: "disk_wipe",
+      reason: "Filesystem format command detected. This would erase all data on the target device.",
+    },
+    {
+      test: (cmd) => />\s*\/dev\/[sh]d[a-z]/.test(cmd),
+      severity: "critical",
+      category: "disk_wipe",
+      reason: "Output redirect to block device detected.",
+      suggestion: "Redirect to a regular file instead.",
+    },
+    {
+      test: (cmd) => /\bDROP\s+DATABASE\b/i.test(cmd),
+      severity: "critical",
+      category: "sql_drop",
+      reason: "DROP DATABASE command detected. This permanently destroys an entire database.",
+      suggestion: "Create a backup first, or use specific table operations.",
+    },
+    {
+      test: (_cmd, tokens) =>
+        tokens[0] === "kill" &&
+        (tokens.includes("1") || tokens.includes("-9") && tokens.includes("1")),
+      severity: "critical",
+      category: "service_disruption",
+      reason: "Attempting to kill PID 1 (init/systemd). This would crash the system.",
+      suggestion: "Target specific process IDs instead.",
+    },
+  ]
+
+  // ---- HIGH: blocked, requires explicit override ----
+
+  export const HIGH: Pattern[] = [
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "git" || tokens[1] !== "push") return false
+        const hasForce = tokens.some((t) => t === "--force" || t === "-f")
+        const hasMain = tokens.some((t) => /^(main|master|origin\/main|origin\/master)$/.test(t))
+        return hasForce && hasMain
+      },
+      severity: "high",
+      category: "force_push",
+      reason: "Force push to main/master branch detected. This could overwrite shared history.",
+      suggestion: "Use '--force-with-lease' to a feature branch, or create a PR instead.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "git" || tokens[1] !== "push") return false
+        return tokens.some((t) => t === "--force" || t === "-f")
+      },
+      severity: "high",
+      category: "force_push",
+      reason: "Force push detected. This could overwrite remote branch history.",
+      suggestion: "Use '--force-with-lease' for safer force pushes, or push without --force.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "git" || tokens[1] !== "reset") return false
+        return tokens.some((t) => t === "--hard")
+      },
+      severity: "high",
+      category: "hard_reset",
+      reason: "git reset --hard detected. This discards all uncommitted changes permanently.",
+      suggestion: "Use 'git stash' to save changes before resetting, or use 'git reset --soft'.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "git" || tokens[1] !== "clean") return false
+        return tokens.some((t) => /^-[a-z]*f/.test(t))
+      },
+      severity: "high",
+      category: "hard_reset",
+      reason: "git clean -f detected. This permanently removes untracked files.",
+      suggestion: "Use 'git clean -n' (dry run) first to preview what would be deleted.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "git") return false
+        if (tokens[1] === "checkout" && tokens.includes(".")) return true
+        if (tokens[1] === "restore" && tokens.includes(".")) return true
+        return false
+      },
+      severity: "high",
+      category: "hard_reset",
+      reason: "Discarding all uncommitted changes detected.",
+      suggestion: "Use 'git stash' to save changes, or target specific files.",
+    },
+    {
+      test: (cmd) => /\bDROP\s+TABLE\b/i.test(cmd),
+      severity: "high",
+      category: "sql_drop",
+      reason: "DROP TABLE command detected. This permanently deletes a database table.",
+      suggestion: "Use TRUNCATE for clearing data, or create a backup before dropping.",
+    },
+    {
+      test: (cmd) => /\bTRUNCATE\s+TABLE\b/i.test(cmd),
+      severity: "high",
+      category: "sql_drop",
+      reason: "TRUNCATE TABLE detected. This deletes all data from a table.",
+      suggestion: "Use DELETE with a WHERE clause for selective deletion.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "chmod") return false
+        return tokens.some((t) => t === "777") && tokens.some((t) => /^-[a-z]*R/.test(t))
+      },
+      severity: "high",
+      category: "permission_escalation",
+      reason: "Recursive chmod 777 detected. This makes all files world-readable/writable/executable.",
+      suggestion: "Use more restrictive permissions like 755 for directories, 644 for files.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "rm") return false
+        const hasRf = tokens.some((t) => /^-[a-z]*r[a-z]*f|^-[a-z]*f[a-z]*r/.test(t))
+        const SYSTEM_DIRS = [
+          "/etc", "/usr", "/var", "/boot", "/bin", "/sbin", "/lib", "/opt",
+          "/System", "/Library", "/Applications",
+          "C:\\Windows", "C:\\Program Files",
+        ]
+        const targetsSystem = tokens.some((t) =>
+          SYSTEM_DIRS.some((d) => t === d || t.startsWith(d + "/") || t.startsWith(d + "\\")),
+        )
+        return hasRf && targetsSystem
+      },
+      severity: "high",
+      category: "recursive_delete",
+      reason: "Recursive deletion targeting system directory detected.",
+      suggestion: "Target specific files within the directory instead.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "systemctl") return false
+        return ["stop", "disable", "mask"].some((a) => tokens.includes(a))
+      },
+      severity: "high",
+      category: "service_disruption",
+      reason: "Stopping/disabling system service detected.",
+      suggestion: "Verify the service name and consider 'systemctl restart' instead.",
+    },
+  ]
+
+  // ---- MEDIUM: warn but allow ----
+
+  export const MEDIUM: Pattern[] = [
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "chmod") return false
+        return tokens.some((t) => t === "777") && !tokens.some((t) => /^-[a-z]*R/.test(t))
+      },
+      severity: "medium",
+      category: "permission_escalation",
+      reason: "chmod 777 detected. Consider using more restrictive permissions.",
+      suggestion: "Use 755 for directories or 644 for files.",
+    },
+    {
+      test: (cmd) => /curl\s.*\|\s*(ba)?sh/.test(cmd) || /wget\s.*\|\s*(ba)?sh/.test(cmd),
+      severity: "medium",
+      category: "destructive_command",
+      reason: "Piping remote content to shell detected. This executes arbitrary remote code.",
+      suggestion: "Download the script first, review it, then execute.",
+    },
+    {
+      test: (_cmd, tokens) => {
+        if (tokens[0] !== "rm") return false
+        return tokens.some((t) => /^-[a-z]*r[a-z]*f|^-[a-z]*f[a-z]*r/.test(t))
+      },
+      severity: "medium",
+      category: "recursive_delete",
+      reason: "Recursive force delete detected. Verify the target path is correct.",
+      suggestion: "Consider listing files first with 'find' or using 'rm -ri' (interactive).",
+    },
+    {
+      test: (cmd) => /\bDELETE\s+FROM\b/i.test(cmd) && !/\bWHERE\b/i.test(cmd),
+      severity: "medium",
+      category: "sql_drop",
+      reason: "DELETE FROM without WHERE clause detected. This deletes all rows.",
+      suggestion: "Add a WHERE clause to target specific rows.",
+    },
+  ]
+
+  export const ALL: Pattern[] = [...CRITICAL, ...HIGH, ...MEDIUM]
+}

--- a/packages/opencode/src/governance/types.ts
+++ b/packages/opencode/src/governance/types.ts
@@ -1,0 +1,38 @@
+import z from "zod"
+
+export namespace Governance {
+  export const Severity = z.enum(["critical", "high", "medium"])
+  export type Severity = z.infer<typeof Severity>
+
+  export const Category = z.enum([
+    "destructive_command",
+    "force_push",
+    "hard_reset",
+    "sql_drop",
+    "fork_bomb",
+    "disk_wipe",
+    "permission_escalation",
+    "credential_exposure",
+    "system_path_write",
+    "recursive_delete",
+    "service_disruption",
+  ])
+  export type Category = z.infer<typeof Category>
+
+  export const Verdict = z.object({
+    blocked: z.boolean(),
+    severity: Severity,
+    category: Category,
+    command: z.string(),
+    pattern: z.string(),
+    reason: z.string(),
+    suggestion: z.string().optional(),
+  })
+  export type Verdict = z.infer<typeof Verdict>
+
+  export const CheckResult = z.object({
+    allowed: z.boolean(),
+    verdicts: z.array(Verdict),
+  })
+  export type CheckResult = z.infer<typeof CheckResult>
+}

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -89,6 +89,9 @@ export const BashTool = Tool.define("bash", async () => {
       if (!Instance.containsPath(cwd)) directories.add(cwd)
       const patterns = new Set<string>()
       const always = new Set<string>()
+      // kilocode_change start - governed agent protocol: collect tokens for governance check
+      const governanceTokenSets: string[][] = []
+      // kilocode_change end
 
       for (const node of tree.rootNode.descendantsOfType("command")) {
         if (!node) continue
@@ -137,12 +140,32 @@ export const BashTool = Tool.define("bash", async () => {
           }
         }
 
+        // kilocode_change start - governed agent protocol: collect tokens
+        if (command.length > 0) governanceTokenSets.push([...command])
+        // kilocode_change end
+
         // cd covered by above check
         if (command.length && command[0] !== "cd") {
           patterns.add(commandText)
           always.add(BashArity.prefix(command).join(" ") + " *")
         }
       }
+
+      // kilocode_change start - governed agent protocol: check for destructive commands
+      const { GovernanceIntegration } = await import("../governance/integration")
+      const govCheck = GovernanceIntegration.checkBash(params.command, governanceTokenSets)
+      if (!govCheck.allowed) {
+        return {
+          title: "[governance] blocked",
+          metadata: {
+            output: govCheck.output!,
+            exit: 1,
+            description: params.description,
+          },
+          output: govCheck.output!,
+        }
+      }
+      // kilocode_change end
 
       if (directories.size > 0) {
         const globs = Array.from(directories).map((dir) => path.join(dir, "*"))
@@ -254,6 +277,12 @@ export const BashTool = Tool.define("bash", async () => {
       if (resultMetadata.length > 0) {
         output += "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
       }
+
+      // kilocode_change start - governed agent protocol: append warnings for medium severity
+      if (govCheck.warnings) {
+        output += "\n\n" + govCheck.warnings
+      }
+      // kilocode_change end
 
       return {
         title: params.description,

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -42,6 +42,23 @@ export const EditTool = Tool.define("edit", {
     }
 
     const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+
+    // kilocode_change start - governed agent protocol: check write path
+    const { GovernanceIntegration } = await import("../governance/integration")
+    const govCheck = GovernanceIntegration.checkWritePath(filePath, Instance.directory)
+    if (!govCheck.allowed) {
+      return {
+        title: "[governance] blocked",
+        metadata: {
+          diagnostics: {},
+          diff: "",
+          filediff: { file: filePath, before: "", after: "", additions: 0, deletions: 0 },
+        },
+        output: govCheck.output!,
+      }
+    }
+    // kilocode_change end
+
     await assertExternalDirectory(ctx, filePath)
 
     let diff = ""

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -24,6 +24,23 @@ export const WriteTool = Tool.define("write", {
   }),
   async execute(params, ctx) {
     const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+
+    // kilocode_change start - governed agent protocol: check write path
+    const { GovernanceIntegration } = await import("../governance/integration")
+    const govCheck = GovernanceIntegration.checkWritePath(filepath, Instance.directory)
+    if (!govCheck.allowed) {
+      return {
+        title: "[governance] blocked",
+        metadata: {
+          diagnostics: {},
+          filepath,
+          exists: false,
+        },
+        output: govCheck.output!,
+      }
+    }
+    // kilocode_change end
+
     await assertExternalDirectory(ctx, filepath)
 
     const file = Bun.file(filepath)

--- a/packages/opencode/test/governance/demo.ts
+++ b/packages/opencode/test/governance/demo.ts
@@ -1,0 +1,207 @@
+/**
+ * Governed Agent Protocol — Standalone Demo
+ *
+ * Run: bun run test/governance/demo.ts
+ *
+ * Exercises the governance engine against a range of commands
+ * showing BLOCKED, WARNED, and ALLOWED outcomes.
+ */
+
+import { GovernanceDetector } from "../../src/governance/detector"
+import { GovernanceIntegration } from "../../src/governance/integration"
+import { PathGuard } from "../../src/governance/path-guard"
+
+// ── Helpers ─────────────────────────────────────────────
+
+function header(text: string) {
+  console.log(`\n${"═".repeat(60)}`)
+  console.log(`  ${text}`)
+  console.log(`${"═".repeat(60)}`)
+}
+
+function demo(label: string, command: string, tokens?: string[][]) {
+  const t = tokens ?? [command.split(/\s+/)]
+  const result = GovernanceDetector.checkBashCommand(command, t)
+
+  const status = !result.allowed
+    ? "\x1b[31mBLOCKED\x1b[0m"
+    : result.verdicts.length > 0
+      ? "\x1b[33mWARNED\x1b[0m"
+      : "\x1b[32mALLOWED\x1b[0m"
+
+  console.log(`\n  [${status}] ${label}`)
+  console.log(`    Command: ${command}`)
+
+  if (result.verdicts.length > 0) {
+    for (const v of result.verdicts) {
+      console.log(`    Severity: ${v.severity.toUpperCase()} | Category: ${v.category}`)
+      console.log(`    Reason: ${v.reason}`)
+      if (v.suggestion) console.log(`    Suggest: ${v.suggestion}`)
+    }
+  }
+}
+
+function demoPath(label: string, filepath: string, project: string) {
+  const result = PathGuard.checkWritePath(filepath, project)
+
+  const status = !result.allowed
+    ? "\x1b[31mBLOCKED\x1b[0m"
+    : "\x1b[32mALLOWED\x1b[0m"
+
+  console.log(`\n  [${status}] ${label}`)
+  console.log(`    Path: ${filepath}`)
+
+  if (result.verdicts.length > 0) {
+    for (const v of result.verdicts) {
+      console.log(`    Severity: ${v.severity.toUpperCase()} | Category: ${v.category}`)
+      console.log(`    Reason: ${v.reason}`)
+    }
+  }
+}
+
+// ── Demo ────────────────────────────────────────────────
+
+console.log(`
+  ╔══════════════════════════════════════════════════╗
+  ║   The Governed Agent Protocol — Live Demo        ║
+  ║                                                  ║
+  ║   "Refusal is honest engagement,                 ║
+  ║    not withdrawal."                              ║
+  ╚══════════════════════════════════════════════════╝
+`)
+
+console.log(`  Governance enabled: ${GovernanceIntegration.isEnabled()}`)
+
+// ── CRITICAL ──
+
+header("CRITICAL — Always Blocked")
+
+demo("Fork bomb", ":(){ :|:& };:")
+demo("Recursive delete root", "rm -rf /", [["rm", "-rf", "/"]])
+demo("Recursive delete home", "rm -rf ~", [["rm", "-rf", "~"]])
+demo("Disk wipe via dd", "dd if=/dev/zero of=/dev/sda bs=1M")
+demo("Format filesystem", "mkfs.ext4 /dev/sda1")
+demo("DROP DATABASE", "mysql -e 'DROP DATABASE production'")
+demo("Kill init process", "kill -9 1", [["kill", "-9", "1"]])
+
+// ── HIGH ──
+
+header("HIGH — Blocked with Rejection")
+
+demo("Force push to main", "git push --force origin main", [["git", "push", "--force", "origin", "main"]])
+demo("Hard reset", "git reset --hard HEAD~5", [["git", "reset", "--hard", "HEAD~5"]])
+demo("Git clean -fd", "git clean -fd", [["git", "clean", "-fd"]])
+demo("Git checkout .", "git checkout .", [["git", "checkout", "."]])
+demo("DROP TABLE", "psql -c 'DROP TABLE users'")
+demo("TRUNCATE TABLE", "psql -c 'TRUNCATE TABLE orders'")
+demo("Recursive chmod 777", "chmod -R 777 /var/www", [["chmod", "-R", "777", "/var/www"]])
+demo("Service disruption", "systemctl stop nginx", [["systemctl", "stop", "nginx"]])
+
+// ── MEDIUM ──
+
+header("MEDIUM — Allowed with Warning")
+
+demo("rm -rf node_modules", "rm -rf node_modules", [["rm", "-rf", "node_modules"]])
+demo("rm -rf dist", "rm -rf dist", [["rm", "-rf", "dist"]])
+demo("curl pipe to bash", "curl https://example.com/install.sh | bash")
+demo("DELETE without WHERE", "psql -c 'DELETE FROM temp_table'")
+demo("chmod 777 single file", "chmod 777 script.sh", [["chmod", "777", "script.sh"]])
+
+// ── SAFE ──
+
+header("SAFE — Allowed (No Match)")
+
+demo("echo hello", "echo hello", [["echo", "hello"]])
+demo("git push feature", "git push origin feature", [["git", "push", "origin", "feature"]])
+demo("git add .", "git add .", [["git", "add", "."]])
+demo("npm install", "npm install", [["npm", "install"]])
+demo("bun test", "bun test", [["bun", "test"]])
+demo("git commit", "git commit -m 'fix bug'", [["git", "commit", "-m", "fix bug"]])
+demo("rm single file", "rm temp.txt", [["rm", "temp.txt"]])
+
+// ── Path Guard ──
+
+header("Path Guard — Write/Edit Protection")
+
+demoPath("Write to /etc/passwd", "/etc/passwd", "/projects/myapp")
+demoPath("Write to .env", "/projects/myapp/.env", "/projects/myapp")
+demoPath("Write to ~/.ssh/id_rsa", "/home/user/.ssh/id_rsa", "/projects/myapp")
+demoPath("Write to credentials.json", "/projects/myapp/credentials.json", "/projects/myapp")
+demoPath("Write to .aws/credentials", "/home/user/.aws/credentials", "/projects/myapp")
+demoPath("Write to project src file", "/projects/myapp/src/index.ts", "/projects/myapp")
+demoPath("Write to tsconfig.json", "/projects/myapp/tsconfig.json", "/projects/myapp")
+demoPath("Write to README.md", "/projects/myapp/README.md", "/projects/myapp")
+
+// ── Integration Bridge ──
+
+header("Integration Bridge — Full Check")
+
+const check1 = GovernanceIntegration.checkBash("rm -rf /", [["rm", "-rf", "/"]])
+console.log(`\n  rm -rf / → allowed: ${check1.allowed}`)
+if (check1.output) {
+  console.log(`  Output preview: ${check1.output.split("\n")[0]}`)
+}
+
+const check2 = GovernanceIntegration.checkBash("rm -rf node_modules", [["rm", "-rf", "node_modules"]])
+console.log(`\n  rm -rf node_modules → allowed: ${check2.allowed}, has warnings: ${!!check2.warnings}`)
+
+const check3 = GovernanceIntegration.checkBash("echo hello", [["echo", "hello"]])
+console.log(`\n  echo hello → allowed: ${check3.allowed}, warnings: ${check3.warnings ?? "none"}`)
+
+const check4 = GovernanceIntegration.checkWritePath("/etc/passwd", "/projects/myapp")
+console.log(`\n  write /etc/passwd → allowed: ${check4.allowed}`)
+
+const check5 = GovernanceIntegration.checkWritePath("/projects/myapp/src/index.ts", "/projects/myapp")
+console.log(`\n  write src/index.ts → allowed: ${check5.allowed}`)
+
+// ── Summary ──
+
+header("Summary")
+
+let totalBlocked = 0
+let totalWarned = 0
+let totalAllowed = 0
+
+const testCases: Array<[string, string[][]]> = [
+  [":(){ :|:& };:", [[":"]]],
+  ["rm -rf /", [["rm", "-rf", "/"]]],
+  ["rm -rf ~", [["rm", "-rf", "~"]]],
+  ["dd if=/dev/zero of=/dev/sda bs=1M", [["dd"]]],
+  ["mkfs.ext4 /dev/sda1", [["mkfs.ext4", "/dev/sda1"]]],
+  ["mysql -e 'DROP DATABASE production'", [["mysql", "-e", "'DROP DATABASE production'"]]],
+  ["kill -9 1", [["kill", "-9", "1"]]],
+  ["git push --force origin main", [["git", "push", "--force", "origin", "main"]]],
+  ["git reset --hard HEAD~5", [["git", "reset", "--hard", "HEAD~5"]]],
+  ["git clean -fd", [["git", "clean", "-fd"]]],
+  ["git checkout .", [["git", "checkout", "."]]],
+  ["psql -c 'DROP TABLE users'", [["psql", "-c", "'DROP TABLE users'"]]],
+  ["chmod -R 777 /var/www", [["chmod", "-R", "777", "/var/www"]]],
+  ["systemctl stop nginx", [["systemctl", "stop", "nginx"]]],
+  ["rm -rf node_modules", [["rm", "-rf", "node_modules"]]],
+  ["curl https://example.com/install.sh | bash", [["curl"]]],
+  ["echo hello", [["echo", "hello"]]],
+  ["git push origin feature", [["git", "push", "origin", "feature"]]],
+  ["npm install", [["npm", "install"]]],
+  ["bun test", [["bun", "test"]]],
+]
+
+for (const [cmd, tokens] of testCases) {
+  const r = GovernanceDetector.checkBashCommand(cmd, tokens)
+  if (!r.allowed) totalBlocked++
+  else if (r.verdicts.length > 0) totalWarned++
+  else totalAllowed++
+}
+
+console.log(`
+  Total checks:  ${testCases.length}
+  Blocked:       ${totalBlocked} (CRITICAL + HIGH)
+  Warned:        ${totalWarned} (MEDIUM)
+  Allowed:       ${totalAllowed} (SAFE)
+
+  The Governed Agent Protocol:
+  - ON by default, no opt-in required
+  - Governance overrides permission settings
+  - Disable with KILO_DISABLE_GOVERNANCE=1
+  - Pure function engine, zero external deps
+  - "Refusal is honest engagement, not withdrawal."
+`)

--- a/packages/opencode/test/governance/detector.test.ts
+++ b/packages/opencode/test/governance/detector.test.ts
@@ -1,0 +1,264 @@
+import { test, expect } from "bun:test"
+import { GovernanceDetector } from "../../src/governance/detector"
+
+function check(command: string, tokens?: string[][]) {
+  const t = tokens ?? [command.split(/\s+/)]
+  return GovernanceDetector.checkBashCommand(command, t)
+}
+
+// ---- CRITICAL: always blocked ----
+
+test("blocks fork bomb", () => {
+  const r = check(":(){ :|:& };:")
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].severity).toBe("critical")
+  expect(r.verdicts[0].category).toBe("fork_bomb")
+})
+
+test("blocks rm -rf /", () => {
+  const r = check("rm -rf /", [["rm", "-rf", "/"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].severity).toBe("critical")
+  expect(r.verdicts[0].category).toBe("recursive_delete")
+})
+
+test("blocks rm -rf /*", () => {
+  const r = check("rm -rf /*", [["rm", "-rf", "/*"]])
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks rm -rf ~", () => {
+  const r = check("rm -rf ~", [["rm", "-rf", "~"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("recursive_delete")
+})
+
+test("blocks rm -rf $HOME", () => {
+  const r = check("rm -rf $HOME", [["rm", "-rf", "$HOME"]])
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks dd to block device", () => {
+  const r = check("dd if=/dev/zero of=/dev/sda bs=1M")
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("disk_wipe")
+})
+
+test("blocks dd from /dev/zero to file", () => {
+  const r = check("dd if=/dev/zero of=disk.img bs=1M count=100")
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks mkfs", () => {
+  const r = check("mkfs.ext4 /dev/sda1")
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("disk_wipe")
+})
+
+test("blocks redirect to block device", () => {
+  const r = check("echo > /dev/sda")
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks DROP DATABASE", () => {
+  const r = check("mysql -e 'DROP DATABASE production'")
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("sql_drop")
+})
+
+test("blocks kill PID 1", () => {
+  const r = check("kill -9 1", [["kill", "-9", "1"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("service_disruption")
+})
+
+// ---- HIGH: blocked ----
+
+test("blocks git push --force main", () => {
+  const r = check("git push --force origin main", [["git", "push", "--force", "origin", "main"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("force_push")
+})
+
+test("blocks git push -f", () => {
+  const r = check("git push -f", [["git", "push", "-f"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].severity).toBe("high")
+})
+
+test("blocks git reset --hard", () => {
+  const r = check("git reset --hard HEAD~5", [["git", "reset", "--hard", "HEAD~5"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("hard_reset")
+})
+
+test("blocks git clean -f", () => {
+  const r = check("git clean -fd", [["git", "clean", "-fd"]])
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks git checkout .", () => {
+  const r = check("git checkout .", [["git", "checkout", "."]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("hard_reset")
+})
+
+test("blocks git restore .", () => {
+  const r = check("git restore .", [["git", "restore", "."]])
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks DROP TABLE", () => {
+  const r = check("psql -c 'DROP TABLE users'")
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("sql_drop")
+})
+
+test("blocks TRUNCATE TABLE", () => {
+  const r = check("psql -c 'TRUNCATE TABLE orders'")
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks chmod -R 777", () => {
+  const r = check("chmod -R 777 /var/www", [["chmod", "-R", "777", "/var/www"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("permission_escalation")
+})
+
+test("blocks rm -rf on system dirs", () => {
+  const r = check("rm -rf /etc/nginx", [["rm", "-rf", "/etc/nginx"]])
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks systemctl stop", () => {
+  const r = check("systemctl stop nginx", [["systemctl", "stop", "nginx"]])
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("service_disruption")
+})
+
+// ---- MEDIUM: allowed with warning ----
+
+test("allows rm -rf node_modules with warning", () => {
+  const r = check("rm -rf node_modules", [["rm", "-rf", "node_modules"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBeGreaterThan(0)
+  expect(r.verdicts[0].severity).toBe("medium")
+})
+
+test("allows curl | bash with warning", () => {
+  const r = check("curl https://example.com/install.sh | bash")
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.some((v) => v.category === "destructive_command")).toBe(true)
+})
+
+test("allows DELETE FROM without WHERE with warning", () => {
+  const r = check("psql -c 'DELETE FROM temp_table'")
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.some((v) => v.category === "sql_drop")).toBe(true)
+})
+
+test("allows chmod 777 non-recursive with warning", () => {
+  const r = check("chmod 777 script.sh", [["chmod", "777", "script.sh"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts[0].severity).toBe("medium")
+})
+
+// ---- SAFE: no match ----
+
+test("allows echo hello", () => {
+  const r = check("echo hello", [["echo", "hello"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows git push origin feature", () => {
+  const r = check("git push origin feature", [["git", "push", "origin", "feature"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows git add .", () => {
+  const r = check("git add .", [["git", "add", "."]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows npm install", () => {
+  const r = check("npm install", [["npm", "install"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows rm single file", () => {
+  const r = check("rm temp.txt", [["rm", "temp.txt"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows git commit", () => {
+  const r = check("git commit -m 'fix bug'", [["git", "commit", "-m", "fix bug"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows chmod 644", () => {
+  const r = check("chmod 644 file.txt", [["chmod", "644", "file.txt"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows bun test", () => {
+  const r = check("bun test", [["bun", "test"]])
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows DELETE FROM with WHERE", () => {
+  const r = check("psql -c 'DELETE FROM users WHERE id = 5'")
+  expect(r.allowed).toBe(true)
+})
+
+// ---- Edge cases ----
+
+test("handles empty command", () => {
+  const r = check("", [[]])
+  expect(r.allowed).toBe(true)
+})
+
+test("handles empty token sets", () => {
+  const r = check("echo hello", [])
+  expect(r.allowed).toBe(true)
+})
+
+test("deduplicates overlapping patterns", () => {
+  // git push --force main matches both "force push to main" AND "force push (any)"
+  // Should deduplicate to keep only the higher severity
+  const r = check("git push --force origin main", [["git", "push", "--force", "origin", "main"]])
+  expect(r.allowed).toBe(false)
+  const forcePushVerdicts = r.verdicts.filter((v) => v.category === "force_push")
+  expect(forcePushVerdicts.length).toBe(1)
+})
+
+// ---- Format output ----
+
+test("formatRejection includes severity and reason", () => {
+  const r = check("rm -rf /", [["rm", "-rf", "/"]])
+  const msg = GovernanceDetector.formatRejection(r.verdicts)
+  expect(msg).toContain("[governance]")
+  expect(msg).toContain("CRITICAL")
+  expect(msg).toContain("Recursive deletion")
+})
+
+test("formatWarnings wraps in governance_warning tags", () => {
+  const r = check("rm -rf dist", [["rm", "-rf", "dist"]])
+  const msg = GovernanceDetector.formatWarnings(r.verdicts)
+  expect(msg).toContain("<governance_warning>")
+  expect(msg).toContain("</governance_warning>")
+})
+
+test("formatRejection includes suggestion when available", () => {
+  const r = check("git reset --hard HEAD", [["git", "reset", "--hard", "HEAD"]])
+  const msg = GovernanceDetector.formatRejection(r.verdicts)
+  expect(msg).toContain("Suggest:")
+  expect(msg).toContain("git stash")
+})

--- a/packages/opencode/test/governance/integration.test.ts
+++ b/packages/opencode/test/governance/integration.test.ts
@@ -1,0 +1,93 @@
+import { test, expect, beforeEach, afterEach } from "bun:test"
+import { GovernanceIntegration } from "../../src/governance/integration"
+
+let origDisable: string | undefined
+
+beforeEach(() => {
+  origDisable = process.env.KILO_DISABLE_GOVERNANCE
+  delete process.env.KILO_DISABLE_GOVERNANCE
+})
+
+afterEach(() => {
+  if (origDisable !== undefined) {
+    process.env.KILO_DISABLE_GOVERNANCE = origDisable
+  } else {
+    delete process.env.KILO_DISABLE_GOVERNANCE
+  }
+})
+
+// ---- Feature toggle ----
+
+test("isEnabled returns true by default", () => {
+  expect(GovernanceIntegration.isEnabled()).toBe(true)
+})
+
+test("isEnabled returns false when KILO_DISABLE_GOVERNANCE=1", () => {
+  process.env.KILO_DISABLE_GOVERNANCE = "1"
+  expect(GovernanceIntegration.isEnabled()).toBe(false)
+})
+
+test("allows everything when governance disabled", () => {
+  process.env.KILO_DISABLE_GOVERNANCE = "1"
+  const r = GovernanceIntegration.checkBash("rm -rf /", [["rm", "-rf", "/"]])
+  expect(r.allowed).toBe(true)
+})
+
+test("allows write to .env when governance disabled", () => {
+  process.env.KILO_DISABLE_GOVERNANCE = "1"
+  const r = GovernanceIntegration.checkWritePath("/projects/.env", "/projects")
+  expect(r.allowed).toBe(true)
+})
+
+// ---- Bash checks ----
+
+test("blocks destructive bash when enabled", () => {
+  const r = GovernanceIntegration.checkBash("rm -rf /", [["rm", "-rf", "/"]])
+  expect(r.allowed).toBe(false)
+  expect(r.output).toContain("[governance]")
+})
+
+test("allows safe bash when enabled", () => {
+  const r = GovernanceIntegration.checkBash("echo hello", [["echo", "hello"]])
+  expect(r.allowed).toBe(true)
+  expect(r.output).toBeUndefined()
+})
+
+test("returns warnings for medium severity", () => {
+  const r = GovernanceIntegration.checkBash("rm -rf dist", [["rm", "-rf", "dist"]])
+  expect(r.allowed).toBe(true)
+  expect(r.warnings).toContain("governance_warning")
+})
+
+// ---- Write path checks ----
+
+test("blocks write to /etc/passwd", () => {
+  const r = GovernanceIntegration.checkWritePath("/etc/passwd", "/projects/myapp")
+  expect(r.allowed).toBe(false)
+  expect(r.output).toContain("[governance]")
+})
+
+test("blocks write to .env", () => {
+  const r = GovernanceIntegration.checkWritePath("/projects/myapp/.env", "/projects/myapp")
+  expect(r.allowed).toBe(false)
+})
+
+test("allows write to project file", () => {
+  const r = GovernanceIntegration.checkWritePath("/projects/myapp/src/index.ts", "/projects/myapp")
+  expect(r.allowed).toBe(true)
+})
+
+// ---- Output quality ----
+
+test("rejection output includes severity and reason", () => {
+  const r = GovernanceIntegration.checkBash("git reset --hard", [["git", "reset", "--hard"]])
+  expect(r.allowed).toBe(false)
+  expect(r.output).toContain("HIGH")
+  expect(r.output).toContain("git reset --hard")
+  expect(r.output).toContain("Suggest:")
+})
+
+test("rejection output mentions override mechanism", () => {
+  const r = GovernanceIntegration.checkBash("rm -rf /", [["rm", "-rf", "/"]])
+  expect(r.output).toContain("KILO_DISABLE_GOVERNANCE")
+})

--- a/packages/opencode/test/governance/path-guard.test.ts
+++ b/packages/opencode/test/governance/path-guard.test.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "bun:test"
+import { PathGuard } from "../../src/governance/path-guard"
+
+const PROJECT = "/projects/myapp"
+
+// ---- System paths ----
+
+test("blocks write to /etc/passwd", () => {
+  const r = PathGuard.checkWritePath("/etc/passwd", PROJECT)
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("system_path_write")
+})
+
+test("blocks write to /usr/local/bin/script", () => {
+  const r = PathGuard.checkWritePath("/usr/local/bin/script.sh", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to /boot/grub/grub.cfg", () => {
+  const r = PathGuard.checkWritePath("/boot/grub/grub.cfg", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to /bin/sh", () => {
+  const r = PathGuard.checkWritePath("/bin/sh", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+// ---- Credential files ----
+
+test("blocks write to .env", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/.env", PROJECT)
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].category).toBe("credential_exposure")
+})
+
+test("blocks write to .env.production", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/.env.production", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to id_rsa", () => {
+  const r = PathGuard.checkWritePath("/home/user/.ssh/id_rsa", PROJECT)
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts.some((v) => v.category === "credential_exposure")).toBe(true)
+})
+
+test("blocks write to credentials.json", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/credentials.json", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to secrets.yaml", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/secrets.yaml", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to private.pem", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/private.pem", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to .htpasswd", () => {
+  const r = PathGuard.checkWritePath("/var/www/.htpasswd", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+// ---- Credential directories ----
+
+test("blocks write to .ssh/config", () => {
+  const r = PathGuard.checkWritePath("/home/user/.ssh/config", PROJECT)
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts.some((v) => v.pattern === "credential_directory")).toBe(true)
+})
+
+test("blocks write to .aws/credentials", () => {
+  const r = PathGuard.checkWritePath("/home/user/.aws/credentials", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to .gnupg/pubring.kbx", () => {
+  const r = PathGuard.checkWritePath("/home/user/.gnupg/pubring.kbx", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+test("blocks write to .kube/config", () => {
+  const r = PathGuard.checkWritePath("/home/user/.kube/config", PROJECT)
+  expect(r.allowed).toBe(false)
+})
+
+// ---- Safe paths ----
+
+test("allows write to project src file", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/src/index.ts", PROJECT)
+  expect(r.allowed).toBe(true)
+  expect(r.verdicts.length).toBe(0)
+})
+
+test("allows write to project config file", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/tsconfig.json", PROJECT)
+  expect(r.allowed).toBe(true)
+})
+
+test("allows write to README", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/README.md", PROJECT)
+  expect(r.allowed).toBe(true)
+})
+
+test("allows write to test file", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/test/auth.test.ts", PROJECT)
+  expect(r.allowed).toBe(true)
+})
+
+test("allows write to package.json", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/package.json", PROJECT)
+  expect(r.allowed).toBe(true)
+})
+
+// ---- Rejection message quality ----
+
+test("rejection includes suggestion", () => {
+  const r = PathGuard.checkWritePath("/etc/nginx/nginx.conf", PROJECT)
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].suggestion).toBeDefined()
+})
+
+test("credential file rejection includes suggestion", () => {
+  const r = PathGuard.checkWritePath("/projects/myapp/.env", PROJECT)
+  expect(r.allowed).toBe(false)
+  expect(r.verdicts[0].suggestion).toContain("environment variables")
+})


### PR DESCRIPTION
> **Kilo League Challenge #3 — DeveloperWeek 2026 Hackathon Entry**

## The Governed Agent Protocol

A hard safety layer that blocks destructive commands **before execution**, regardless of permission settings. ON by default — no opt-in required.

### The Problem

Kilo's safety model is almost entirely soft. System prompts tell the LLM "don't run `git reset --hard`" but nothing in code enforces it. If a user grants `bash:*` permission (or the LLM social-engineers approval), any command executes — `rm -rf /`, `DROP DATABASE`, fork bombs, anything.

### The Solution

A pure-function detection engine that intercepts tool calls **before** permission checks. Governance overrides permissions.

### Three Severity Levels

| Level | Behavior | Examples |
|-------|----------|---------|
| **CRITICAL** | Always blocked | `rm -rf /`, fork bomb, `dd of=/dev/sda`, `DROP DATABASE`, `mkfs`, `kill 1` |
| **HIGH** | Blocked with rejection | `git push --force`, `git reset --hard`, `git clean -f`, `DROP TABLE`, `chmod -R 777` |
| **MEDIUM** | Warns, allows execution | `rm -rf node_modules`, `curl \| bash`, `DELETE FROM` without WHERE |

### Path Guard (Write/Edit Protection)

| Category | Patterns |
|----------|---------|
| System paths | `/etc/`, `/usr/`, `/boot/`, `C:\Windows\` |
| Credential files | `.env`, `id_rsa`, `credentials.json`, `secrets.*`, `private.pem` |
| Credential dirs | `.ssh/`, `.aws/`, `.gnupg/`, `.kube/`, `.docker/` |

### Architecture

```
governance/
  types.ts          — Zod schemas (Severity, Category, Verdict, CheckResult)
  patterns.ts       — ~30 destructive patterns across 3 severity levels
  detector.ts       — Pure function engine: checkBashCommand(), formatRejection()
  path-guard.ts     — Sensitive path protection for write/edit tools
  integration.ts    — Bridge module (lazy import, zero overhead when disabled)
  index.ts          — Barrel export
```

### Integration Points

- **bash.ts** — Intercepts after tree-sitter AST parsing, before `ctx.ask()` permission checks
- **write.ts** — Intercepts after filepath resolution, before `assertExternalDirectory()`
- **edit.ts** — Same as write.ts
- **flag.ts** — `KILO_DISABLE_GOVERNANCE` flag added

### Key Design Decisions

- **ON by default** — Unlike `--warm`, governance doesn't need a flag to activate
- **Pure functions** — Detector is stateless, fully synchronous, trivially testable
- **Governance overrides permissions** — Check happens BEFORE `ctx.ask()`, so even `bash:*` allowall can't bypass it
- **Lazy import** — `await import("../governance/integration")` keeps zero overhead for disabled state
- **Rejection messages include suggestions** — "Refusal is honest engagement, not withdrawal"

### Test Results

- 75 governance tests passing across 3 test files
- Standalone demo exercising all severity levels + path guard
- Pre-existing typecheck errors in `kilo-sessions` (unrelated `simple-git` missing types)

### Run the Demo

```bash
cd packages/opencode
bun run test/governance/demo.ts
```

### Philosophy

> "Refusal is honest engagement, not withdrawal. When an AI system says no to a destructive command, it isn't failing — it's succeeding at the deeper task of responsible operation."

The Governed Agent Protocol treats safety as a first-class outcome, not an afterthought. Blocking `rm -rf /` isn't an error state — it's the system working exactly as designed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)