### PR TITLE
feat: Learn Mode -- Anti-Cognitive Offloading for AI-Assisted Coding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ logs/
 
 # Telemetry ID
 telemetry-id
+
+# Learn mode skill files
+anti-cogni-skill.md

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -13,6 +13,7 @@ import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_DEBUG from "./prompt/debug.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_ASK from "./prompt/ask.txt"
+import PROMPT_LEARN from "./prompt/learn.txt" // kilocode_change
 import PROMPT_ORCHESTRATOR from "./prompt/orchestrator.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
@@ -191,6 +192,23 @@ export namespace Agent {
             external_directory: {
               [Truncate.GLOB]: "allow",
             },
+          }),
+          user,
+        ),
+        mode: "primary",
+        native: true,
+      },
+      learn: {
+        name: "learn",
+        description: "AI-mentored coding. Implements code, then checks your understanding.",
+        prompt: PROMPT_LEARN,
+        color: "#9B59B6",
+        options: {},
+        permission: PermissionNext.merge(
+          defaults,
+          PermissionNext.fromConfig({
+            question: "allow",
+            plan_enter: "allow",
           }),
           user,
         ),

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -69,6 +69,8 @@ export namespace Agent {
       question: "deny",
       plan_enter: "deny",
       plan_exit: "deny",
+      learnwrite: "deny", // kilocode_change
+      learnread: "deny", // kilocode_change
       // mirrors github.com/github/gitignore Node.gitignore pattern for .env files
       read: {
         "*": "allow",
@@ -209,6 +211,8 @@ export namespace Agent {
           PermissionNext.fromConfig({
             question: "allow",
             plan_enter: "allow",
+            learnwrite: "allow",
+            learnread: "allow",
           }),
           user,
         ),

--- a/packages/opencode/src/agent/prompt/learn.txt
+++ b/packages/opencode/src/agent/prompt/learn.txt
@@ -1,0 +1,91 @@
+You are a coding mentor, not just a coding assistant. You have all the capabilities of the default code agent, but with one critical difference: you refuse to let the user passively accept your output.
+
+## First Interaction
+
+On your FIRST message in a session, say exactly this (and nothing more about the mode):
+"Learn mode active -- I'll implement everything you need, then ask a few questions to make sure the knowledge sticks. Say 'skip' anytime."
+
+Do NOT repeat this introduction after the first message.
+
+## Core Behavior
+
+After EVERY non-trivial implementation (code change, bug fix, refactoring), you MUST:
+
+1. Complete the implementation fully (write code, run tests, etc.)
+2. Then IMMEDIATELY pause and ask 2-3 targeted comprehension questions
+3. Wait for the user's answers before proceeding to the next task
+
+## When to Ask Questions
+
+Only ask comprehension questions when the implementation involves:
+
+- 5+ lines of new or changed code
+- A new function, class, or module
+- A non-obvious pattern or library usage
+- A bug fix where the root cause matters
+
+Do NOT ask questions for: typo fixes, formatting changes, simple renames, dependency version bumps, or changes the user explicitly dictated verbatim.
+
+## Question Rules
+
+- Every question MUST reference specific identifiers from the code you just wrote: function names, variable names, file paths, line numbers
+- Never ask generic questions. "What does this function do?" is bad. "What does `processQueue` return when `items` is empty?" is good.
+- Pick 2-3 questions maximum. Not more.
+- Vary the question types across these categories:
+
+**Comprehension**: "In your own words, what does `[function]` do?" / "If I deleted `[line]`, what would break?" / "What data flows into `[function]`, and what comes out?"
+
+**Decision Reasoning**: "I used `[approach]` here -- why not `[alternative]`?" / "What's the tradeoff?" / "If this needed to handle 100x the load, what breaks first?"
+
+**System Thinking**: "Which other modules interact with `[thisModule]`?" / "Name the functions a request passes through from `[entry]` to `[here]`." / "What would a new developer need to know before touching `[file]`?"
+
+**Edge Cases**: "What happens if `[input]` is null/empty/malicious?" / "Where are the failure points?" / "If this fails silently, how would we know?"
+
+## Handling Answers
+
+**Correct answer**: Confirm briefly ("Exactly right.") and move on. Don't over-praise. Note strong understanding -- skip similar checks later.
+
+**Partial answer**: Give a focused hint: "You're close -- think about what happens at `[specific point]`." Don't give the full answer. Let them connect the dot.
+
+**Wrong or no answer**: Point them to the specific file and line: "Take a look at `[file:line]`. What do you see there?" Give them a moment to look before explaining. Then explain clearly and mark this as a gap area.
+
+**"skip" or "I know this"**: Respect it immediately. Move on. Log it internally for the session summary.
+
+## Difficulty Calibration
+
+Track the user's skill level by analyzing their answers in THIS session:
+
+- If 2+ answers in a row are "I don't know" or clearly wrong: shift to Comprehension questions, be more patient
+- If answers are correct but shallow (restating what code does without why): shift to Decision Reasoning and System Thinking
+- If the user proactively identifies trade-offs or suggests alternatives: shift to Edge Cases, challenge with "how would you design this differently?"
+
+## Escape Hatches
+
+- If the user says "flow mode" or "no questions": disable check-ins for the remainder of the current task. Resume on the next new task.
+- If the user says "summary" or "done": immediately produce the Session Learning Log.
+
+## Session Learning Log
+
+At natural breakpoints (end of a feature, end of a session, or on request), provide:
+
+```
+## Session Learning Log
+Understood: [concepts they demonstrated understanding of]
+Skipped: [check-ins they skipped]
+Gaps identified: [concepts they struggled with -- suggest revisiting]
+Suggested next steps: [specific files, docs, or concepts to review]
+```
+
+Connect gaps to project documentation, relevant source files, or official library docs.
+
+## Tone
+
+Be Socratic but not condescending. You're a senior engineer pairing with a colleague -- firm, direct, supportive. Never quiz for the sake of quizzing. Every question should have genuine learning value.
+
+## Anti-Patterns
+
+- Don't turn every line into a quiz. Pick the 2-3 most important things.
+- Don't ask questions you know they already understand.
+- Don't be condescending. Collaborative, not testing.
+- Don't block progress. If they want to skip, let them skip.
+- Don't repeat the same question type every time. Vary the categories.

--- a/packages/opencode/src/agent/prompt/learn.txt
+++ b/packages/opencode/src/agent/prompt/learn.txt
@@ -15,6 +15,15 @@ After EVERY non-trivial implementation (code change, bug fix, refactoring), you 
 2. Then IMMEDIATELY pause and ask 2-3 targeted comprehension questions
 3. Wait for the user's answers before proceeding to the next task
 
+## Tracking Comprehension
+
+You have two tools for tracking learning progress:
+
+- **learnwrite**: Call this AFTER the user answers (or skips) each comprehension question. Record the question, its category (comprehension/reasoning/system/edge), the answer quality (correct/partial/wrong/skipped), and the concepts covered.
+- **learnread**: Call this before generating a Session Learning Log, or to check the user's current level and adjust difficulty.
+
+Always use learnwrite to record results. This data persists for the session and powers the Session Learning Log.
+
 ## When to Ask Questions
 
 Only ask comprehension questions when the implementation involves:
@@ -43,36 +52,41 @@ Do NOT ask questions for: typo fixes, formatting changes, simple renames, depend
 
 ## Handling Answers
 
-**Correct answer**: Confirm briefly ("Exactly right.") and move on. Don't over-praise. Note strong understanding -- skip similar checks later.
+After evaluating the user's answer, ALWAYS call learnwrite to record the result before responding.
 
-**Partial answer**: Give a focused hint: "You're close -- think about what happens at `[specific point]`." Don't give the full answer. Let them connect the dot.
+**Correct answer**: Record as "correct". Confirm briefly ("Exactly right.") and move on. Don't over-praise.
 
-**Wrong or no answer**: Point them to the specific file and line: "Take a look at `[file:line]`. What do you see there?" Give them a moment to look before explaining. Then explain clearly and mark this as a gap area.
+**Partial answer**: Record as "partial". Give a focused hint: "You're close -- think about what happens at `[specific point]`." Don't give the full answer.
 
-**"skip" or "I know this"**: Respect it immediately. Move on. Log it internally for the session summary.
+**Wrong or no answer**: Record as "wrong". Point them to the specific file and line: "Take a look at `[file:line]`. What do you see there?"
+
+**"skip" or "I know this"**: Record as "skipped". Respect it immediately. Move on.
 
 ## Difficulty Calibration
 
-Track the user's skill level by analyzing their answers in THIS session:
+Use learnread to check the current level. The tracker automatically calibrates based on recent answers:
 
-- If 2+ answers in a row are "I don't know" or clearly wrong: shift to Comprehension questions, be more patient
-- If answers are correct but shallow (restating what code does without why): shift to Decision Reasoning and System Thinking
-- If the user proactively identifies trade-offs or suggests alternatives: shift to Edge Cases, challenge with "how would you design this differently?"
+- **beginner** (2+ recent wrong answers): Shift to Comprehension questions, be more patient
+- **intermediate** (default): Mix all question types
+- **advanced** (4+ recent correct answers): Focus on Edge Cases and System Thinking, challenge with "how would you design this differently?"
 
 ## Escape Hatches
 
 - If the user says "flow mode" or "no questions": disable check-ins for the remainder of the current task. Resume on the next new task.
-- If the user says "summary" or "done": immediately produce the Session Learning Log.
+- If the user says "summary" or "done": call learnread, then produce the Session Learning Log from the tracked data.
 
 ## Session Learning Log
 
-At natural breakpoints (end of a feature, end of a session, or on request), provide:
+At natural breakpoints (end of a feature, end of a session, or on request):
+
+1. Call learnread to get the tracked data
+2. Produce the log from actual tracked results:
 
 ```
 ## Session Learning Log
-Understood: [concepts they demonstrated understanding of]
-Skipped: [check-ins they skipped]
-Gaps identified: [concepts they struggled with -- suggest revisiting]
+Understood: [concepts marked as "correct" in the tracker]
+Skipped: [concepts marked as "skipped"]
+Gaps identified: [concepts marked as "wrong" or "partial" -- suggest revisiting]
 Suggested next steps: [specific files, docs, or concepts to review]
 ```
 
@@ -85,7 +99,7 @@ Be Socratic but not condescending. You're a senior engineer pairing with a colle
 ## Anti-Patterns
 
 - Don't turn every line into a quiz. Pick the 2-3 most important things.
-- Don't ask questions you know they already understand.
+- Don't ask questions you know they already understand (check with learnread first).
 - Don't be condescending. Collaborative, not testing.
 - Don't block progress. If they want to skip, let them skip.
 - Don't repeat the same question type every time. Vary the categories.

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -335,7 +335,7 @@ function App() {
   let resumed = false
   createEffect(() => {
     if (resumed || sync.status === "loading") return
-    if (args.continue || args.sessionID || args.prompt) return
+    if (args.continue || args.sessionID || args.prompt || args.agent || args.model) return
     const recent = sync.data.session
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .find((x) => x.parentID === undefined)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -865,8 +865,8 @@ export function Prompt(props: PromptProps) {
                 }
                 if (keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
-                    // kilocode_change start - double ctrl+c to exit, single ctrl+d exits immediately
-                    if (e.ctrl && e.name === "c") {
+                    // kilocode_change start - double ctrl+c/ctrl+d to exit
+                    if (e.ctrl && (e.name === "c" || e.name === "d")) {
                       setStore("exitPress", store.exitPress + 1)
                       setTimeout(() => {
                         setStore("exitPress", 0)
@@ -1141,10 +1141,10 @@ export function Prompt(props: PromptProps) {
           </Show>
           <Show when={status().type !== "retry"}>
             <box gap={2} flexDirection="row">
-              {/* kilocode_change start - show "ctrl+c again to exit" hint */}
+              {/* kilocode_change start - show "press again to exit" hint */}
               <Show when={store.exitPress > 0}>
                 <text fg={theme.primary}>
-                  ctrl+c <span style={{ fg: theme.primary }}>again to exit</span>
+                  press <span style={{ fg: theme.primary }}>again to exit</span>
                 </text>
               </Show>
               {/* kilocode_change end */}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1027,6 +1027,19 @@ export function Prompt(props: PromptProps) {
                       <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
                     </text>
                   </Show>
+                  {/* kilocode_change start */}
+                  <Show
+                    when={
+                      local.agent.current().name === "learn" && props.sessionID && sync.data.learn[props.sessionID!]
+                    }
+                  >
+                    <text fg={theme.textMuted}>·</text>
+                    <text fg={highlight()}>
+                      {sync.data.learn[props.sessionID!].level} · {sync.data.learn[props.sessionID!].checks.length}{" "}
+                      checks
+                    </text>
+                  </Show>
+                  {/* kilocode_change end */}
                 </box>
               </Show>
             </box>

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -17,6 +17,7 @@ import type {
   ProviderListResponse,
   ProviderAuthMethod,
   VcsInfo,
+  LearnState, // kilocode_change
 } from "@kilocode/sdk/v2"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
@@ -57,6 +58,10 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       todo: {
         [sessionID: string]: Todo[]
       }
+      learn: {
+        // kilocode_change
+        [sessionID: string]: LearnState
+      }
       message: {
         [sessionID: string]: Message[]
       }
@@ -92,6 +97,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session_status: {},
       session_diff: {},
       todo: {},
+      learn: {}, // kilocode_change
       message: {},
       part: {},
       lsp: [],
@@ -188,6 +194,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         case "todo.updated":
           setStore("todo", event.properties.sessionID, event.properties.todos)
           break
+
+        // kilocode_change start
+        case "learn.updated":
+          setStore("learn", event.properties.sessionID, event.properties.state)
+          break
+        // kilocode_change end
 
         case "session.diff":
           setStore("session_diff", event.properties.sessionID, event.properties.diff)

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -474,9 +474,14 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           )
           fullSyncedSessions.add(sessionID)
           // kilocode_change - lazy fetch learn state (non-blocking, most sessions don't use learn mode)
-          sdk.client.session.learn({ sessionID }).then((learn) => {
-            setStore("learn", sessionID, learn.data ?? { checks: [], level: "intermediate" })
-          })
+          sdk.client.session
+            .learn({ sessionID })
+            .then((learn) => {
+              setStore("learn", sessionID, learn.data ?? { checks: [], level: "intermediate" })
+            })
+            .catch((err) => {
+              Log.Default.info("learn state fetch skipped", { sessionID, err })
+            })
         },
       },
       bootstrap,

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -453,11 +453,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         },
         async sync(sessionID: string) {
           if (fullSyncedSessions.has(sessionID)) return
-          const [session, messages, todo, diff] = await Promise.all([
+          const [session, messages, todo, diff, learn] = await Promise.all([
             sdk.client.session.get({ sessionID }, { throwOnError: true }),
             sdk.client.session.messages({ sessionID, limit: 100 }),
             sdk.client.session.todo({ sessionID }),
             sdk.client.session.diff({ sessionID }),
+            sdk.client.session.learn({ sessionID }), // kilocode_change
           ])
           setStore(
             produce((draft) => {
@@ -465,6 +466,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               if (match.found) draft.session[match.index] = session.data!
               if (!match.found) draft.session.splice(match.index, 0, session.data!)
               draft.todo[sessionID] = todo.data ?? []
+              draft.learn[sessionID] = learn.data ?? { checks: [], level: "intermediate" } // kilocode_change
               draft.message[sessionID] = messages.data!.map((x) => x.info)
               for (const message of messages.data!) {
                 draft.part[message.info.id] = message.parts

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -241,12 +241,12 @@ export function Session() {
     // kilocode_change end
   })
 
-  // kilocode_change start - double ctrl+c to exit for child sessions
+  // kilocode_change start - double ctrl+c/ctrl+d to exit for child sessions
   const [exitPress, setExitPress] = createSignal(0)
   useKeyboard((evt) => {
     if (!session()?.parentID) return
     if (keybind.match("app_exit", evt)) {
-      if (evt.ctrl && evt.name === "c") {
+      if (evt.ctrl && (evt.name === "c" || evt.name === "d")) {
         evt.preventDefault()
         setExitPress(exitPress() + 1)
         setTimeout(() => setExitPress(0), 1000)

--- a/packages/opencode/src/kilocode/learn-tool.ts
+++ b/packages/opencode/src/kilocode/learn-tool.ts
@@ -1,0 +1,68 @@
+// kilocode_change - new file
+import z from "zod"
+import { Tool } from "../tool/tool"
+import { LearnTracker } from "./learn-tracker"
+
+export const LearnWriteTool = Tool.define("learnwrite", {
+  description: [
+    "Record a comprehension check result from a Learn mode session.",
+    "Use this after the user answers (or skips) a comprehension question.",
+    "This tracks what was understood, what was skipped, and where gaps exist.",
+    "",
+    "Parameters:",
+    "- question: The question you asked",
+    "- category: One of comprehension, reasoning, system, edge",
+    "- quality: One of correct, partial, wrong, skipped",
+    "- concepts: Array of identifiers/concepts the question covered",
+  ].join("\n"),
+  parameters: z.object({
+    question: z.string().describe("The comprehension question that was asked"),
+    category: LearnTracker.Category.describe("Question category"),
+    quality: LearnTracker.Quality.describe("Quality of the user's answer"),
+    concepts: z.array(z.string()).describe("Concepts or identifiers covered by this question"),
+  }),
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "learnwrite",
+      patterns: ["*"],
+      always: ["*"],
+      metadata: {},
+    })
+
+    const state = await LearnTracker.record({
+      sessionID: ctx.sessionID,
+      check: params,
+    })
+    const sum = LearnTracker.summary(state)
+    return {
+      title: `${state.checks.length} checks (level: ${state.level})`,
+      output: JSON.stringify(sum, null, 2),
+      metadata: { state },
+    }
+  },
+})
+
+export const LearnReadTool = Tool.define("learnread", {
+  description: [
+    "Read the current Learn mode tracking state for this session.",
+    "Use this to check the user's current level, what they've understood, and where gaps exist.",
+    "Use this before generating a Session Learning Log.",
+  ].join("\n"),
+  parameters: z.object({}),
+  async execute(_params, ctx) {
+    await ctx.ask({
+      permission: "learnread",
+      patterns: ["*"],
+      always: ["*"],
+      metadata: {},
+    })
+
+    const state = await LearnTracker.get(ctx.sessionID)
+    const sum = LearnTracker.summary(state)
+    return {
+      title: `${state.checks.length} checks (level: ${state.level})`,
+      output: JSON.stringify({ ...sum, checks: state.checks }, null, 2),
+      metadata: { state },
+    }
+  },
+})

--- a/packages/opencode/src/kilocode/learn-tracker.ts
+++ b/packages/opencode/src/kilocode/learn-tracker.ts
@@ -1,0 +1,95 @@
+// kilocode_change - new file
+import { BusEvent } from "@/bus/bus-event"
+import { Bus } from "@/bus"
+import z from "zod"
+import { Storage } from "../storage/storage"
+
+export namespace LearnTracker {
+  export const Category = z.enum(["comprehension", "reasoning", "system", "edge"])
+
+  export const Quality = z.enum(["correct", "partial", "wrong", "skipped"])
+
+  export const Check = z
+    .object({
+      id: z.string(),
+      question: z.string(),
+      category: Category,
+      quality: Quality,
+      concepts: z.array(z.string()).describe("Concepts or identifiers referenced in this check"),
+      timestamp: z.number(),
+    })
+    .meta({ ref: "LearnCheck" })
+  export type Check = z.infer<typeof Check>
+
+  export const State = z
+    .object({
+      checks: z.array(Check),
+      level: z.enum(["beginner", "intermediate", "advanced"]),
+    })
+    .meta({ ref: "LearnState" })
+  export type State = z.infer<typeof State>
+
+  export const Event = {
+    Updated: BusEvent.define(
+      "learn.updated",
+      z.object({
+        sessionID: z.string(),
+        state: State,
+      }),
+    ),
+  }
+
+  function empty(): State {
+    return { checks: [], level: "intermediate" }
+  }
+
+  export async function get(sessionID: string): Promise<State> {
+    return Storage.read<State>(["learn", sessionID])
+      .then((x) => x || empty())
+      .catch(() => empty())
+  }
+
+  export async function record(input: { sessionID: string; check: Omit<Check, "id" | "timestamp"> }) {
+    const current = await get(input.sessionID)
+    const check: Check = {
+      ...input.check,
+      id: `chk_${Date.now().toString(36)}`,
+      timestamp: Date.now(),
+    }
+    current.checks.push(check)
+    current.level = calibrate(current.checks)
+    await Storage.write(["learn", input.sessionID], current)
+    Bus.publish(Event.Updated, { sessionID: input.sessionID, state: current })
+    return current
+  }
+
+  export async function clear(sessionID: string) {
+    const state = empty()
+    await Storage.write(["learn", sessionID], state)
+    Bus.publish(Event.Updated, { sessionID, state })
+  }
+
+  function calibrate(checks: Check[]): State["level"] {
+    const recent = checks.slice(-5)
+    if (recent.length === 0) return "intermediate"
+    const wrong = recent.filter((c) => c.quality === "wrong").length
+    const correct = recent.filter((c) => c.quality === "correct").length
+    if (wrong >= 2) return "beginner"
+    if (correct >= 4) return "advanced"
+    return "intermediate"
+  }
+
+  export function summary(state: State) {
+    const understood = state.checks.filter((c) => c.quality === "correct").flatMap((c) => c.concepts)
+    const skipped = state.checks.filter((c) => c.quality === "skipped").flatMap((c) => c.concepts)
+    const gaps = state.checks.filter((c) => c.quality === "wrong" || c.quality === "partial").flatMap((c) => c.concepts)
+
+    return {
+      understood: [...new Set(understood)],
+      skipped: [...new Set(skipped)],
+      gaps: [...new Set(gaps)],
+      total: state.checks.length,
+      level: state.level,
+    }
+  }
+}

--- a/packages/opencode/src/kilocode/learn-tracker.ts
+++ b/packages/opencode/src/kilocode/learn-tracker.ts
@@ -131,10 +131,13 @@ export namespace LearnTracker {
       .catch(() => emptyAggregate())
   }
 
+  const MAX_AGGREGATE_CHECKS = 500
+
   export async function appendAggregate(input: { sessionID: string; check: Check }) {
     const current = await getAggregate()
     const entry: AggregateCheck = { ...input.check, sessionID: input.sessionID }
     current.checks.push(entry)
+    if (current.checks.length > MAX_AGGREGATE_CHECKS) current.checks = current.checks.slice(-MAX_AGGREGATE_CHECKS)
     current.level = calibrate(current.checks)
     const ids = new Set(current.checks.map((c) => c.sessionID))
     current.sessions = ids.size

--- a/packages/opencode/src/kilocode/learn-tracker.ts
+++ b/packages/opencode/src/kilocode/learn-tracker.ts
@@ -58,7 +58,7 @@ export namespace LearnTracker {
     const now = Date.now()
     const check: Check = {
       ...input.check,
-      id: `chk_${now.toString(36)}`,
+      id: `chk_${now.toString(36)}_${Math.random().toString(36).slice(2, 6)}`,
       timestamp: now,
     }
     current.checks.push(check)

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -10,6 +10,7 @@ import { SessionRevert } from "../../session/revert"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "../../session/todo"
+import { LearnTracker } from "../../kilocode/learn-tracker" // kilocode_change
 import { Agent } from "../../agent/agent"
 import { Snapshot } from "@/snapshot"
 import { Log } from "../../util/log"
@@ -182,6 +183,39 @@ export const SessionRoutes = lazy(() =>
         return c.json(todos)
       },
     )
+    // kilocode_change start
+    .get(
+      "/:sessionID/learn",
+      describeRoute({
+        summary: "Get learn state",
+        description:
+          "Retrieve the learning tracker state for a session, including comprehension checks, difficulty level, and summary.",
+        operationId: "session.learn",
+        responses: {
+          200: {
+            description: "Learn state",
+            content: {
+              "application/json": {
+                schema: resolver(LearnTracker.State),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const state = await LearnTracker.get(sessionID)
+        return c.json(state)
+      },
+    )
+    // kilocode_change end
     .post(
       "/",
       describeRoute({

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -90,6 +90,31 @@ export const SessionRoutes = lazy(() =>
         return c.json(result)
       },
     )
+    // kilocode_change start
+    .get(
+      "/learn-aggregate",
+      describeRoute({
+        summary: "Get project learn aggregate",
+        description: "Retrieve the aggregated learning progress across all sessions for the current project.",
+        operationId: "session.learnAggregate",
+        responses: {
+          200: {
+            description: "Learn aggregate",
+            content: {
+              "application/json": {
+                schema: resolver(LearnTracker.Aggregate),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      async (c) => {
+        const aggregate = await LearnTracker.getAggregate()
+        return c.json(aggregate)
+      },
+    )
+    // kilocode_change end
     .get(
       "/:sessionID",
       describeRoute({

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -27,6 +27,7 @@ import { LspTool } from "./lsp"
 import { Truncate } from "./truncation"
 import { PlanExitTool, PlanEnterTool } from "./plan"
 import { ApplyPatchTool } from "./apply_patch"
+import { LearnWriteTool, LearnReadTool } from "../kilocode/learn-tool" // kilocode_change
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -112,6 +113,8 @@ export namespace ToolRegistry {
       CodeSearchTool,
       SkillTool,
       ApplyPatchTool,
+      LearnWriteTool, // kilocode_change
+      LearnReadTool, // kilocode_change
       ...(Flag.KILO_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...(Flag.KILO_EXPERIMENTAL_PLAN_MODE && Flag.KILO_CLIENT === "cli" ? [PlanExitTool, PlanEnterTool] : []),

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -748,6 +748,7 @@ test("defaultAgent throws when all primary agents are disabled", async () => {
         debug: { disable: true },
         orchestrator: { disable: true },
         ask: { disable: true },
+        learn: { disable: true },
         // kilocode_change end
       },
     },

--- a/packages/opencode/test/kilocode/learn-tool.test.ts
+++ b/packages/opencode/test/kilocode/learn-tool.test.ts
@@ -1,0 +1,243 @@
+// kilocode_change - new file
+import { describe, expect, test } from "bun:test"
+import { LearnWriteTool, LearnReadTool } from "../../src/kilocode/learn-tool"
+import { LearnTracker } from "../../src/kilocode/learn-tracker"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import type { Tool } from "../../src/tool/tool"
+
+const baseCtx: Omit<Tool.Context, "ask"> = {
+  sessionID: "tool-test",
+  messageID: "",
+  callID: "",
+  agent: "learn",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+}
+
+describe("LearnWriteTool", () => {
+  test("records a check and returns summary", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await LearnWriteTool.init()
+        const ctx: Tool.Context = { ...baseCtx, sessionID: "write-test", ask: async () => {} }
+
+        const result = await tool.execute(
+          {
+            question: "What does calibrate return?",
+            category: "comprehension",
+            quality: "correct",
+            concepts: ["calibrate", "LearnTracker"],
+          },
+          ctx,
+        )
+
+        expect(result.title).toContain("1 checks")
+        expect(result.title).toContain("level:")
+        const output = JSON.parse(result.output)
+        expect(output.understood).toContain("calibrate")
+        expect(output.understood).toContain("LearnTracker")
+        expect(output.total).toBe(1)
+      },
+    })
+  })
+
+  test("accumulates checks across multiple writes", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await LearnWriteTool.init()
+        const ctx: Tool.Context = { ...baseCtx, sessionID: "multi-write", ask: async () => {} }
+
+        await tool.execute({ question: "Q1", category: "comprehension", quality: "correct", concepts: ["a"] }, ctx)
+        const result = await tool.execute(
+          { question: "Q2", category: "reasoning", quality: "wrong", concepts: ["b"] },
+          ctx,
+        )
+
+        expect(result.title).toContain("2 checks")
+        const output = JSON.parse(result.output)
+        expect(output.understood).toEqual(["a"])
+        expect(output.gaps).toEqual(["b"])
+        expect(output.total).toBe(2)
+      },
+    })
+  })
+
+  test("requests learnwrite permission", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await LearnWriteTool.init()
+        const requests: { permission: string }[] = []
+        const ctx: Tool.Context = {
+          ...baseCtx,
+          sessionID: "perm-write",
+          ask: async (req) => {
+            requests.push(req as { permission: string })
+          },
+        }
+
+        await tool.execute({ question: "Q1", category: "comprehension", quality: "correct", concepts: ["x"] }, ctx)
+
+        expect(requests).toHaveLength(1)
+        expect(requests[0].permission).toBe("learnwrite")
+      },
+    })
+  })
+
+  test("returns state in metadata", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await LearnWriteTool.init()
+        const ctx: Tool.Context = { ...baseCtx, sessionID: "meta-write", ask: async () => {} }
+
+        const result = await tool.execute(
+          { question: "Q1", category: "edge", quality: "partial", concepts: ["y"] },
+          ctx,
+        )
+
+        expect(result.metadata.state).toBeDefined()
+        expect(result.metadata.state.checks).toHaveLength(1)
+        expect(result.metadata.state.level).toBe("intermediate")
+      },
+    })
+  })
+})
+
+describe("LearnReadTool", () => {
+  test("returns empty state for fresh session", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await LearnReadTool.init()
+        const ctx: Tool.Context = { ...baseCtx, sessionID: "read-fresh", ask: async () => {} }
+
+        const result = await tool.execute({}, ctx)
+
+        expect(result.title).toContain("0 checks")
+        const output = JSON.parse(result.output)
+        expect(output.understood).toEqual([])
+        expect(output.gaps).toEqual([])
+        expect(output.skipped).toEqual([])
+        expect(output.total).toBe(0)
+        expect(output.checks).toEqual([])
+      },
+    })
+  })
+
+  test("reads state written by LearnWriteTool", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const writer = await LearnWriteTool.init()
+        const reader = await LearnReadTool.init()
+        const ctx: Tool.Context = { ...baseCtx, sessionID: "read-after-write", ask: async () => {} }
+
+        await writer.execute({ question: "Q1", category: "system", quality: "correct", concepts: ["Bus"] }, ctx)
+        await writer.execute({ question: "Q2", category: "edge", quality: "wrong", concepts: ["SSE"] }, ctx)
+
+        const result = await reader.execute({}, ctx)
+        const output = JSON.parse(result.output)
+
+        expect(output.understood).toEqual(["Bus"])
+        expect(output.gaps).toEqual(["SSE"])
+        expect(output.total).toBe(2)
+        expect(output.checks).toHaveLength(2)
+        expect(output.checks[0].question).toBe("Q1")
+        expect(output.checks[1].question).toBe("Q2")
+      },
+    })
+  })
+
+  test("requests learnread permission", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await LearnReadTool.init()
+        const requests: { permission: string }[] = []
+        const ctx: Tool.Context = {
+          ...baseCtx,
+          sessionID: "perm-read",
+          ask: async (req) => {
+            requests.push(req as { permission: string })
+          },
+        }
+
+        await tool.execute({}, ctx)
+
+        expect(requests).toHaveLength(1)
+        expect(requests[0].permission).toBe("learnread")
+      },
+    })
+  })
+
+  test("includes full checks array in output", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // Write directly via tracker to set up state
+        await LearnTracker.record({
+          sessionID: "read-full",
+          check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["fn1"] },
+        })
+
+        const tool = await LearnReadTool.init()
+        const ctx: Tool.Context = { ...baseCtx, sessionID: "read-full", ask: async () => {} }
+
+        const result = await tool.execute({}, ctx)
+        const output = JSON.parse(result.output)
+
+        // learnread includes checks array (unlike summary-only)
+        expect(output.checks).toBeDefined()
+        expect(output.checks[0].id).toStartWith("chk_")
+        expect(output.checks[0].timestamp).toBeGreaterThan(0)
+      },
+    })
+  })
+
+  test("reflects calibrated level in title", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const sid = "level-title"
+        // Record 4 correct to reach advanced
+        await LearnTracker.record({
+          sessionID: sid,
+          check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["a"] },
+        })
+        await LearnTracker.record({
+          sessionID: sid,
+          check: { question: "Q2", category: "reasoning", quality: "correct", concepts: ["b"] },
+        })
+        await LearnTracker.record({
+          sessionID: sid,
+          check: { question: "Q3", category: "system", quality: "correct", concepts: ["c"] },
+        })
+        await LearnTracker.record({
+          sessionID: sid,
+          check: { question: "Q4", category: "edge", quality: "correct", concepts: ["d"] },
+        })
+
+        const tool = await LearnReadTool.init()
+        const ctx: Tool.Context = { ...baseCtx, sessionID: sid, ask: async () => {} }
+
+        const result = await tool.execute({}, ctx)
+        expect(result.title).toContain("advanced")
+        expect(result.title).toContain("4 checks")
+      },
+    })
+  })
+})

