### PR TITLE
feat(agent-manager): add keyboard shortcuts dialog to settings menu

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -417,11 +417,21 @@ export class AgentManagerProvider implements vscode.Disposable {
     const mac = process.platform === "darwin"
     const prefix = "kilo-code.new.agentManager."
     const bindings: Record<string, string> = {}
+
+    // Global keybindings exposed to the shortcuts dialog
+    const globals: Record<string, string> = {
+      "kilo-code.new.agentManagerOpen": "agentManagerOpen",
+    }
+
     for (const kb of keybindings) {
-      if (!kb.command.startsWith(prefix)) continue
-      const action = kb.command.slice(prefix.length)
       const raw = mac ? (kb.mac ?? kb.key) : kb.key
-      if (raw) bindings[action] = formatKeybinding(raw, mac)
+      if (!raw) continue
+
+      if (kb.command.startsWith(prefix)) {
+        bindings[kb.command.slice(prefix.length)] = formatKeybinding(raw, mac)
+      } else if (globals[kb.command]) {
+        bindings[globals[kb.command]] = formatKeybinding(raw, mac)
+      }
     }
 
     this.postToWebview({ type: "agentManager.keybindings", bindings })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -77,6 +77,8 @@ const defaultBindings: Record<string, string> = {
   closeTab: isMac ? "⌘W" : "Ctrl+W",
   newWorktree: isMac ? "⌘N" : "Ctrl+N",
   closeWorktree: isMac ? "⌘⇧W" : "Ctrl+Shift+W",
+  agentManagerOpen: isMac ? "⌘⇧M" : "Ctrl+Shift+M",
+  focusPanel: isMac ? "⌘." : "Ctrl+.",
 }
 
 /** Manages horizontal scroll for the tab list: hides the scrollbar, converts
@@ -142,6 +144,76 @@ function useTabScroll(activeTabs: Accessor<SessionInfo[]>, activeId: Accessor<st
   })
 
   return { setRef, showLeft, showRight }
+}
+
+/** Shortcut category definition for the keyboard shortcuts dialog */
+interface ShortcutEntry {
+  label: string
+  binding: string
+}
+
+interface ShortcutCategory {
+  title: string
+  shortcuts: ShortcutEntry[]
+}
+
+/** Build the categorized list of keyboard shortcuts from the current bindings */
+function buildShortcutCategories(bindings: Record<string, string>): ShortcutCategory[] {
+  return [
+    {
+      title: "Sidebar",
+      shortcuts: [
+        { label: "Previous item", binding: bindings.previousSession ?? "" },
+        { label: "Next item", binding: bindings.nextSession ?? "" },
+        { label: "New worktree", binding: bindings.newWorktree ?? "" },
+        { label: "Delete worktree", binding: bindings.closeWorktree ?? "" },
+      ],
+    },
+    {
+      title: "Tabs",
+      shortcuts: [
+        { label: "Previous tab", binding: bindings.previousTab ?? "" },
+        { label: "Next tab", binding: bindings.nextTab ?? "" },
+        { label: "New tab", binding: bindings.newTab ?? "" },
+        { label: "Close tab", binding: bindings.closeTab ?? "" },
+      ],
+    },
+    {
+      title: "Terminal",
+      shortcuts: [
+        { label: "Toggle terminal", binding: bindings.showTerminal ?? "" },
+        { label: "Focus panel", binding: bindings.focusPanel ?? "" },
+      ],
+    },
+    {
+      title: "Global",
+      shortcuts: [{ label: "Open Agent Manager", binding: bindings.agentManagerOpen ?? "" }].filter((s) => s.binding),
+    },
+  ].filter((c) => c.shortcuts.length > 0)
+}
+
+/** Parse a display keybinding string into separate key tokens for rendering.
+ *  Windows/Linux format ("Ctrl+Shift+W") splits on "+".
+ *  Mac format ("⌘⇧W") splits on known modifier symbols. */
+function parseBindingTokens(binding: string): string[] {
+  if (!binding) return []
+  // Windows/Linux: "Ctrl+Shift+W" → ["Ctrl", "Shift", "W"]
+  if (binding.includes("+")) return binding.split("+")
+  // Mac: "⌘⇧W" → ["⌘", "⇧", "W"] — peel off known modifier symbols
+  const tokens: string[] = []
+  let rest = binding
+  const modifiers = ["⌘", "⇧", "⌃", "⌥"]
+  while (rest.length > 0) {
+    const mod = modifiers.find((m) => rest.startsWith(m))
+    if (mod) {
+      tokens.push(mod)
+      rest = rest.slice(mod.length)
+    } else {
+      tokens.push(rest)
+      break
+    }
+  }
+  return tokens
 }
 
 const AgentManagerContent: Component = () => {
@@ -538,6 +610,37 @@ const AgentManagerContent: Component = () => {
     vscode.postMessage({ type: "agentManager.configureSetupScript" })
   }
 
+  const handleShowKeyboardShortcuts = () => {
+    const categories = buildShortcutCategories(kb())
+    dialog.show(() => (
+      <Dialog title="Keyboard Shortcuts" fit>
+        <div class="am-shortcuts">
+          <For each={categories}>
+            {(category) => (
+              <div class="am-shortcuts-category">
+                <div class="am-shortcuts-category-title">{category.title}</div>
+                <div class="am-shortcuts-list">
+                  <For each={category.shortcuts}>
+                    {(shortcut) => (
+                      <div class="am-shortcuts-row">
+                        <span class="am-shortcuts-label">{shortcut.label}</span>
+                        <span class="am-shortcuts-keys">
+                          <For each={parseBindingTokens(shortcut.binding)}>
+                            {(token) => <kbd class="am-kbd">{token}</kbd>}
+                          </For>
+                        </span>
+                      </div>
+                    )}
+                  </For>
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </Dialog>
+    ))
+  }
+
   const handleCreateWorktree = () => {
     vscode.postMessage({ type: "agentManager.createWorktree" })
   }
@@ -781,6 +884,10 @@ const AgentManagerContent: Component = () => {
                 />
                 <DropdownMenu.Portal>
                   <DropdownMenu.Content>
+                    <DropdownMenu.Item onSelect={handleShowKeyboardShortcuts}>
+                      <DropdownMenu.ItemLabel>Keyboard Shortcuts</DropdownMenu.ItemLabel>
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator />
                     <DropdownMenu.Item onSelect={handleConfigureSetupScript}>
                       <DropdownMenu.ItemLabel>Worktree Setup Script</DropdownMenu.ItemLabel>
                     </DropdownMenu.Item>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -720,6 +720,82 @@
   color: var(--text-base);
 }
 
+/* Keyboard shortcuts dialog */
+
+.am-shortcuts {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 0 24px 20px 24px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.am-shortcuts-category {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.am-shortcuts-category-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-weaker);
+  padding: 0 0 4px 0;
+}
+
+.am-shortcuts-list {
+  border: 1px solid var(--border-weak-base);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.am-shortcuts-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  gap: 16px;
+}
+
+.am-shortcuts-row + .am-shortcuts-row {
+  border-top: 1px solid var(--border-weak-base);
+}
+
+.am-shortcuts-label {
+  font-size: var(--font-size-base);
+  color: var(--text-base);
+  white-space: nowrap;
+}
+
+.am-shortcuts-keys {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.am-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
+  min-width: 22px;
+  padding: 0 6px;
+  border-radius: 4px;
+  background: var(--surface-inset-base);
+  border: 1px solid var(--border-weak-base);
+  font-family: var(--font-family-sans);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--text-weak);
+  white-space: nowrap;
+  box-shadow: 0 1px 0 var(--border-weak-base);
+}
+
 /* Skeleton loading states */
 
 @keyframes am-skeleton-pulse {


### PR DESCRIPTION
## Summary

- Adds a **Keyboard Shortcuts** item to the settings gear dropdown in the Agent Manager sidebar
- Opens a kilo-ui `Dialog` showing all available shortcuts grouped by category: **Sidebar**, **Tabs**, **Terminal**, **Global**
- Renders keys as styled `<kbd>` elements with platform-appropriate display (Mac symbols vs Windows key names)
- Exposes the global `agentManagerOpen` (⌘⇧M) keybinding alongside agent-manager-scoped shortcuts

<img width="631" height="789" alt="image" src="https://github.com/user-attachments/assets/cfcd5eed-a90a-4342-8948-29cb6f849e2d" />


## Details

**Categories shown in the dialog:**

| Category | Shortcuts |
|---|---|
| Sidebar | Previous/Next item (⌘↑/↓), New worktree (⌘N), Delete worktree (⌘⇧W) |
| Tabs | Previous/Next tab (⌘←/→), New tab (⌘T), Close tab (⌘W) |
| Terminal | Toggle terminal (⌘/), Focus panel (⌘.) |
| Global | Open Agent Manager (⌘⇧M) |

**Note:** `focusChatInput` (⌘⇧A) is intentionally excluded — it currently only targets the sidebar's KiloProvider and has no effect in the Agent Manager. Fixing that routing is tracked separately.

## Files changed

- `packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts` — extend `sendKeybindings()` to include global keybindings
- `packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx` — add shortcut categories, token parser, dialog handler, dropdown menu item
- `packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css` — styles for shortcuts dialog and `<kbd>` elements