### PR TITLE
feat: Windows Explorer context menu — one-click install on first launch

### DIFF
--- a/packages/opencode/src/cli/cmd/windows.ts
+++ b/packages/opencode/src/cli/cmd/windows.ts
@@ -1,0 +1,100 @@
+import { cmd } from "./cmd"
+import * as prompts from "@clack/prompts"
+import { UI } from "../ui"
+import { WindowsRegistry } from "../../windows-context-menu/registry"
+
+// kilocode_change - Windows-specific CLI commands
+
+const InstallContextMenuCommand = cmd({
+  command: "install-context-menu",
+  describe: "add 'Open Kilo CLI Here' to Windows Explorer right-click menu",
+  handler: async () => {
+    if (process.platform !== "win32") {
+      prompts.log.warn("Context menu integration is only available on Windows.")
+      return
+    }
+
+    UI.empty()
+    prompts.intro("Install Explorer Context Menu")
+
+    const already = await WindowsRegistry.isInstalled()
+    if (already) {
+      prompts.log.info("Context menu is already installed.")
+      prompts.outro("Nothing to do")
+      return
+    }
+
+    const spinner = prompts.spinner()
+    spinner.start("Registering context menu entries...")
+
+    const results = await WindowsRegistry.install(process.execPath)
+    const failed = results.filter((r) => !r.success)
+
+    if (failed.length === 0) {
+      spinner.stop("Installed successfully")
+      UI.empty()
+      prompts.log.success("Right-click any folder in Explorer to see 'Open Kilo CLI Here'")
+      prompts.log.info("Entries registered:")
+      prompts.log.info("  - Folder background (right-click empty space)")
+      prompts.log.info("  - Folder (right-click a folder)")
+      prompts.log.info("  - Drive (right-click a drive)")
+    } else {
+      spinner.stop("Some entries failed", 1)
+      for (const f of failed) {
+        prompts.log.error(`  ${f.target}: ${f.error}`)
+      }
+    }
+
+    prompts.outro("Done")
+  },
+})
+
+const RemoveContextMenuCommand = cmd({
+  command: "remove-context-menu",
+  describe: "remove 'Open Kilo CLI Here' from Windows Explorer right-click menu",
+  handler: async () => {
+    if (process.platform !== "win32") {
+      prompts.log.warn("Context menu integration is only available on Windows.")
+      return
+    }
+
+    UI.empty()
+    prompts.intro("Remove Explorer Context Menu")
+
+    const installed = await WindowsRegistry.isInstalled()
+    if (!installed) {
+      prompts.log.info("Context menu is not currently installed.")
+      prompts.outro("Nothing to do")
+      return
+    }
+
+    const spinner = prompts.spinner()
+    spinner.start("Removing context menu entries...")
+
+    const results = await WindowsRegistry.uninstall()
+    const failed = results.filter((r) => !r.success)
+
+    if (failed.length === 0) {
+      spinner.stop("Removed successfully")
+      prompts.log.success("Explorer context menu entries have been removed.")
+    } else {
+      spinner.stop("Some entries failed to remove", 1)
+      for (const f of failed) {
+        prompts.log.error(`  ${f.target}: ${f.error}`)
+      }
+    }
+
+    prompts.outro("Done")
+  },
+})
+
+export const WindowsCommand = cmd({
+  command: "windows",
+  describe: "Windows-specific integrations",
+  builder: (yargs) =>
+    yargs
+      .command(InstallContextMenuCommand)
+      .command(RemoveContextMenuCommand)
+      .demandCommand(),
+  async handler() {},
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -26,6 +26,7 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
+import { WindowsCommand } from "./cli/cmd/windows" // kilocode_change - Windows context menu
 // kilocode_change start - Import telemetry and legacy migration
 import { Telemetry } from "@kilocode/kilo-telemetry"
 import { migrateLegacyKiloAuth, ENV_FEATURE } from "@kilocode/kilo-gateway"
@@ -114,6 +115,15 @@ const cli = yargs(hideBin(process.argv))
 
     Telemetry.trackCliStart()
     // kilocode_change end
+
+    // kilocode_change start - first-launch context menu prompt (Windows only)
+    if (process.platform === "win32") {
+      const { FirstLaunch } = await import("./windows-context-menu/first-launch")
+      if (await FirstLaunch.shouldPrompt()) {
+        await FirstLaunch.prompt()
+      }
+    }
+    // kilocode_change end
   })
   .usage("\n" + UI.logo())
   .completion("completion", "generate shell completion script")
