### PR TITLE
fix(agent-manager): dismiss setup overlay on script error

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -460,6 +460,12 @@ export class AgentManagerProvider implements vscode.Disposable {
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
       this.outputChannel.appendLine(`[AgentManager] Setup script error: ${msg}`)
+      this.postToWebview({
+        type: "agentManager.worktreeSetup",
+        status: "error",
+        message: `Setup script failed: ${msg}`,
+        branch,
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix agent manager UI becoming permanently unresponsive when the worktree setup script fails
- The catch block in `runSetupScriptForWorktree` only logged errors to the output channel but never posted a `status: "error"` message to the webview
- Since the setup overlay (`am-setup-overlay`, `position: absolute; inset: 0; z-index: 10`) only dismisses on `"ready"` or `"error"` status, any exception left it covering the entire UI permanently

## Details

The setup overlay blocks all interaction while a worktree is being created. The flow is:

1. `createWorktreeOnDisk()` → overlay activates
2. `runSetupScriptForWorktree()` → overlay shows "Running setup script..."
3. If `runIfConfigured()` throws, the catch block logged the error but **did not** post `status: "error"` to the webview
4. The overlay stayed up forever — no `"ready"` or `"error"` status ever arrived to dismiss it

The fix adds `postToWebview({ status: "error" })` in the catch block so the webview can dismiss the overlay and display the error.