### PR TITLE
fix(vscode): absolutely position notification bar to not push content down

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -55,11 +55,13 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   return (
     <div class="chat-view">
       <TaskHeader />
-      <Show when={!id()}>
-        <KiloNotifications />
-      </Show>
-      <div class="chat-messages">
-        <MessageList onSelectSession={props.onSelectSession} />
+      <div class="chat-messages-wrapper">
+        <Show when={!id()}>
+          <KiloNotifications />
+        </Show>
+        <div class="chat-messages">
+          <MessageList onSelectSession={props.onSelectSession} />
+        </div>
       </div>
 
       <Show when={!props.readonly}>

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -14,8 +14,15 @@
   overflow: hidden;
 }
 
-.chat-messages {
+.chat-messages-wrapper {
+  position: relative;
   flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.chat-messages {
+  height: 100%;
   overflow: hidden;
   min-height: 0;
 }
@@ -706,8 +713,11 @@
    ============================================ */
 
 .kilo-notifications {
-  flex-shrink: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
+  z-index: 10;
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid var(--vscode-panel-border);


### PR DESCRIPTION
## Summary

- Wraps `chat-messages` and `KiloNotifications` in a `position: relative` container (`.chat-messages-wrapper`)
- Changes `.kilo-notifications` to `position: absolute; top: 0; left: 0` so it overlays the session history/logo instead of pushing it down