@@ -137,6 +147,7 @@ const cli = yargs(hideBin(process.argv))
   // .command(GithubCommand) // kilocode_change (Disabled until backend is ready)
   .command(PrCommand)
   .command(SessionCommand)
+  .command(WindowsCommand) // kilocode_change - Windows context menu
   .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||

--- a/packages/opencode/src/windows-context-menu/first-launch.ts
+++ b/packages/opencode/src/windows-context-menu/first-launch.ts
@@ -1,0 +1,62 @@
+import path from "path"
+import * as prompts from "@clack/prompts"
+import { Global } from "../global"
+import { WindowsRegistry } from "./registry"
+
+// kilocode_change - First-launch context menu prompt for Windows
+
+const FLAG_FILE = ".context-menu-offered"
+
+export namespace FirstLaunch {
+  function flagPath(): string {
+    return path.join(Global.Path.data, FLAG_FILE)
+  }
+
+  export async function shouldPrompt(): Promise<boolean> {
+    if (process.platform !== "win32") return false
+
+    const offered = await Bun.file(flagPath()).exists()
+    if (offered) return false
+
+    const installed = await WindowsRegistry.isInstalled()
+    if (installed) {
+      await markOffered()
+      return false
+    }
+
+    return true
+  }
+
+  export async function markOffered(): Promise<void> {
+    await Bun.write(flagPath(), new Date().toISOString())
+  }
+
+  export async function prompt(): Promise<void> {
+    const confirm = await prompts.confirm({
+      message: "Add Kilo to your Windows Explorer right-click menu?",
+      initialValue: true,
+    })
+
+    if (prompts.isCancel(confirm) || !confirm) {
+      await markOffered()
+      return
+    }
+
+    const spinner = prompts.spinner()
+    spinner.start("Installing context menu entries...")
+
+    const results = await WindowsRegistry.install(process.execPath)
+    const failed = results.filter((r) => !r.success)
+
+    if (failed.length === 0) {
+      spinner.stop("Context menu installed — right-click any folder in Explorer!")
+    } else {
+      spinner.stop("Some entries failed to install", 1)
+      for (const f of failed) {
+        prompts.log.warn(`  ${f.target}: ${f.error}`)
+      }
+    }
+
+    await markOffered()
+  }
+}

--- a/packages/opencode/src/windows-context-menu/index.ts
+++ b/packages/opencode/src/windows-context-menu/index.ts
@@ -1,0 +1,4 @@
+// kilocode_change - Windows Explorer context menu integration
+export { ContextMenu } from "./types"
+export { WindowsRegistry } from "./registry"
+export { FirstLaunch } from "./first-launch"

