### PR TITLE
feat(agent-manager): accept Cmd+Enter as confirm in delete worktree dialog

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -390,9 +390,15 @@ const AgentManagerContent: Component = () => {
       }
       dialog.close()
     }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        doDelete()
+      }
+    }
     dialog.show(() => (
       <Dialog title="Delete Worktree" fit>
-        <div class="am-confirm">
+        <div class="am-confirm" onKeyDown={onKeyDown}>
           <div class="am-confirm-message">
             <Icon name="trash" size="small" />
             <span>


### PR DESCRIPTION
## Summary

- Adds a `keydown` handler to the agent manager's delete worktree confirmation dialog so that Cmd+Enter (macOS) or Ctrl+Enter (Windows/Linux) also confirms the deletion, in addition to the existing plain Enter behavior via the autofocused Delete button.