--- a/packages/opencode/test/kilocode/learn-tracker.test.ts
+++ b/packages/opencode/test/kilocode/learn-tracker.test.ts
@@ -1,0 +1,521 @@
+// kilocode_change - new file
+import { test, expect, describe, afterEach } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { LearnTracker } from "../../src/kilocode/learn-tracker"
+import { Bus } from "../../src/bus"
+
+describe("LearnTracker", () => {
+  describe("get", () => {
+    test("returns empty state for unknown session", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const state = await LearnTracker.get("nonexistent")
+          expect(state.checks).toEqual([])
+          expect(state.level).toBe("intermediate")
+        },
+      })
+    })
+  })
+
+  describe("record", () => {
+    test("records a check and returns updated state", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const state = await LearnTracker.record({
+            sessionID: "test-session",
+            check: {
+              question: "What does processQueue do?",
+              category: "comprehension",
+              quality: "correct",
+              concepts: ["processQueue", "queue"],
+            },
+          })
+
+          expect(state.checks).toHaveLength(1)
+          expect(state.checks[0].question).toBe("What does processQueue do?")
+          expect(state.checks[0].category).toBe("comprehension")
+          expect(state.checks[0].quality).toBe("correct")
+          expect(state.checks[0].concepts).toEqual(["processQueue", "queue"])
+          expect(state.checks[0].id).toStartWith("chk_")
+          expect(state.checks[0].timestamp).toBeGreaterThan(0)
+        },
+      })
+    })
+
+    test("appends multiple checks to the same session", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await LearnTracker.record({
+            sessionID: "append-test",
+            check: {
+              question: "Q1",
+              category: "comprehension",
+              quality: "correct",
+              concepts: ["a"],
+            },
+          })
+          const state = await LearnTracker.record({
+            sessionID: "append-test",
+            check: {
+              question: "Q2",
+              category: "reasoning",
+              quality: "wrong",
+              concepts: ["b"],
+            },
+          })
+
+          expect(state.checks).toHaveLength(2)
+          expect(state.checks[0].question).toBe("Q1")
+          expect(state.checks[1].question).toBe("Q2")
+        },
+      })
+    })
+
+    test("persists state across reads", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await LearnTracker.record({
+            sessionID: "persist-test",
+            check: {
+              question: "Q1",
+              category: "comprehension",
+              quality: "correct",
+              concepts: ["x"],
+            },
+          })
+
+          const state = await LearnTracker.get("persist-test")
+          expect(state.checks).toHaveLength(1)
+          expect(state.checks[0].question).toBe("Q1")
+        },
+      })
+    })
+
+    test("isolates sessions from each other", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await LearnTracker.record({
+            sessionID: "session-a",
+            check: {
+              question: "Q-A",
+              category: "comprehension",
+              quality: "correct",
+              concepts: ["a"],
+            },
+          })
+          await LearnTracker.record({
+            sessionID: "session-b",
+            check: {
+              question: "Q-B",
+              category: "edge",
+              quality: "wrong",
+              concepts: ["b"],
+            },
+          })
+
+          const stateA = await LearnTracker.get("session-a")
+          const stateB = await LearnTracker.get("session-b")
+
+          expect(stateA.checks).toHaveLength(1)
+          expect(stateA.checks[0].question).toBe("Q-A")
+          expect(stateB.checks).toHaveLength(1)
+          expect(stateB.checks[0].question).toBe("Q-B")
+        },
+      })
+    })
+
+    test("publishes learn.updated bus event on record", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const events: { sessionID: string; state: LearnTracker.State }[] = []
+          const unsub = Bus.subscribe(LearnTracker.Event.Updated, (evt) => {
+            events.push(evt.properties)
+          })
+
+          await LearnTracker.record({
+            sessionID: "bus-test",
+            check: {
+              question: "Q1",
+              category: "comprehension",
+              quality: "correct",
+              concepts: ["x"],
+            },
+          })
+
+          expect(events).toHaveLength(1)
+          expect(events[0].sessionID).toBe("bus-test")
+          expect(events[0].state.checks).toHaveLength(1)
+
+          unsub()
+        },
+      })
+    })
+
+    test("generates unique check IDs", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const state1 = await LearnTracker.record({
+            sessionID: "id-test",
+            check: {
+              question: "Q1",
+              category: "comprehension",
+              quality: "correct",
+              concepts: ["a"],
+            },
+          })
+          // small delay to ensure different timestamps
+          await new Promise((r) => setTimeout(r, 2))
+          const state2 = await LearnTracker.record({
+            sessionID: "id-test",
+            check: {
+              question: "Q2",
+              category: "reasoning",
+              quality: "partial",
+              concepts: ["b"],
+            },
+          })
+
+          expect(state2.checks[0].id).not.toBe(state2.checks[1].id)
+        },
+      })
+    })
+  })
+
+  describe("clear", () => {
+    test("resets state to empty", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await LearnTracker.record({
+            sessionID: "clear-test",
+            check: {
+              question: "Q1",
+              category: "comprehension",
+              quality: "correct",
+              concepts: ["a"],
+            },
+          })
+
+          await LearnTracker.clear("clear-test")
+
+          const state = await LearnTracker.get("clear-test")
+          expect(state.checks).toEqual([])
+          expect(state.level).toBe("intermediate")
+        },
+      })
+    })
+
+    test("publishes bus event on clear", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const events: { sessionID: string; state: LearnTracker.State }[] = []
+          const unsub = Bus.subscribe(LearnTracker.Event.Updated, (evt) => {
+            events.push(evt.properties)
+          })
+
+          await LearnTracker.clear("clear-bus-test")
+
+          expect(events).toHaveLength(1)
+          expect(events[0].state.checks).toEqual([])
+          expect(events[0].state.level).toBe("intermediate")
+
+          unsub()
+        },
+      })
+    })
+  })
+
+  describe("calibrate (via record)", () => {
+    test("defaults to intermediate with no checks", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const state = await LearnTracker.get("empty")
+          expect(state.level).toBe("intermediate")
+        },
+      })
+    })
+
+    test("stays intermediate with mixed results", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "mixed"
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["a"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "wrong", concepts: ["b"] },
+          })
+          const state = await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q3", category: "system", quality: "correct", concepts: ["c"] },
+          })
+
+          expect(state.level).toBe("intermediate")
+        },
+      })
+    })
+
+    test("drops to beginner with 2+ wrong in last 5", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "beginner"
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["a"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "wrong", concepts: ["b"] },
+          })
+          const state = await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q3", category: "system", quality: "wrong", concepts: ["c"] },
+          })
+
+          expect(state.level).toBe("beginner")
+        },
+      })
+    })
+
+    test("rises to advanced with 4+ correct in last 5", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "advanced"
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["a"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "correct", concepts: ["b"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q3", category: "system", quality: "correct", concepts: ["c"] },
+          })
+          const state = await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q4", category: "edge", quality: "correct", concepts: ["d"] },
+          })
+
+          expect(state.level).toBe("advanced")
+        },
+      })
+    })
+
+    test("wrong takes priority over correct in calibration", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "priority"
+          // 4 correct + 2 wrong = beginner (wrong >= 2 checked first)
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["a"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "correct", concepts: ["b"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q3", category: "system", quality: "wrong", concepts: ["c"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q4", category: "edge", quality: "correct", concepts: ["d"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q5", category: "comprehension", quality: "wrong", concepts: ["e"] },
+          })
+          const state = await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q6", category: "reasoning", quality: "correct", concepts: ["f"] },
+          })
+
+          // Last 5: correct, wrong, correct, wrong, correct => 2 wrong => beginner
+          expect(state.level).toBe("beginner")
+        },
+      })
+    })
+
+    test("sliding window only considers last 5 checks", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "window"
+          // First 3 are wrong (will slide out of window)
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "wrong", concepts: ["a"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "wrong", concepts: ["b"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q3", category: "system", quality: "wrong", concepts: ["c"] },
+          })
+          // Next 5 are correct (these are the last 5)
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q4", category: "edge", quality: "correct", concepts: ["d"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q5", category: "comprehension", quality: "correct", concepts: ["e"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q6", category: "reasoning", quality: "correct", concepts: ["f"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q7", category: "system", quality: "correct", concepts: ["g"] },
+          })
+          const state = await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q8", category: "edge", quality: "correct", concepts: ["h"] },
+          })
+
+          // Last 5: correct, correct, correct, correct, correct => 5 correct => advanced
+          expect(state.level).toBe("advanced")
+        },
+      })
+    })
+
+    test("skipped answers do not count as wrong or correct", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "skipped"
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "skipped", concepts: ["a"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "skipped", concepts: ["b"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q3", category: "system", quality: "skipped", concepts: ["c"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q4", category: "edge", quality: "skipped", concepts: ["d"] },
+          })
+          const state = await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q5", category: "comprehension", quality: "skipped", concepts: ["e"] },
+          })
+
+          // All skipped: 0 wrong, 0 correct => intermediate
+          expect(state.level).toBe("intermediate")
+        },
+      })
+    })
+  })
+
+  describe("summary", () => {
+    test("categorizes checks by quality", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "summary-test"
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["Storage"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "wrong", concepts: ["Bus"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q3", category: "system", quality: "skipped", concepts: ["SSE"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q4", category: "edge", quality: "partial", concepts: ["calibrate"] },
+          })
+
+          const state = await LearnTracker.get(sid)
+          const sum = LearnTracker.summary(state)
+
+          expect(sum.understood).toEqual(["Storage"])
+          expect(sum.gaps).toEqual(["Bus", "calibrate"])
+          expect(sum.skipped).toEqual(["SSE"])
+          expect(sum.total).toBe(4)
+        },
+      })
+    })
+
+    test("deduplicates concepts across checks", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const sid = "dedup-test"
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q1", category: "comprehension", quality: "correct", concepts: ["Storage", "Bus"] },
+          })
+          await LearnTracker.record({
+            sessionID: sid,
+            check: { question: "Q2", category: "reasoning", quality: "correct", concepts: ["Storage", "SSE"] },
+          })
+
+          const state = await LearnTracker.get(sid)
+          const sum = LearnTracker.summary(state)
+
+          // Storage appears in both checks but should be deduplicated
+          expect(sum.understood).toEqual(["Storage", "Bus", "SSE"])
+        },
+      })
+    })
+
+    test("returns empty arrays for empty state", () => {
+      const sum = LearnTracker.summary({ checks: [], level: "intermediate" })
+      expect(sum.understood).toEqual([])
+      expect(sum.gaps).toEqual([])
+      expect(sum.skipped).toEqual([])
+      expect(sum.total).toBe(0)
+      expect(sum.level).toBe("intermediate")
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -121,6 +121,8 @@ import type {
   SessionGetResponses,
   SessionInitErrors,
   SessionInitResponses,
+  SessionLearnAggregateErrors,
+  SessionLearnAggregateResponses,
   SessionLearnErrors,
   SessionLearnResponses,
   SessionListResponses,
@@ -1028,6 +1030,29 @@ export class Session extends HeyApiClient {
     const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
     return (options?.client ?? this.client).get<SessionStatusResponses, SessionStatusErrors, ThrowOnError>({
       url: "/session/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get project learn aggregate
+   *
+   * Retrieve the aggregated learning progress across all sessions for the current project.
+   */
+  public learnAggregate<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<
+      SessionLearnAggregateResponses,
+      SessionLearnAggregateErrors,
+      ThrowOnError
+    >({
+      url: "/session/learn-aggregate",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -121,6 +121,8 @@ import type {
   SessionGetResponses,
   SessionInitErrors,
   SessionInitResponses,
+  SessionLearnErrors,
+  SessionLearnResponses,
   SessionListResponses,
   SessionMessageErrors,
   SessionMessageResponses,
@@ -1187,6 +1189,36 @@ export class Session extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<SessionTodoResponses, SessionTodoErrors, ThrowOnError>({
       url: "/session/{sessionID}/todo",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get learn state
+   *
+   * Retrieve the learning tracker state for a session, including comprehension checks, difficulty level, and summary.
+   */
+  public learn<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionLearnResponses, SessionLearnErrors, ThrowOnError>({
+      url: "/session/{sessionID}/learn",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -713,6 +713,31 @@ export type EventTodoUpdated = {
   }
 }
 
+export type LearnCheck = {
+  id: string
+  question: string
+  category: "comprehension" | "reasoning" | "system" | "edge"
+  quality: "correct" | "partial" | "wrong" | "skipped"
+  /**
+   * Concepts or identifiers referenced in this check
+   */
+  concepts: Array<string>
+  timestamp: number
+}
+
+export type LearnState = {
+  checks: Array<LearnCheck>
+  level: "beginner" | "intermediate" | "advanced"
+}
+
+export type EventLearnUpdated = {
+  type: "learn.updated"
+  properties: {
+    sessionID: string
+    state: LearnState
+  }
+}
+
 export type EventTuiPromptAppend = {
   type: "tui.prompt.append"
   properties: {
@@ -978,6 +1003,7 @@ export type Event =
   | EventSessionCompacted
   | EventFileWatcherUpdated
   | EventTodoUpdated
+  | EventLearnUpdated
   | EventTuiPromptAppend
   | EventTuiCommandExecute
   | EventTuiToastShow
@@ -3181,6 +3207,42 @@ export type SessionTodoResponses = {
 }
 
 export type SessionTodoResponse = SessionTodoResponses[keyof SessionTodoResponses]
+
+export type SessionLearnData = {
+  body?: never
+  path: {
+    /**
+     * Session ID
+     */
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/learn"
+}
+
+export type SessionLearnErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionLearnError = SessionLearnErrors[keyof SessionLearnErrors]
+
+export type SessionLearnResponses = {
+  /**
+   * Learn state
+   */
+  200: LearnState
+}
+
+export type SessionLearnResponse = SessionLearnResponses[keyof SessionLearnResponses]
 
 export type SessionInitData = {
   body?: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2099,6 +2099,28 @@ export type McpResource = {
   client: string
 }
 
+export type LearnAggregateCheck = {
+  id: string
+  question: string
+  category: "comprehension" | "reasoning" | "system" | "edge"
+  quality: "correct" | "partial" | "wrong" | "skipped"
+  /**
+   * Concepts or identifiers referenced in this check
+   */
+  concepts: Array<string>
+  timestamp: number
+  sessionID: string
+}
+
+export type LearnAggregate = {
+  checks: Array<LearnAggregateCheck>
+  level: "beginner" | "intermediate" | "advanced"
+  /**
+   * Number of sessions with learn data
+   */
+  sessions: number
+}
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -3034,6 +3056,33 @@ export type SessionStatusResponses = {
 }
 
 export type SessionStatusResponse = SessionStatusResponses[keyof SessionStatusResponses]
+
+export type SessionLearnAggregateData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/session/learn-aggregate"
+}
+
+export type SessionLearnAggregateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type SessionLearnAggregateError = SessionLearnAggregateErrors[keyof SessionLearnAggregateErrors]
+
+export type SessionLearnAggregateResponses = {
+  /**
+   * Learn aggregate
+   */
+  200: LearnAggregate
+}
+
+export type SessionLearnAggregateResponse = SessionLearnAggregateResponses[keyof SessionLearnAggregateResponses]
 
 export type SessionDeleteData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1425,6 +1425,50 @@
         ]
       }
     },
+    "/session/learn-aggregate": {
+      "get": {
+        "operationId": "session.learnAggregate",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get project learn aggregate",
+        "description": "Retrieve the aggregated learning progress across all sessions for the current project.",
+        "responses": {
+          "200": {
+            "description": "Learn aggregate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LearnAggregate"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.session.learnAggregate({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}": {
       "get": {
         "operationId": "session.get",
@@ -11076,6 +11120,59 @@
           }
         },
         "required": ["name", "uri", "client"]
+      },
+      "LearnAggregateCheck": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["comprehension", "reasoning", "system", "edge"]
+          },
+          "quality": {
+            "type": "string",
+            "enum": ["correct", "partial", "wrong", "skipped"]
+          },
+          "concepts": {
+            "description": "Concepts or identifiers referenced in this check",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "sessionID": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "question", "category", "quality", "concepts", "timestamp", "sessionID"]
+      },
+      "LearnAggregate": {
+        "type": "object",
+        "properties": {
+          "checks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LearnAggregateCheck"
+            }
+          },
+          "level": {
+            "type": "string",
+            "enum": ["beginner", "intermediate", "advanced"]
+          },
+          "sessions": {
+            "description": "Number of sessions with learn data",
+            "type": "number"
+          }
+        },
+        "required": ["checks", "level", "sessions"]
       },
       "TextPartInput": {
         "type": "object",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1765,6 +1765,69 @@
         ]
       }
     },
+    "/session/{sessionID}/learn": {
+      "get": {
+        "operationId": "session.learn",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Session ID"
+          }
+        ],
+        "summary": "Get learn state",
+        "description": "Retrieve the learning tracker state for a session, including comprehension checks, difficulty level, and summary.",
+        "responses": {
+          "200": {
+            "description": "Learn state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LearnState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.session.learn({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/init": {
       "post": {
         "operationId": "session.init",
@@ -8177,6 +8240,74 @@
         },
         "required": ["type", "properties"]
       },
+      "LearnCheck": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["comprehension", "reasoning", "system", "edge"]
+          },
+          "quality": {
+            "type": "string",
+            "enum": ["correct", "partial", "wrong", "skipped"]
+          },
+          "concepts": {
+            "description": "Concepts or identifiers referenced in this check",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": ["id", "question", "category", "quality", "concepts", "timestamp"]
+      },
+      "LearnState": {
+        "type": "object",
+        "properties": {
+          "checks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LearnCheck"
+            }
+          },
+          "level": {
+            "type": "string",
+            "enum": ["beginner", "intermediate", "advanced"]
+          }
+        },
+        "required": ["checks", "level"]
+      },
+      "Event.learn.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "learn.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "state": {
+                "$ref": "#/components/schemas/LearnState"
+              }
+            },
+            "required": ["sessionID", "state"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "Event.tui.prompt.append": {
         "type": "object",
         "properties": {
@@ -8895,6 +9026,9 @@
           },
           {
             "$ref": "#/components/schemas/Event.todo.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.learn.updated"
           },
           {
             "$ref": "#/components/schemas/Event.tui.prompt.append"


### PR DESCRIPTION
## Hackathon Submission
**Kilo League Challenge #3 — "For Devs, By Devs"** | DeveloperWeek 2026
This PR is our submission for the DeveloperWeek 2026 hackathon track. 
It contributes a new native feature to Kilo: Learn Mode.

## Summary

Learn Mode is a new native agent for Kilo Code that turns AI-assisted coding into AI-mentored coding. After every implementation, the agent pauses to ask 2-3 targeted comprehension questions to make sure the developer actually understands what was built. Working code you can't explain is technical debt in your brain.

## What It Does

1. **Implements code fully** -- no degraded coding experience
2. **Pauses after implementation** to ask comprehension questions referencing specific functions, variables, and file paths
3. **Tracks understanding** with a persistent learning tracker (4 question categories: Comprehension, Reasoning, System Thinking, Edge Cases)
4. **Auto-calibrates difficulty** via a sliding window algorithm over the last 5 answers
5. **Persists progress across sessions** via a project-scoped aggregate keyed by git root commit hash
6. **Shows real-time status** in the TUI prompt bar via Bus -> SSE -> SolidJS reactivity

## Architecture

```
User answers question
    |
    v
LLM calls learnwrite tool
    |
    v
LearnTracker.record()
    |--- Storage.write(["learn", sessionID])              [session state]
    |--- appendAggregate(["learn_aggregate", projectID])  [cross-session]
    |--- Bus.publish("learn.updated")
              |
              v
         SSE -> TUI sync store -> prompt bar indicator
```

## Files Changed

| Layer | File | Change |
|-------|------|--------|
| Agent | src/agent/agent.ts | Native learn agent with custom permissions |
| Prompt | src/agent/prompt/learn.txt | Full system prompt (106 lines) |
| Tracker | src/kilocode/learn-tracker.ts | Learning state + calibration + aggregate |
| Tools | src/kilocode/learn-tool.ts | learnwrite/learnread with permission gating |
| Registry | src/tool/registry.ts | Register learn tools |
| Server | src/server/routes/session.ts | GET /:sessionID/learn + GET /learn-aggregate |
| TUI Sync | src/cli/cmd/tui/context/sync.tsx | learn.updated event handler + initial fetch |
| TUI Prompt | src/cli/cmd/tui/component/prompt/index.tsx | Learn level indicator |
| Tests | test/kilocode/learn-tracker.test.ts | 25 tests (calibration, persistence, bus, aggregate) |
| Tests | test/kilocode/learn-tool.test.ts | 9 tests (tools, permissions) |
| Tests | test/agent/agent.test.ts | Fix disabled agents test |
| SDK | packages/sdk/js/src/v2/gen/ | Auto-generated types + client methods |
| Skill | .kilocode/skills/anti-cognitive-offloading/SKILL.md | Question framework |

## Test Results

- **34 new tests**, all passing
- **0 regressions** on existing test suite
- **Clean typecheck** across all 10 packages

## Key Design Decisions

- **Permission gating**: learnwrite/learnread denied globally, allowed only for learn agent
- **Write-before-publish**: Storage.write() completes before Bus.publish() fires, ensuring SSE clients never read stale data
- **Aggregate is best-effort**: appendAggregate() uses .catch(() => {}) so aggregate failures don't break session-level tracking
- **kilocode_change markers**: All changes to shared files are marked for upstream merge compatibility