--- a/packages/opencode/src/windows-context-menu/registry.ts
+++ b/packages/opencode/src/windows-context-menu/registry.ts
@@ -1,0 +1,94 @@
+import { $ } from "bun"
+import { ContextMenu } from "./types"
+
+// kilocode_change - Windows Explorer context menu registry operations
+
+export namespace WindowsRegistry {
+  export function buildInstallCommands(execPath: string): ContextMenu.RegistryCommand[] {
+    const quoted = `"${execPath}"`
+    const commands: ContextMenu.RegistryCommand[] = []
+
+    for (const target of ContextMenu.RegistryTarget.options) {
+      const key = ContextMenu.REGISTRY_KEYS[target]
+      const commandKey = `${key}\\command`
+      const arg = target === "background" ? "%V" : "%1"
+
+      commands.push({
+        target,
+        args: ["reg", "add", key, "/ve", "/d", ContextMenu.LABEL, "/f"],
+        description: `Set label for ${target}`,
+      })
+      commands.push({
+        target,
+        args: ["reg", "add", key, "/v", "Icon", "/d", quoted, "/f"],
+        description: `Set icon for ${target}`,
+      })
+      commands.push({
+        target,
+        args: ["reg", "add", commandKey, "/ve", "/d", `${quoted} "${arg}"`, "/f"],
+        description: `Set command for ${target}`,
+      })
+    }
+
+    return commands
+  }
+
+  export function buildUninstallCommands(): ContextMenu.RegistryCommand[] {
+    return ContextMenu.RegistryTarget.options.map((target) => ({
+      target,
+      args: ["reg", "delete", ContextMenu.REGISTRY_KEYS[target], "/f"],
+      description: `Remove ${target} context menu entry`,
+    }))
+  }
+
+  export async function install(execPath: string): Promise<ContextMenu.InstallResult[]> {
+    const commands = buildInstallCommands(execPath)
+    const results: ContextMenu.InstallResult[] = []
+
+    for (const target of ContextMenu.RegistryTarget.options) {
+      const targetCmds = commands.filter((c) => c.target === target)
+      let failed = false
+      for (const cmd of targetCmds) {
+        try {
+          const result = await $`${cmd.args}`.quiet().nothrow()
+          if (result.exitCode !== 0) {
+            results.push({ target, success: false, error: result.stderr.toString().trim() })
+            failed = true
+            break
+          }
+        } catch (e) {
+          results.push({ target, success: false, error: e instanceof Error ? e.message : String(e) })
+          failed = true
+          break
+        }
+      }
+      if (!failed) {
+        results.push({ target, success: true })
+      }
+    }
+
+    return results
+  }
+
+  export async function uninstall(): Promise<ContextMenu.InstallResult[]> {
+    const commands = buildUninstallCommands()
+    const results: ContextMenu.InstallResult[] = []
+
+    for (const cmd of commands) {
+      const result = await $`${cmd.args}`.quiet().nothrow()
+      results.push({
+        target: cmd.target,
+        success: result.exitCode === 0,
+        error: result.exitCode !== 0 ? result.stderr.toString().trim() : undefined,
+      })
+    }
+
+    return results
+  }
+
+  export async function isInstalled(): Promise<boolean> {
+    const key = ContextMenu.REGISTRY_KEYS.background
+    const result = await $`reg query ${key}`.quiet().nothrow()
+    return result.exitCode === 0
+  }
+}

--- a/packages/opencode/src/windows-context-menu/types.ts
+++ b/packages/opencode/src/windows-context-menu/types.ts
@@ -1,0 +1,30 @@
+import z from "zod"
+
+// kilocode_change - Windows Explorer context menu types
+
+export namespace ContextMenu {
+  export const RegistryTarget = z.enum(["background", "folder", "drive"])
+  export type RegistryTarget = z.infer<typeof RegistryTarget>
+
+  export const RegistryCommand = z.object({
+    target: RegistryTarget,
+    args: z.array(z.string()),
+    description: z.string(),
+  })
+  export type RegistryCommand = z.infer<typeof RegistryCommand>
+
+  export const InstallResult = z.object({
+    target: RegistryTarget,
+    success: z.boolean(),
+    error: z.string().optional(),
+  })
+  export type InstallResult = z.infer<typeof InstallResult>
+
+  export const REGISTRY_KEYS: Record<RegistryTarget, string> = {
+    background: "HKCU\\Software\\Classes\\Directory\\Background\\shell\\KiloCLI",
+    folder: "HKCU\\Software\\Classes\\Directory\\shell\\KiloCLI",
+    drive: "HKCU\\Software\\Classes\\Drive\\shell\\KiloCLI",
+  }
+
+  export const LABEL = "Open Kilo CLI Here"
+}

