### PR TITLE
fix(agent-manager): resolve sessionsLoaded race condition with webview mount

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -153,7 +153,17 @@ export class AgentManagerProvider implements vscode.Disposable {
     }
     if (type === "agentManager.requestState") {
       void this.stateReady
-        ?.then(() => this.pushState())
+        ?.then(() => {
+          this.pushState()
+          // Refresh sessions after pushState so the webview's sessionsLoaded
+          // handler is guaranteed to be registered (requestState fires from
+          // onMount). Without this, the initial refreshSessions() in
+          // initializeState() can race ahead of webview mount, causing
+          // sessionsLoaded to never flip to true.
+          if (this.state && this.state.getSessions().length > 0) {
+            this.provider?.refreshSessions()
+          }
+        })
         .catch((err) => {
           this.log("initializeState failed, pushing partial state:", err)
           this.pushState()


### PR DESCRIPTION
## Summary

- Fixes a race condition where the Agent Manager panel permanently shows loading skeletons instead of worktrees/sessions
- `initializeState()` called `refreshSessions()` before the webview's `onMount` handlers registered, so the `sessionsLoaded` message was lost and the skeleton gate never opened
- Adds a `refreshSessions()` call to the `requestState` handler, which fires from the webview's `onMount`, guaranteeing all message listeners are ready

## Root Cause

Commit `2d2699f07` introduced `worktreesLoaded` and `sessionsLoaded` boolean gates that must both be `true` before the UI renders. The `sessionsLoaded` signal was set by an `onMount` message handler, but `refreshSessions()` could send the `sessionsLoaded` message before mount completed. Since the session store was already populated, the `MessageList` backup effect (`sessions().length === 0`) never triggered a retry.