### PR TITLE
fix(vscode): hide scrollbar and add fade indicators for agent manager tab overflow

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -308,6 +308,50 @@
   min-width: 0;
   overflow-x: auto;
   height: 100%;
+
+  /* Hide scrollbar while keeping scroll functionality */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.am-tab-list::-webkit-scrollbar {
+  display: none;
+}
+
+/* Wrapper that positions overflow fade indicators */
+.am-tab-scroll-area {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: stretch;
+  height: 100%;
+}
+
+/* Fade indicators for overflow */
+.am-tab-fade {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 32px;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.am-tab-fade-visible {
+  opacity: 1;
+}
+
+.am-tab-fade-left {
+  left: 0;
+  background: linear-gradient(to right, var(--surface-base) 0%, transparent 100%);
+}
+
+.am-tab-fade-right {
+  right: 0;
+  background: linear-gradient(to left, var(--surface-base) 0%, transparent 100%);
 }
 
 .am-tab {


### PR DESCRIPTION
## Summary

- Hides the native horizontal scrollbar on the Agent Manager session tab bar that was causing UI jank when many tabs were open
- Adds left/right gradient fade indicators that appear when tabs overflow, signaling more tabs exist in each direction
- Converts vertical mouse wheel events to horizontal scroll on the tab list for easier navigation
- Auto-scrolls the active tab into view when selected via click or keyboard

## Before
A visible scrollbar appears below session tabs when many are open, shifting the UI vertically and making it harder to use.

## After
No scrollbar is shown. Instead, subtle gradient fades on the left/right edges indicate overflow. Horizontal scroll still works via mouse wheel, and the active tab is always scrolled into view.