--- a/packages/opencode/test/windows-context-menu/first-launch.test.ts
+++ b/packages/opencode/test/windows-context-menu/first-launch.test.ts
@@ -1,0 +1,72 @@
+import { test, expect, beforeEach, afterEach } from "bun:test"
+import { FirstLaunch } from "../../src/windows-context-menu/first-launch"
+import { Global } from "../../src/global"
+import path from "path"
+import fs from "fs/promises"
+
+const FLAG_FILE = ".context-menu-offered"
+
+function flagPath(): string {
+  return path.join(Global.Path.data, FLAG_FILE)
+}
+
+async function cleanFlag(): Promise<void> {
+  await fs.rm(flagPath(), { force: true })
+}
+
+// ---- shouldPrompt ----
+
+test("shouldPrompt returns false on non-Windows", async () => {
+  // This test runs on whatever platform CI uses
+  // On non-Windows, it should always return false
+  if (process.platform !== "win32") {
+    expect(await FirstLaunch.shouldPrompt()).toBe(false)
+  }
+})
+
+test("shouldPrompt returns false when flag file exists", async () => {
+  if (process.platform !== "win32") return
+
+  await FirstLaunch.markOffered()
+  expect(await FirstLaunch.shouldPrompt()).toBe(false)
+  await cleanFlag()
+})
+
+test("shouldPrompt returns true on first Windows launch", async () => {
+  if (process.platform !== "win32") return
+
+  await cleanFlag()
+  // Note: this will also return false if context menu is already installed
+  // We can't easily mock isInstalled, so we just test the flag logic
+  const result = await FirstLaunch.shouldPrompt()
+  // Result depends on whether context menu is actually installed
+  expect(typeof result).toBe("boolean")
+})
+
+// ---- markOffered ----
+
+test("markOffered creates the flag file", async () => {
+  await cleanFlag()
+  await FirstLaunch.markOffered()
+  const exists = await Bun.file(flagPath()).exists()
+  expect(exists).toBe(true)
+  await cleanFlag()
+})
+
+test("markOffered writes an ISO date string", async () => {
+  await cleanFlag()
+  await FirstLaunch.markOffered()
+  const content = await Bun.file(flagPath()).text()
+  expect(() => new Date(content)).not.toThrow()
+  expect(new Date(content).getFullYear()).toBeGreaterThanOrEqual(2025)
+  await cleanFlag()
+})
+
+test("markOffered is idempotent", async () => {
+  await cleanFlag()
+  await FirstLaunch.markOffered()
+  await FirstLaunch.markOffered()
+  const exists = await Bun.file(flagPath()).exists()
+  expect(exists).toBe(true)
+  await cleanFlag()
+})

