### PR TITLE
feat(agent-manager): collapsible sessions section with persisted state

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -160,6 +160,10 @@ export class AgentManagerProvider implements vscode.Disposable {
       this.state?.setTabOrder(msg.key as string, msg.order as string[])
       return null
     }
+    if (type === "agentManager.setSessionsCollapsed" && typeof msg.collapsed === "boolean") {
+      this.state?.setSessionsCollapsed(msg.collapsed as boolean)
+      return null
+    }
 
     // When switching sessions, show existing terminal if one is open
     if (type === "loadMessages" && typeof msg.sessionID === "string") {
@@ -496,6 +500,7 @@ export class AgentManagerProvider implements vscode.Disposable {
       worktrees: state.getWorktrees(),
       sessions: state.getSessions(),
       tabOrder: state.getTabOrder(),
+      sessionsCollapsed: state.getSessionsCollapsed(),
     })
   }
 

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -249,6 +249,40 @@ describe("WorktreeStateManager", () => {
     })
   })
 
+  describe("sessionsCollapsed", () => {
+    it("defaults to false", () => {
+      expect(manager.getSessionsCollapsed()).toBe(false)
+    })
+
+    it("sets and gets collapsed state", () => {
+      manager.setSessionsCollapsed(true)
+      expect(manager.getSessionsCollapsed()).toBe(true)
+
+      manager.setSessionsCollapsed(false)
+      expect(manager.getSessionsCollapsed()).toBe(false)
+    })
+
+    it("persists and loads collapsed state", async () => {
+      manager.setSessionsCollapsed(true)
+      await manager.flush()
+      await manager.save()
+
+      const loaded = new WorktreeStateManager(root, () => {})
+      await loaded.load()
+      expect(loaded.getSessionsCollapsed()).toBe(true)
+    })
+
+    it("does not persist when false", async () => {
+      manager.setSessionsCollapsed(false)
+      await manager.flush()
+      await manager.save()
+
+      const content = fs.readFileSync(path.join(root, ".kilocode", "agent-manager.json"), "utf-8")
+      const data = JSON.parse(content)
+      expect(data.sessionsCollapsed).toBeUndefined()
+    })
+  })
+
   describe("validate", () => {
     it("removes worktrees whose directories do not exist", async () => {
       const existing = path.join(root, "wt-exists")

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -168,6 +168,7 @@ const AgentManagerContent: Component = () => {
   const persisted = vscode.getState<{ localSessionIDs?: string[]; sidebarWidth?: number }>()
   const [localSessionIDs, setLocalSessionIDs] = createSignal<string[]>(persisted?.localSessionIDs ?? [])
   const [sidebarWidth, setSidebarWidth] = createSignal(persisted?.sidebarWidth ?? DEFAULT_SIDEBAR_WIDTH)
+  const [sessionsCollapsed, setSessionsCollapsed] = createSignal(false)
 
   // Pending local tab counter for generating unique IDs
   let pendingCounter = 0
@@ -503,6 +504,8 @@ const AgentManagerContent: Component = () => {
           ).map((item) => item.id)
           setLocalSessionIDs(reordered)
         }
+        // Recover sessions collapsed state from extension-persisted state
+        if (state.sessionsCollapsed !== undefined) setSessionsCollapsed(state.sessionsCollapsed)
         // Clear deleting state for worktrees that have been removed
         const ids = new Set(state.worktrees.map((wt) => wt.id))
         setDeletingWorktrees((prev) => {
@@ -767,7 +770,7 @@ const AgentManagerContent: Component = () => {
         </button>
 
         {/* WORKTREES section */}
-        <div class="am-section">
+        <div class={`am-section ${sessionsCollapsed() ? "am-section-grow" : ""}`}>
           <div class="am-section-header">
             <span class="am-section-label">WORKTREES</span>
             <div class="am-section-actions">
@@ -909,60 +912,76 @@ const AgentManagerContent: Component = () => {
           </div>
         </div>
 
-        {/* SESSIONS section (unassigned) */}
-        <div class="am-section am-section-grow">
-          <div class="am-section-header">
-            <span class="am-section-label">SESSIONS</span>
-          </div>
-          <div class="am-list">
-            <Show
-              when={sessionsLoaded()}
-              fallback={
-                <div class="am-skeleton-list">
-                  <div class="am-skeleton-session">
-                    <div class="am-skeleton-session-title" style={{ width: "70%" }} />
-                    <div class="am-skeleton-session-time" />
-                  </div>
-                  <div class="am-skeleton-session">
-                    <div class="am-skeleton-session-title" style={{ width: "55%" }} />
-                    <div class="am-skeleton-session-time" />
-                  </div>
-                  <div class="am-skeleton-session">
-                    <div class="am-skeleton-session-title" style={{ width: "65%" }} />
-                    <div class="am-skeleton-session-time" />
-                  </div>
-                </div>
-              }
-            >
-              <For each={unassignedSessions()}>
-                {(s) => (
-                  <button
-                    class={`am-item ${s.id === session.currentSessionID() && selection() === null ? "am-item-active" : ""}`}
-                    data-sidebar-id={s.id}
-                    onClick={() => {
-                      saveTabMemory()
-                      setSelection(null)
-                      session.selectSession(s.id)
-                    }}
-                  >
-                    <span class="am-item-title">{s.title || "Untitled"}</span>
-                    <span class="am-item-time">{formatRelativeDate(s.updatedAt)}</span>
-                    <div class="am-item-promote">
-                      <TooltipKeybind title="Open in worktree" keybind={kb().newWorktree ?? ""} placement="right">
-                        <IconButton
-                          icon="branch"
-                          size="small"
-                          variant="ghost"
-                          label="Open in worktree"
-                          onClick={(e: MouseEvent) => handlePromote(s.id, e)}
-                        />
-                      </TooltipKeybind>
+        {/* SESSIONS section (unassigned) — collapsible */}
+        <div class={`am-section ${sessionsCollapsed() ? "" : "am-section-grow"}`}>
+          <button
+            class="am-section-header am-section-toggle"
+            onClick={() => {
+              const next = !sessionsCollapsed()
+              setSessionsCollapsed(next)
+              vscode.postMessage({ type: "agentManager.setSessionsCollapsed", collapsed: next })
+            }}
+          >
+            <span class="am-section-label">
+              <Icon
+                name={sessionsCollapsed() ? "chevron-right" : "chevron-down"}
+                size="small"
+                class="am-section-chevron"
+              />
+              SESSIONS
+            </span>
+          </button>
+          <Show when={!sessionsCollapsed()}>
+            <div class="am-list">
+              <Show
+                when={sessionsLoaded()}
+                fallback={
+                  <div class="am-skeleton-list">
+                    <div class="am-skeleton-session">
+                      <div class="am-skeleton-session-title" style={{ width: "70%" }} />
+                      <div class="am-skeleton-session-time" />
                     </div>
-                  </button>
-                )}
-              </For>
-            </Show>
-          </div>
+                    <div class="am-skeleton-session">
+                      <div class="am-skeleton-session-title" style={{ width: "55%" }} />
+                      <div class="am-skeleton-session-time" />
+                    </div>
+                    <div class="am-skeleton-session">
+                      <div class="am-skeleton-session-title" style={{ width: "65%" }} />
+                      <div class="am-skeleton-session-time" />
+                    </div>
+                  </div>
+                }
+              >
+                <For each={unassignedSessions()}>
+                  {(s) => (
+                    <button
+                      class={`am-item ${s.id === session.currentSessionID() && selection() === null ? "am-item-active" : ""}`}
+                      data-sidebar-id={s.id}
+                      onClick={() => {
+                        saveTabMemory()
+                        setSelection(null)
+                        session.selectSession(s.id)
+                      }}
+                    >
+                      <span class="am-item-title">{s.title || "Untitled"}</span>
+                      <span class="am-item-time">{formatRelativeDate(s.updatedAt)}</span>
+                      <div class="am-item-promote">
+                        <TooltipKeybind title="Open in worktree" keybind={kb().newWorktree ?? ""} placement="right">
+                          <IconButton
+                            icon="branch"
+                            size="small"
+                            variant="ghost"
+                            label="Open in worktree"
+                            onClick={(e: MouseEvent) => handlePromote(s.id, e)}
+                          />
+                        </TooltipKeybind>
+                      </div>
+                    </button>
+                  )}
+                </For>
+              </Show>
+            </div>
+          </Show>
         </div>
       </div>
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -107,6 +107,30 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-weak);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Collapsible section toggle */
+
+button.am-section-toggle {
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px 2px;
+  cursor: pointer;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+button.am-section-toggle:hover .am-section-label {
+  color: var(--text-base);
+}
+
+.am-section-chevron {
+  flex-shrink: 0;
 }
 
 .am-section-actions {
@@ -124,6 +148,11 @@
   overflow-y: auto;
   overflow-x: hidden;
   max-height: 50vh;
+}
+
+.am-section-grow .am-worktree-list {
+  max-height: none;
+  flex: 1;
 }
 
 /* Worktree item — larger card style */

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -564,6 +564,7 @@ export interface AgentManagerStateMessage {
   worktrees: WorktreeState[]
   sessions: ManagedSessionState[]
   tabOrder?: Record<string, string[]>
+  sessionsCollapsed?: boolean
 }
 
 // Resolved keybindings for agent manager actions
@@ -863,6 +864,12 @@ export interface SetTabOrderRequest {
   order: string[]
 }
 
+// Persist sessions collapsed state
+export interface SetSessionsCollapsedRequest {
+  type: "agentManager.setSessionsCollapsed"
+  collapsed: boolean
+}
+
 export type WebviewMessage =
   | SendMessageRequest
   | AbortRequest
@@ -910,6 +917,7 @@ export type WebviewMessage =
   | ConfigureSetupScriptRequest
   | ShowTerminalRequest
   | SetTabOrderRequest
+  | SetSessionsCollapsedRequest
 
 // ============================================
 // VS Code API type


### PR DESCRIPTION
## Summary
- Makes the SESSIONS header in the Agent Manager sidebar clickable to collapse/expand the session list
- When collapsed, the worktrees section takes the full vertical space (removes the `max-height: 50vh` cap)
- Collapsed state is persisted to `.kilocode/agent-manager.json` so it survives VS Code restarts

## Changes
- **WorktreeStateManager**: Added `sessionsCollapsed` field with getter/setter, persisted to the state file
- **AgentManagerProvider**: Includes `sessionsCollapsed` in `pushState()`, handles `agentManager.setSessionsCollapsed` message
- **AgentManagerApp.tsx**: SESSIONS header is now a clickable button with chevron indicator; toggle sends update to extension for persistence; initializes from extension state
- **agent-manager.css**: Styled the toggle button, chevron, and worktree list flex growth when sessions are collapsed
- **messages.ts**: Added `sessionsCollapsed` to `AgentManagerStateMessage` and new `SetSessionsCollapsedRequest` type
- **Tests**: 4 new tests for default value, get/set, persistence round-trip, and clean file when false