### PR TITLE
feat(vscode): add Cmd+Shift+M keybinding to open Agent Manager

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -292,6 +292,11 @@
         "mac": "cmd+shift+a"
       },
       {
+        "command": "kilo-code.new.agentManagerOpen",
+        "key": "ctrl+shift+m",
+        "mac": "cmd+shift+m"
+      },
+      {
         "command": "kilo-code.new.addToContext",
         "key": "ctrl+k ctrl+a",
         "mac": "cmd+k cmd+a",


### PR DESCRIPTION
## Summary

- Registers a global keyboard shortcut (`Cmd+Shift+M` on macOS, `Ctrl+Shift+M` on Windows/Linux) for the `agentManagerOpen` command
- VS Code automatically appends the shortcut to the sidebar toolbar button tooltip, so hovering the Agent Manager icon now shows "Agent Manager (⌘⇧M)"
- The shortcut overrides VS Code's "Toggle Problems Panel" (`Cmd+Shift+M`), which is a low-frequency action — users can rebind if needed

## Why this shortcut?

- **Mnemonic**: M = Manager
- **No conflict** with any existing Kilo keybindings
- **Single keystroke** (not a chord), making it fast to invoke
- The overridden VS Code default ("Toggle Problems Panel") is rarely used and easily re-bindable