--- a/packages/opencode/test/windows-context-menu/registry.test.ts
+++ b/packages/opencode/test/windows-context-menu/registry.test.ts
@@ -1,0 +1,193 @@
+import { test, expect } from "bun:test"
+import { WindowsRegistry } from "../../src/windows-context-menu/registry"
+import { ContextMenu } from "../../src/windows-context-menu/types"
+
+// ---- buildInstallCommands ----
+
+test("generates 9 commands (3 per target × 3 targets)", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  expect(cmds.length).toBe(9)
+})
+
+test("generates 3 commands per target", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  for (const target of ContextMenu.RegistryTarget.options) {
+    const targetCmds = cmds.filter((c) => c.target === target)
+    expect(targetCmds.length).toBe(3)
+  }
+})
+
+test("first command for each target sets the label", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  for (const target of ContextMenu.RegistryTarget.options) {
+    const targetCmds = cmds.filter((c) => c.target === target)
+    expect(targetCmds[0].args).toContain("/ve")
+    expect(targetCmds[0].args).toContain(ContextMenu.LABEL)
+  }
+})
+
+test("second command for each target sets the icon", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  for (const target of ContextMenu.RegistryTarget.options) {
+    const targetCmds = cmds.filter((c) => c.target === target)
+    expect(targetCmds[1].args).toContain("Icon")
+    expect(targetCmds[1].args).toContain('"C:\\kilo\\kilo.exe"')
+  }
+})
+
+test("third command for each target sets the shell command", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  for (const target of ContextMenu.RegistryTarget.options) {
+    const targetCmds = cmds.filter((c) => c.target === target)
+    const cmdArgs = targetCmds[2].args.join(" ")
+    expect(cmdArgs).toContain("\\command")
+  }
+})
+
+test("background target uses %V argument", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  const bgCmds = cmds.filter((c) => c.target === "background")
+  const shellCmd = bgCmds[2].args.find((a) => a.includes("%V"))
+  expect(shellCmd).toBeDefined()
+})
+
+test("folder target uses %1 argument", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  const folderCmds = cmds.filter((c) => c.target === "folder")
+  const shellCmd = folderCmds[2].args.find((a) => a.includes("%1"))
+  expect(shellCmd).toBeDefined()
+})
+
+test("drive target uses %1 argument", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  const driveCmds = cmds.filter((c) => c.target === "drive")
+  const shellCmd = driveCmds[2].args.find((a) => a.includes("%1"))
+  expect(shellCmd).toBeDefined()
+})
+
+test("handles paths with spaces", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\Program Files\\Kilo\\kilo.exe")
+  const bgCmds = cmds.filter((c) => c.target === "background")
+  const iconCmd = bgCmds[1]
+  expect(iconCmd.args).toContain('"C:\\Program Files\\Kilo\\kilo.exe"')
+})
+
+test("all commands use /f flag for force overwrite", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  for (const cmd of cmds) {
+    expect(cmd.args).toContain("/f")
+  }
+})
+
+test("all commands start with reg add", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  for (const cmd of cmds) {
+    expect(cmd.args[0]).toBe("reg")
+    expect(cmd.args[1]).toBe("add")
+  }
+})
+
+test("uses correct HKCU registry paths", () => {
+  const cmds = WindowsRegistry.buildInstallCommands("C:\\kilo\\kilo.exe")
+  const bgCmds = cmds.filter((c) => c.target === "background")
+  expect(bgCmds[0].args[2]).toBe("HKCU\\Software\\Classes\\Directory\\Background\\shell\\KiloCLI")
+
+  const folderCmds = cmds.filter((c) => c.target === "folder")
+  expect(folderCmds[0].args[2]).toBe("HKCU\\Software\\Classes\\Directory\\shell\\KiloCLI")
+
+  const driveCmds = cmds.filter((c) => c.target === "drive")
+  expect(driveCmds[0].args[2]).toBe("HKCU\\Software\\Classes\\Drive\\shell\\KiloCLI")
+})
+
+// ---- buildUninstallCommands ----
+
+test("generates 3 uninstall commands (one per target)", () => {
+  const cmds = WindowsRegistry.buildUninstallCommands()
+  expect(cmds.length).toBe(3)
+})
+
+test("uninstall commands use reg delete", () => {
+  const cmds = WindowsRegistry.buildUninstallCommands()
+  for (const cmd of cmds) {
+    expect(cmd.args[0]).toBe("reg")
+    expect(cmd.args[1]).toBe("delete")
+  }
+})
+
+test("uninstall commands use /f flag", () => {
+  const cmds = WindowsRegistry.buildUninstallCommands()
+  for (const cmd of cmds) {
+    expect(cmd.args).toContain("/f")
+  }
+})
+
+test("uninstall commands target correct registry keys", () => {
+  const cmds = WindowsRegistry.buildUninstallCommands()
+  const keys = cmds.map((c) => c.args[2])
+  expect(keys).toContain("HKCU\\Software\\Classes\\Directory\\Background\\shell\\KiloCLI")
+  expect(keys).toContain("HKCU\\Software\\Classes\\Directory\\shell\\KiloCLI")
+  expect(keys).toContain("HKCU\\Software\\Classes\\Drive\\shell\\KiloCLI")
+})
+
+test("each uninstall command maps to a distinct target", () => {
+  const cmds = WindowsRegistry.buildUninstallCommands()
+  const targets = cmds.map((c) => c.target)
+  expect(new Set(targets).size).toBe(3)
+  expect(targets).toContain("background")
+  expect(targets).toContain("folder")
+  expect(targets).toContain("drive")
+})
+
+// ---- RegistryTarget enum ----
+
+test("RegistryTarget has exactly 3 options", () => {
+  expect(ContextMenu.RegistryTarget.options.length).toBe(3)
+})
+
+test("RegistryTarget validates known values", () => {
+  expect(ContextMenu.RegistryTarget.parse("background")).toBe("background")
+  expect(ContextMenu.RegistryTarget.parse("folder")).toBe("folder")
+  expect(ContextMenu.RegistryTarget.parse("drive")).toBe("drive")
+})
+
+test("RegistryTarget rejects unknown values", () => {
+  expect(() => ContextMenu.RegistryTarget.parse("invalid")).toThrow()
+})
+
+// ---- REGISTRY_KEYS mapping ----
+
+test("REGISTRY_KEYS maps all targets to HKCU paths", () => {
+  for (const target of ContextMenu.RegistryTarget.options) {
+    expect(ContextMenu.REGISTRY_KEYS[target]).toStartWith("HKCU\\")
+  }
+})
+
+test("REGISTRY_KEYS all include KiloCLI", () => {
+  for (const target of ContextMenu.RegistryTarget.options) {
+    expect(ContextMenu.REGISTRY_KEYS[target]).toContain("KiloCLI")
+  }
+})
+
+// ---- InstallResult schema ----
+
+test("InstallResult validates success result", () => {
+  const result = ContextMenu.InstallResult.parse({ target: "background", success: true })
+  expect(result.success).toBe(true)
+  expect(result.error).toBeUndefined()
+})
+
+test("InstallResult validates failure result with error", () => {
+  const result = ContextMenu.InstallResult.parse({
+    target: "folder",
+    success: false,
+    error: "Access denied",
+  })
+  expect(result.success).toBe(false)
+  expect(result.error).toBe("Access denied")
+})
+
+test("InstallResult rejects invalid target", () => {
+  expect(() =>
+    ContextMenu.InstallResult.parse({ target: "unknown", success: true }),
+  ).toThrow()
+})


