### PR TITLE
fix(agent-manager): reset stale body styles when webview regains focus

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -559,7 +559,14 @@ const AgentManagerContent: Component = () => {
     window.addEventListener("keydown", preventDefaults)
 
     // When the panel regains focus (e.g. returning from terminal), focus the prompt
-    const onWindowFocus = () => window.dispatchEvent(new Event("focusPrompt"))
+    // and clear any stale body styles left by Kobalte modal overlays (dropdowns/dialogs
+    // set pointer-events:none and overflow:hidden on body, but cleanup never runs if
+    // focus leaves the webview before the overlay closes).
+    const onWindowFocus = () => {
+      document.body.style.pointerEvents = ""
+      document.body.style.overflow = ""
+      window.dispatchEvent(new Event("focusPrompt"))
+    }
     window.addEventListener("focus", onWindowFocus)
 
     // When a session is created while on local, replace the current pending tab with the real session.


### PR DESCRIPTION
## Summary
- Fixes the agent manager UI becoming unclickable after opening the setup script editor from the settings dropdown
- Clears stale `pointer-events: none` and `overflow: hidden` styles from `document.body` when the webview regains focus

## Problem
Kobalte's modal `DropdownMenu` sets `pointer-events: none` and `overflow: hidden` on `document.body` when opened. When the user selects "Worktree Setup Script", `vscode.window.showTextDocument()` steals focus from the webview before the dropdown's SolidJS cleanup callbacks can run. The body retains these styles permanently, making the entire UI unresponsive.

## Fix
The existing `window.focus` handler (which fires when the panel regains focus) now resets both body styles to empty strings. This is a general safety net that covers any scenario where focus leaves the webview while a Kobalte modal overlay is open — not just the setup script case.