### PR TITLE
fix(vscode): improve worktree error messages when not in a git repository

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -168,7 +168,11 @@ export class AgentManagerProvider implements vscode.Disposable {
     const manager = this.getWorktreeManager()
     const state = this.getStateManager()
     if (!manager || !state) {
-      this.postToWebview({ type: "agentManager.worktreeSetup", status: "error", message: "No workspace folder open" })
+      this.postToWebview({
+        type: "agentManager.worktreeSetup",
+        status: "error",
+        message: "Open a folder that contains a git repository to use worktrees",
+      })
       return null
     }
 
@@ -178,11 +182,11 @@ export class AgentManagerProvider implements vscode.Disposable {
     try {
       result = await manager.createWorktree({ prompt: "kilo" })
     } catch (error) {
-      const err = error instanceof Error ? error.message : String(error)
+      const msg = error instanceof Error ? error.message : String(error)
       this.postToWebview({
         type: "agentManager.worktreeSetup",
         status: "error",
-        message: `Failed to create worktree: ${err}`,
+        message: msg,
       })
       return null
     }

--- a/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
@@ -42,7 +42,7 @@ export class SessionTerminalManager {
 
     if (!cwd) {
       this.log(`showTerminal: no cwd resolved for session ${sessionId}`)
-      vscode.window.showWarningMessage("No workspace folder open")
+      vscode.window.showWarningMessage("Open a folder that contains a git repository to use worktrees")
       return
     }
 

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -46,7 +46,10 @@ export class WorktreeManager {
 
   async createWorktree(params: { prompt?: string; existingBranch?: string }): Promise<CreateWorktreeResult> {
     const repo = await this.git.checkIsRepo()
-    if (!repo) throw new Error("Workspace is not a git repository")
+    if (!repo)
+      throw new Error(
+        "This folder is not a git repository. Initialize a repository or open a git project to use worktrees.",
+      )
 
     await this.ensureDir()
     await this.ensureGitExclude()

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -696,7 +696,7 @@ const AgentManagerContent: Component = () => {
           <div class="am-setup-overlay">
             <div class="am-setup-card">
               <Icon name="branch" size="large" />
-              <div class="am-setup-title">Setting up workspace</div>
+              <div class="am-setup-title">{setup().error ? "Workspace setup failed" : "Setting up workspace"}</div>
               <Show when={setup().branch}>
                 <div class="am-setup-branch">{setup().branch}</div>
               </Show>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -455,7 +455,7 @@
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  max-width: 300px;
+  max-width: 400px;
   text-align: center;
 }
 
@@ -479,12 +479,14 @@
 .am-setup-status {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   padding: 8px 16px;
   border-radius: var(--radius-sm);
   background: var(--surface-inset-base);
   color: var(--text-base);
   font-size: var(--font-size-base);
+  text-align: center;
 }
 
 .am-setup-spinner {


### PR DESCRIPTION
## Summary

- Improve error messaging when users try to use worktrees without a git repository, replacing vague "No workspace folder open" with actionable guidance
- Show "Workspace setup failed" as the overlay title on error instead of "Setting up workspace"
- Widen the setup card (300px → 400px) and center error text to prevent layout clipping with longer messages

## Changes

- **AgentManagerProvider.ts**: Updated no-workspace error to "Open a folder that contains a git repository to use worktrees"; removed redundant "Failed to create worktree:" prefix since underlying errors are now self-descriptive
- **SessionTerminalManager.ts**: Same message update for the terminal warning notification
- **WorktreeManager.ts**: Changed not-a-repo error to "This folder is not a git repository. Initialize a repository or open a git project to use worktrees."
- **AgentManagerApp.tsx**: Title dynamically shows "Workspace setup failed" on error
- **agent-manager.css**: Increased `max-width` to `400px`, added `justify-content: center` and `text-align: center` to the status box

<img width="508" height="243" alt="image" src="https://github.com/user-attachments/assets/852741ed-a0a9-4519-9090-89701b1647d8" />