### PR DESCRIPTION
> **Kilo League Challenge Kilo-Org/kilo#3 — DeveloperWeek 2026 Hackathon Entry**

## Windows Explorer Context Menu Integration

One-click "Open Kilo CLI Here" for Windows Explorer — offered on first launch, no admin required.

### The Problem

Windows users download Kilo, unzip it, run it — but there's no native OS integration. They can't right-click a folder and jump straight into a Kilo session. VS Code, Windows Terminal, and Git Bash all offer this; Kilo should too.

### The Solution

Two UX paths that both lead to the same outcome:

**1. First-launch prompt** — When a user runs `kilo` for the first time on Windows, they get:

```
◆ Add Kilo to your Windows Explorer right-click menu?
│ ● Yes / ○ No
```

One confirmation and they're done. The prompt never appears again.

**2. Manual CLI commands** — For power users:

```bash
kilo windows install-context-menu    # registers entries
kilo windows remove-context-menu     # removes entries
```

### What Gets Installed

Three per-user registry entries (HKCU — no admin elevation required):

| Context | Effect |
|---------|--------|
| Folder background | Right-click empty space → "Open Kilo CLI Here" |
| Folder | Right-click a folder → "Open Kilo CLI Here" |
| Drive | Right-click a drive → "Open Kilo CLI Here" |

Each entry gets `kilo.exe` as icon and launches Kilo scoped to the clicked path.

### Architecture

```
windows-context-menu/
  types.ts         — Zod schemas (RegistryTarget, InstallResult, RegistryCommand)
  registry.ts      — Pure function engine: buildCommands(), install(), uninstall()
  first-launch.ts  — shouldPrompt() + prompt() with flag file persistence
  index.ts         — Barrel export

cli/cmd/windows.ts — Yargs subcommand group (install/remove)
```

### Key Design Decisions

- **HKCU, not HKLM** — Per-user keys, no admin required, safe for corporate machines
- **`reg.exe` via `Bun.$`** — No FFI, no native deps, just the Windows registry CLI
- **`buildCommands()` is pure** — Returns command arrays without executing, fully testable on any platform
- **Lazy `await import()`** — Zero overhead on non-Windows platforms (same pattern as governance)
- **Flag file persistence** — `.context-menu-offered` in data dir, prompt appears exactly once

### Test Results

31 tests passing across 2 test files:

```bash
cd packages/opencode
bun test test/windows-context-menu/

 31 pass
 0 fail
 92 expect() calls
```

### Proof It Works

Tested locally — "Open Kilo CLI Here" appears in Explorer context menu for folder backgrounds, folders, and drives.

### Philosophy

> The best features are the ones users don't have to configure. First-launch detection turns a power-user registry hack into a one-click experience for everyone.

Closes Kilo-Org/kilocode#6296

🤖 Generated with [Claude Code](https://claude.com/claude-code)