### PR TITLE
fix(agent-manager): left-align add-session button next to tabs

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -323,9 +323,10 @@
   position: relative;
   display: flex;
   min-width: 0;
-  flex: 1;
+  flex-shrink: 1;
   align-items: stretch;
   height: 100%;
+  overflow: hidden;
 }
 
 /* Fade indicators for overflow */


### PR DESCRIPTION
## Summary

- Fixes the `+` (new session) button being pushed to the far right of the tab bar, next to the terminal button
- The button now sits immediately after the last tab, left-aligned, while the terminal button remains on the far right

## Changes

In `.am-tab-scroll-area`:
- Replaced `flex: 1` with `flex-shrink: 1` so the scroll area sizes to its content instead of filling all available space
- Added `overflow: hidden` to clip content when the area shrinks