### PR TITLE
feat(vscode): cloud sessions panel + import-from-cloud

### DIFF
--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -208,6 +208,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
         if (!token) return c.json({ error: "No valid token found" }, 401)
 
         const ingestBase = process.env["KILO_SESSION_INGEST_URL"] ?? "https://ingest.kilosessions.ai"
+        console.log("[Kilo Gateway] cloud/session/import", { sessionId, token: token.slice(0, 20) + "..." })
         const response = await fetch(`${ingestBase}/api/session/${sessionId}/export`, {
           headers: { Authorization: `Bearer ${token}` },
         })
@@ -216,6 +217,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
         if (!response.ok) {
           const text = await response.text()
           console.error("[Kilo Gateway] cloud/session/import export failed:", {
+            sessionId,
             status: response.status,
             body: text.slice(0, 500),
           })

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -152,7 +152,9 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
         }
 
         const json = await response.json()
-        const result = Array.isArray(json) ? json[0]?.result?.data : null
+        console.log("[Kilo Gateway] cloud/sessions tRPC response:", JSON.stringify(json).slice(0, 500))
+        const data = Array.isArray(json) ? json[0]?.result?.data : null
+        const result = data?.json ?? data
         if (!result) return c.json({ sessions: [], nextCursor: null })
 
         const sessions = (result.cliSessions ?? []).map((s: any) => ({

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -215,7 +215,14 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
         if (response.status === 404) return c.json({ error: "Session not found in cloud" }, 404)
         if (!response.ok) {
           const text = await response.text()
-          return c.json({ error: `Cloud export failed: ${response.status} ${text}` }, 500 as any)
+          console.error("[Kilo Gateway] cloud/session/import export failed:", {
+            status: response.status,
+            body: text.slice(0, 500),
+          })
+          return c.json(
+            { error: `This session cannot be imported (export failed: ${response.status})` },
+            response.status as any,
+          )
         }
 
         const data = (await response.json()) as any

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -54,6 +54,11 @@
         "icon": "$(extensions)"
       },
       {
+        "command": "kilo-code.new.cloudSessionsButtonClicked",
+        "title": "Cloud Sessions",
+        "icon": "$(cloud)"
+      },
+      {
         "command": "kilo-code.new.historyButtonClicked",
         "title": "History",
         "icon": "$(history)"
@@ -211,18 +216,23 @@
           "when": "view == kilo-code.new.sidebarView"
         },
         {
-          "command": "kilo-code.new.historyButtonClicked",
+          "command": "kilo-code.new.cloudSessionsButtonClicked",
           "group": "navigation@3",
           "when": "view == kilo-code.new.sidebarView"
         },
         {
-          "command": "kilo-code.new.profileButtonClicked",
+          "command": "kilo-code.new.historyButtonClicked",
           "group": "navigation@4",
           "when": "view == kilo-code.new.sidebarView"
         },
         {
-          "command": "kilo-code.new.settingsButtonClicked",
+          "command": "kilo-code.new.profileButtonClicked",
           "group": "navigation@5",
+          "when": "view == kilo-code.new.sidebarView"
+        },
+        {
+          "command": "kilo-code.new.settingsButtonClicked",
+          "group": "navigation@6",
           "when": "view == kilo-code.new.sidebarView"
         }
       ],

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -726,12 +726,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Handle loading cloud sessions list.
    */
   private async handleLoadCloudSessions(cursor?: string): Promise<void> {
+    console.log("[Kilo New] KiloProvider: Loading cloud sessions", { cursor, hasClient: !!this.httpClient })
     if (!this.httpClient) {
       this.postMessage({ type: "error", message: "Not connected to CLI backend" })
       return
     }
 
     const result = await this.httpClient.listCloudSessions(cursor)
+    console.log("[Kilo New] KiloProvider: Cloud sessions result", { result })
     if (!result) {
       this.postMessage({ type: "cloudSessionsLoaded", sessions: [], nextCursor: null })
       return

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -732,7 +732,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
 
-    const result = await this.httpClient.listCloudSessions(cursor)
+    const result = await this.httpClient.listCloudSessions(cursor, 50)
     console.log("[Kilo New] KiloProvider: Cloud sessions result", { result })
     if (!result) {
       this.postMessage({ type: "cloudSessionsLoaded", sessions: [], nextCursor: null })

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -58,6 +58,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.marketplaceButtonClicked", () => {
       provider.postMessage({ type: "action", action: "marketplaceButtonClicked" })
     }),
+    vscode.commands.registerCommand("kilo-code.new.cloudSessionsButtonClicked", () => {
+      provider.postMessage({ type: "action", action: "cloudSessionsButtonClicked" })
+    }),
     vscode.commands.registerCommand("kilo-code.new.historyButtonClicked", () => {
       provider.postMessage({ type: "action", action: "historyButtonClicked" })
     }),

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -340,7 +340,8 @@ export class HttpClient {
   async importCloudSession(sessionId: string): Promise<SessionInfo | null> {
     try {
       return await this.request<SessionInfo>("POST", "/kilo/cloud/session/import", { sessionId })
-    } catch {
+    } catch (err) {
+      console.error("[Kilo New] HTTP: importCloudSession failed:", err)
       return null
     }
   }

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -12,6 +12,7 @@ import type {
   McpConfig,
   Config,
   KilocodeNotification,
+  CloudSessionsResponse,
 } from "./types"
 import { extractHttpErrorMessage, parseSSEDataLine } from "./http-utils"
 
@@ -314,6 +315,34 @@ export class HttpClient {
   // ============================================
   // Profile Methods
   // ============================================
+
+  /**
+   * List cloud-synced sessions for the current user.
+   * Returns null if not logged in or if the request fails.
+   */
+  async listCloudSessions(cursor?: string, limit?: number): Promise<CloudSessionsResponse | null> {
+    const params = new URLSearchParams()
+    if (cursor) params.set("cursor", cursor)
+    if (limit !== undefined) params.set("limit", String(limit))
+    const query = params.toString()
+    try {
+      return await this.request<CloudSessionsResponse>("GET", `/kilo/cloud/sessions${query ? `?${query}` : ""}`)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Import a cloud session by session ID into local storage.
+   * Returns the imported SessionInfo, or null on failure.
+   */
+  async importCloudSession(sessionId: string): Promise<SessionInfo | null> {
+    try {
+      return await this.request<SessionInfo>("POST", "/session/import-cloud", { sessionId })
+    } catch {
+      return null
+    }
+  }
 
   /**
    * Get the current user's profile from the kilo-gateway.

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -327,7 +327,8 @@ export class HttpClient {
     const query = params.toString()
     try {
       return await this.request<CloudSessionsResponse>("GET", `/kilo/cloud/sessions${query ? `?${query}` : ""}`)
-    } catch {
+    } catch (err) {
+      console.error("[Kilo New] HTTP: listCloudSessions failed:", err)
       return null
     }
   }

--- a/packages/kilo-vscode/src/services/cli-backend/http-client.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/http-client.ts
@@ -338,7 +338,7 @@ export class HttpClient {
    */
   async importCloudSession(sessionId: string): Promise<SessionInfo | null> {
     try {
-      return await this.request<SessionInfo>("POST", "/session/import-cloud", { sessionId })
+      return await this.request<SessionInfo>("POST", "/kilo/cloud/session/import", { sessionId })
     } catch {
       return null
     }

--- a/packages/kilo-vscode/src/services/cli-backend/index.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/index.ts
@@ -28,6 +28,8 @@ export type {
   Config,
   KilocodeNotification,
   KilocodeNotificationAction,
+  CloudSession,
+  CloudSessionsResponse,
 } from "./types"
 
 export { ServerManager } from "./server-manager"

--- a/packages/kilo-vscode/src/services/cli-backend/types.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/types.ts
@@ -213,6 +213,19 @@ export interface ProfileData {
   currentOrgId: string | null
 }
 
+// Cloud session from Kilo cloud (ingest.kilosessions.ai)
+export interface CloudSession {
+  session_id: string
+  title: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CloudSessionsResponse {
+  sessions: CloudSession[]
+  nextCursor: string | null
+}
+
 // MCP server status — discriminated union returned by the backend
 export type McpStatus =
   | { status: "connected" }

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -18,12 +18,13 @@ import { SessionProvider, useSession } from "./context/session"
 import { LanguageProvider } from "./context/language"
 import { ChatView } from "./components/chat"
 import SessionList from "./components/history/SessionList"
+import CloudSessionList from "./components/history/CloudSessionList"
 import { NotificationsProvider } from "./context/notifications"
 import type { Message as SDKMessage, Part as SDKPart } from "@kilocode/sdk/v2"
 import "./styles/chat.css"
 
-type ViewType = "newTask" | "marketplace" | "history" | "profile" | "settings"
-const VALID_VIEWS = new Set<string>(["newTask", "marketplace", "history", "profile", "settings"])
+type ViewType = "newTask" | "marketplace" | "history" | "cloudSessions" | "profile" | "settings"
+const VALID_VIEWS = new Set<string>(["newTask", "marketplace", "history", "cloudSessions", "profile", "settings"])
 
 const DummyView: Component<{ title: string }> = (props) => {
   return (
@@ -117,6 +118,9 @@ const AppContent: Component = () => {
       case "marketplaceButtonClicked":
         setCurrentView("marketplace")
         break
+      case "cloudSessionsButtonClicked":
+        setCurrentView("cloudSessions")
+        break
       case "historyButtonClicked":
         setCurrentView("history")
         break
@@ -161,6 +165,9 @@ const AppContent: Component = () => {
         </Match>
         <Match when={currentView() === "history"}>
           <SessionList onSelectSession={handleSelectSession} />
+        </Match>
+        <Match when={currentView() === "cloudSessions"}>
+          <CloudSessionList onSelectSession={handleSelectSession} />
         </Match>
         <Match when={currentView() === "profile"}>
           <ProfileView

--- a/packages/kilo-vscode/webview-ui/src/components/history/CloudSessionList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/history/CloudSessionList.tsx
@@ -1,0 +1,133 @@
+/**
+ * CloudSessionList component
+ * Displays sessions synced to Kilo cloud, grouped by date.
+ * Clicking a session imports it to local storage and opens it.
+ */
+
+import { Component, For, Show, createSignal, onMount } from "solid-js"
+import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { useSession } from "../../context/session"
+import { useServer } from "../../context/server"
+import { useLanguage } from "../../context/language"
+import { formatRelativeDate } from "../../utils/date"
+import type { CloudSession } from "../../types/messages"
+
+const DATE_GROUP_KEYS = ["time.today", "time.yesterday", "time.thisWeek", "time.thisMonth", "time.older"] as const
+
+function dateGroupKey(iso: string): (typeof DATE_GROUP_KEYS)[number] {
+  const now = new Date()
+  const then = new Date(iso)
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const yesterday = new Date(today.getTime() - 86400000)
+  const weekAgo = new Date(today.getTime() - 7 * 86400000)
+  const monthAgo = new Date(today.getTime() - 30 * 86400000)
+  if (then >= today) return DATE_GROUP_KEYS[0]
+  if (then >= yesterday) return DATE_GROUP_KEYS[1]
+  if (then >= weekAgo) return DATE_GROUP_KEYS[2]
+  if (then >= monthAgo) return DATE_GROUP_KEYS[3]
+  return DATE_GROUP_KEYS[4]
+}
+
+function groupByDate(sessions: CloudSession[]): Array<{ key: string; items: CloudSession[] }> {
+  const map = new Map<string, CloudSession[]>()
+  for (const key of DATE_GROUP_KEYS) map.set(key, [])
+  for (const s of sessions) {
+    map.get(dateGroupKey(s.updated_at))!.push(s)
+  }
+  return DATE_GROUP_KEYS.filter((k) => map.get(k)!.length > 0).map((k) => ({ key: k, items: map.get(k)! }))
+}
+
+interface CloudSessionListProps {
+  onSelectSession: (id: string) => void
+}
+
+const CloudSessionList: Component<CloudSessionListProps> = (props) => {
+  const session = useSession()
+  const server = useServer()
+  const language = useLanguage()
+  const [loading, setLoading] = createSignal(false)
+
+  onMount(() => {
+    if (!server.isConnected()) return
+    setLoading(true)
+    session.loadCloudSessions()
+  })
+
+  const groups = () => groupByDate(session.cloudSessions())
+
+  const handleSelect = (s: CloudSession) => {
+    if (session.importingCloudSessionId()) return
+    session.importCloudSession(s.session_id)
+  }
+
+  const handleLoadMore = () => {
+    const cursor = session.cloudSessionsNextCursor()
+    if (!cursor) return
+    session.loadCloudSessions(cursor)
+  }
+
+  // Clear loading once sessions arrive
+  const cloudSessions = () => {
+    const list = session.cloudSessions()
+    if (loading() && (list.length > 0 || session.cloudSessionsNextCursor() === null)) {
+      setLoading(false)
+    }
+    return list
+  }
+
+  const isLoggedIn = () => server.profileData() !== null
+
+  return (
+    <div class="session-list" data-component="cloud-session-list">
+      <Show when={!isLoggedIn()}>
+        <div class="session-list-empty">
+          <span>{language.t("session.cloud.loginRequired")}</span>
+        </div>
+      </Show>
+      <Show when={isLoggedIn() && loading()}>
+        <div class="session-list-loading">
+          <Spinner />
+        </div>
+      </Show>
+      <Show when={isLoggedIn() && !loading() && cloudSessions().length === 0}>
+        <div class="session-list-empty">
+          <span>{language.t("session.cloud.empty")}</span>
+        </div>
+      </Show>
+      <Show when={isLoggedIn() && !loading() && cloudSessions().length > 0}>
+        <For each={groups()}>
+          {(group) => (
+            <div class="session-group">
+              <div class="session-group-label">{language.t(group.key)}</div>
+              <For each={group.items}>
+                {(s) => {
+                  const importing = () => session.importingCloudSessionId() === s.session_id
+                  return (
+                    <button
+                      class="session-item"
+                      onClick={() => handleSelect(s)}
+                      disabled={!!session.importingCloudSessionId()}
+                    >
+                      <Show when={importing()}>
+                        <Spinner />
+                      </Show>
+                      <span class="session-item-title">{s.title || language.t("session.untitled")}</span>
+                      <span class="session-item-date">{formatRelativeDate(s.updated_at)}</span>
+                    </button>
+                  )
+                }}
+              </For>
+            </div>
+          )}
+        </For>
+        <Show when={!!session.cloudSessionsNextCursor()}>
+          <button class="session-load-more" onClick={handleLoadMore}>
+            {language.t("session.cloud.loadMore")}
+          </button>
+        </Show>
+      </Show>
+    </div>
+  )
+}
+
+export default CloudSessionList

--- a/packages/kilo-vscode/webview-ui/src/components/history/CloudSessionList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/history/CloudSessionList.tsx
@@ -4,7 +4,7 @@
  * Clicking a session imports it to local storage and opens it.
  */
 
-import { Component, For, Show, createSignal, onMount } from "solid-js"
+import { Component, For, Show, createSignal, createEffect, onMount } from "solid-js"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { useSession } from "../../context/session"
 import { useServer } from "../../context/server"
@@ -54,6 +54,13 @@ const CloudSessionList: Component<CloudSessionListProps> = (props) => {
     session.loadCloudSessions()
   })
 
+  // Clear loading once cloud sessions response arrives
+  createEffect(() => {
+    if (session.cloudSessionsLoaded()) {
+      setLoading(false)
+    }
+  })
+
   const groups = () => groupByDate(session.cloudSessions())
 
   const handleSelect = (s: CloudSession) => {
@@ -65,15 +72,6 @@ const CloudSessionList: Component<CloudSessionListProps> = (props) => {
     const cursor = session.cloudSessionsNextCursor()
     if (!cursor) return
     session.loadCloudSessions(cursor)
-  }
-
-  // Clear loading once sessions arrive
-  const cloudSessions = () => {
-    const list = session.cloudSessions()
-    if (loading() && (list.length > 0 || session.cloudSessionsNextCursor() === null)) {
-      setLoading(false)
-    }
-    return list
   }
 
   const isLoggedIn = () => server.profileData() !== null
@@ -90,12 +88,12 @@ const CloudSessionList: Component<CloudSessionListProps> = (props) => {
           <Spinner />
         </div>
       </Show>
-      <Show when={isLoggedIn() && !loading() && cloudSessions().length === 0}>
+      <Show when={isLoggedIn() && !loading() && session.cloudSessions().length === 0}>
         <div class="session-list-empty">
           <span>{language.t("session.cloud.empty")}</span>
         </div>
       </Show>
-      <Show when={isLoggedIn() && !loading() && cloudSessions().length > 0}>
+      <Show when={isLoggedIn() && !loading() && session.cloudSessions().length > 0}>
         <For each={groups()}>
           {(group) => (
             <div class="session-group">

--- a/packages/kilo-vscode/webview-ui/src/components/history/CloudSessionList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/history/CloudSessionList.tsx
@@ -48,6 +48,7 @@ const CloudSessionList: Component<CloudSessionListProps> = (props) => {
   const [loading, setLoading] = createSignal(false)
 
   onMount(() => {
+    console.log("[Kilo New] CloudSessionList: mounted", { connected: server.isConnected() })
     if (!server.isConnected()) return
     setLoading(true)
     session.loadCloudSessions()

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -393,7 +393,7 @@ export const SessionProvider: ParentComponent = (props) => {
           break
 
         case "cloudSessionsLoaded":
-          setCloudSessions(message.sessions)
+          setCloudSessions((prev) => [...prev, ...message.sessions])
           setCloudSessionsNextCursor(message.nextCursor)
           setCloudSessionsLoaded(true)
           break

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -115,6 +115,7 @@ interface SessionContextValue {
   // Cloud sessions
   cloudSessions: Accessor<CloudSession[]>
   cloudSessionsNextCursor: Accessor<string | null>
+  cloudSessionsLoaded: Accessor<boolean>
   importingCloudSessionId: Accessor<string | null>
   loadCloudSessions: (cursor?: string) => void
   importCloudSession: (sessionId: string) => void
@@ -186,6 +187,7 @@ export const SessionProvider: ParentComponent = (props) => {
   // Cloud sessions state
   const [cloudSessions, setCloudSessions] = createSignal<CloudSession[]>([])
   const [cloudSessionsNextCursor, setCloudSessionsNextCursor] = createSignal<string | null>(null)
+  const [cloudSessionsLoaded, setCloudSessionsLoaded] = createSignal(false)
   const [importingCloudSessionId, setImportingCloudSessionId] = createSignal<string | null>(null)
 
   // Store for sessions, messages, parts, todos, modelSelections, agentSelections
@@ -393,6 +395,7 @@ export const SessionProvider: ParentComponent = (props) => {
         case "cloudSessionsLoaded":
           setCloudSessions(message.sessions)
           setCloudSessionsNextCursor(message.nextCursor)
+          setCloudSessionsLoaded(true)
           break
 
         case "cloudSessionImported":
@@ -969,6 +972,7 @@ export const SessionProvider: ParentComponent = (props) => {
     syncSession,
     cloudSessions,
     cloudSessionsNextCursor,
+    cloudSessionsLoaded,
     importingCloudSessionId,
     loadCloudSessions,
     importCloudSession,

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -873,6 +873,11 @@ export const SessionProvider: ParentComponent = (props) => {
   }
 
   function loadCloudSessions(cursor?: string) {
+    if (!cursor) {
+      setCloudSessions([])
+      setCloudSessionsNextCursor(null)
+      setCloudSessionsLoaded(false)
+    }
     vscode.postMessage({ type: "loadCloudSessions", cursor })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -727,6 +727,13 @@ export const dict = {
   "session.recent": "Recent",
   "session.search.placeholder": "Search sessions...",
   "session.empty": "No sessions yet. Click + to start a new conversation.",
+  "session.cloud.loginRequired": "Sign in to view cloud sessions.",
+  "session.cloud.empty": "No cloud sessions found.",
+  "session.cloud.loadMore": "Load more",
+  "session.cloud.importFromCloud": "Import from Cloud",
+  "session.cloud.importPlaceholder": "Session ID or URL",
+  "session.cloud.importInvalidId": "Invalid session ID or URL",
+  "session.cloud.importFailed": "Failed to import session",
 
   "workspace.new": "New workspace",
   "workspace.type.local": "local",

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -737,6 +737,27 @@
   opacity: 0.7;
 }
 
+/* Cloud Session List */
+.session-list[data-component="cloud-session-list"] {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.session-list-loading,
+.session-list-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: var(--vscode-descriptionForeground);
+  text-align: center;
+  padding: 20px;
+  gap: 12px;
+  font-size: 13px;
+}
+
 /* Session List Items */
 .session-list [data-slot="list-item-title"] {
   flex: 1;

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -737,11 +737,12 @@
   opacity: 0.7;
 }
 
-/* Cloud Session List */
-.session-list[data-component="cloud-session-list"] {
+/* Session List (shared by local and cloud) */
+.session-list {
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: hidden;
 }
 
 .session-list-loading,

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -104,6 +104,14 @@ export interface SessionInfo {
   updatedAt: string
 }
 
+// Cloud session from Kilo cloud
+export interface CloudSession {
+  session_id: string
+  title: string | null
+  created_at: string
+  updated_at: string
+}
+
 // Permission request
 export interface PermissionRequest {
   id: string
@@ -534,6 +542,22 @@ export interface NotificationsLoadedMessage {
   dismissedIds: string[]
 }
 
+export interface CloudSessionsLoadedMessage {
+  type: "cloudSessionsLoaded"
+  sessions: CloudSession[]
+  nextCursor: string | null
+}
+
+export interface CloudSessionImportedMessage {
+  type: "cloudSessionImported"
+  session: SessionInfo
+}
+
+export interface CloudSessionImportFailedMessage {
+  type: "cloudSessionImportFailed"
+  error: string
+}
+
 // Agent Manager worktree session metadata
 export interface AgentManagerSessionMetaMessage {
   type: "agentManager.sessionMeta"
@@ -672,6 +696,9 @@ export type ExtensionMessage =
   | SetChatBoxMessage
   | TriggerTaskMessage
   | VariantsLoadedMessage
+  | CloudSessionsLoadedMessage
+  | CloudSessionImportedMessage
+  | CloudSessionImportFailedMessage
 
 // ============================================
 // Messages FROM webview TO extension
@@ -969,6 +996,16 @@ export interface RequestVariantsMessage {
   type: "requestVariants"
 }
 
+export interface LoadCloudSessionsRequest {
+  type: "loadCloudSessions"
+  cursor?: string
+}
+
+export interface ImportCloudSessionRequest {
+  type: "importCloudSession"
+  sessionId: string
+}
+
 export type WebviewMessage =
   | SendMessageRequest
   | AbortRequest
@@ -1023,6 +1060,8 @@ export type WebviewMessage =
   | SetSessionsCollapsedRequest
   | PersistVariantRequest
   | RequestVariantsMessage
+  | LoadCloudSessionsRequest
+  | ImportCloudSessionRequest
 
 // ============================================
 // VS Code API type

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -16,924 +16,1004 @@ import { Log } from "../../util/log"
 import { PermissionNext } from "@/permission/next"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Auth } from "../../auth" // kilocode_change
+import { Storage } from "../../storage/storage" // kilocode_change
+import { Instance } from "../../project/instance" // kilocode_change
 
 const log = Log.create({ service: "server" })
 
-export const SessionRoutes = lazy(() =>
-  new Hono()
-    .get(
-      "/",
-      describeRoute({
-        summary: "List sessions",
-        description: "Get a list of all OpenCode sessions, sorted by most recently updated.",
-        operationId: "session.list",
-        responses: {
-          200: {
-            description: "List of sessions",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info.array()),
+export const SessionRoutes = lazy(
+  () =>
+    new Hono()
+      .get(
+        "/",
+        describeRoute({
+          summary: "List sessions",
+          description: "Get a list of all OpenCode sessions, sorted by most recently updated.",
+          operationId: "session.list",
+          responses: {
+            200: {
+              description: "List of sessions",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info.array()),
+                },
               },
             },
           },
-        },
-      }),
-      validator(
-        "query",
-        z.object({
-          directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
-          roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
-          start: z.coerce
-            .number()
-            .optional()
-            .meta({ description: "Filter sessions updated on or after this timestamp (milliseconds since epoch)" }),
-          search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
-          limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),
         }),
-      ),
-      async (c) => {
-        const query = c.req.valid("query")
-        const term = query.search?.toLowerCase()
-        const sessions: Session.Info[] = []
-        for await (const session of Session.list()) {
-          if (query.directory !== undefined && session.directory !== query.directory) continue
-          if (query.roots && session.parentID) continue
-          if (query.start !== undefined && session.time.updated < query.start) continue
-          if (term !== undefined && !session.title.toLowerCase().includes(term)) continue
-          sessions.push(session)
-          if (query.limit !== undefined && sessions.length >= query.limit) break
-        }
-        return c.json(sessions)
-      },
-    )
-    .get(
-      "/status",
-      describeRoute({
-        summary: "Get session status",
-        description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
-        operationId: "session.status",
-        responses: {
-          200: {
-            description: "Get session status",
-            content: {
-              "application/json": {
-                schema: resolver(z.record(z.string(), SessionStatus.Info)),
-              },
-            },
-          },
-          ...errors(400),
-        },
-      }),
-      async (c) => {
-        const result = SessionStatus.list()
-        return c.json(result)
-      },
-    )
-    .get(
-      "/:sessionID",
-      describeRoute({
-        summary: "Get session",
-        description: "Retrieve detailed information about a specific OpenCode session.",
-        tags: ["Session"],
-        operationId: "session.get",
-        responses: {
-          200: {
-            description: "Get session",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: Session.get.schema,
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        log.info("SEARCH", { url: c.req.url })
-        const session = await Session.get(sessionID)
-        return c.json(session)
-      },
-    )
-    .get(
-      "/:sessionID/children",
-      describeRoute({
-        summary: "Get session children",
-        tags: ["Session"],
-        description: "Retrieve all child sessions that were forked from the specified parent session.",
-        operationId: "session.children",
-        responses: {
-          200: {
-            description: "List of children",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info.array()),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: Session.children.schema,
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const session = await Session.children(sessionID)
-        return c.json(session)
-      },
-    )
-    .get(
-      "/:sessionID/todo",
-      describeRoute({
-        summary: "Get session todos",
-        description: "Retrieve the todo list associated with a specific session, showing tasks and action items.",
-        operationId: "session.todo",
-        responses: {
-          200: {
-            description: "Todo list",
-            content: {
-              "application/json": {
-                schema: resolver(Todo.Info.array()),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const todos = await Todo.get(sessionID)
-        return c.json(todos)
-      },
-    )
-    .post(
-      "/",
-      describeRoute({
-        summary: "Create session",
-        description: "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
-        operationId: "session.create",
-        responses: {
-          ...errors(400),
-          200: {
-            description: "Successfully created session",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
-              },
-            },
-          },
-        },
-      }),
-      validator("json", Session.create.schema.optional()),
-      async (c) => {
-        const body = c.req.valid("json") ?? {}
-        const session = await Session.create(body)
-        return c.json(session)
-      },
-    )
-    .delete(
-      "/:sessionID",
-      describeRoute({
-        summary: "Delete session",
-        description: "Delete a session and permanently remove all associated data, including messages and history.",
-        operationId: "session.delete",
-        responses: {
-          200: {
-            description: "Successfully deleted session",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: Session.remove.schema,
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        await Session.remove(sessionID)
-        return c.json(true)
-      },
-    )
-    .patch(
-      "/:sessionID",
-      describeRoute({
-        summary: "Update session",
-        description: "Update properties of an existing session, such as title or other metadata.",
-        operationId: "session.update",
-        responses: {
-          200: {
-            description: "Successfully updated session",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string(),
-        }),
-      ),
-      validator(
-        "json",
-        z.object({
-          title: z.string().optional(),
-          time: z
-            .object({
-              archived: z.number().optional(),
-            })
-            .optional(),
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const updates = c.req.valid("json")
-
-        const updatedSession = await Session.update(
-          sessionID,
-          (session) => {
-            if (updates.title !== undefined) {
-              session.title = updates.title
-            }
-            if (updates.time?.archived !== undefined) session.time.archived = updates.time.archived
-          },
-          { touch: false },
-        )
-
-        return c.json(updatedSession)
-      },
-    )
-    .post(
-      "/:sessionID/init",
-      describeRoute({
-        summary: "Initialize session",
-        description:
-          "Analyze the current application and create an AGENTS.md file with project-specific agent configurations.",
-        operationId: "session.init",
-        responses: {
-          200: {
-            description: "200",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-        }),
-      ),
-      validator("json", Session.initialize.schema.omit({ sessionID: true })),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const body = c.req.valid("json")
-        await Session.initialize({ ...body, sessionID })
-        return c.json(true)
-      },
-    )
-    .post(
-      "/:sessionID/fork",
-      describeRoute({
-        summary: "Fork session",
-        description: "Create a new session by forking an existing session at a specific message point.",
-        operationId: "session.fork",
-        responses: {
-          200: {
-            description: "200",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
-              },
-            },
-          },
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: Session.fork.schema.shape.sessionID,
-        }),
-      ),
-      validator("json", Session.fork.schema.omit({ sessionID: true })),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const body = c.req.valid("json")
-        const result = await Session.fork({ ...body, sessionID })
-        return c.json(result)
-      },
-    )
-    .post(
-      "/:sessionID/abort",
-      describeRoute({
-        summary: "Abort session",
-        description: "Abort an active session and stop any ongoing AI processing or command execution.",
-        operationId: "session.abort",
-        responses: {
-          200: {
-            description: "Aborted session",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string(),
-        }),
-      ),
-      async (c) => {
-        SessionPrompt.cancel(c.req.valid("param").sessionID)
-        return c.json(true)
-      },
-    )
-    .post(
-      "/:sessionID/share",
-      describeRoute({
-        summary: "Share session",
-        description: "Create a shareable link for a session, allowing others to view the conversation.",
-        operationId: "session.share",
-        responses: {
-          200: {
-            description: "Successfully shared session",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string(),
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        await Session.share(sessionID)
-        const session = await Session.get(sessionID)
-        return c.json(session)
-      },
-    )
-    .get(
-      "/:sessionID/diff",
-      describeRoute({
-        summary: "Get message diff",
-        description: "Get the file changes (diff) that resulted from a specific user message in the session.",
-        operationId: "session.diff",
-        responses: {
-          200: {
-            description: "Successfully retrieved diff",
-            content: {
-              "application/json": {
-                schema: resolver(Snapshot.FileDiff.array()),
-              },
-            },
-          },
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: SessionSummary.diff.schema.shape.sessionID,
-        }),
-      ),
-      validator(
-        "query",
-        z.object({
-          messageID: SessionSummary.diff.schema.shape.messageID,
-        }),
-      ),
-      async (c) => {
-        const query = c.req.valid("query")
-        const params = c.req.valid("param")
-        const result = await SessionSummary.diff({
-          sessionID: params.sessionID,
-          messageID: query.messageID,
-        })
-        return c.json(result)
-      },
-    )
-    .delete(
-      "/:sessionID/share",
-      describeRoute({
-        summary: "Unshare session",
-        description: "Remove the shareable link for a session, making it private again.",
-        operationId: "session.unshare",
-        responses: {
-          200: {
-            description: "Successfully unshared session",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: Session.unshare.schema,
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        await Session.unshare(sessionID)
-        const session = await Session.get(sessionID)
-        return c.json(session)
-      },
-    )
-    .post(
-      "/:sessionID/summarize",
-      describeRoute({
-        summary: "Summarize session",
-        description: "Generate a concise summary of the session using AI compaction to preserve key information.",
-        operationId: "session.summarize",
-        responses: {
-          200: {
-            description: "Summarized session",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-        }),
-      ),
-      validator(
-        "json",
-        z.object({
-          providerID: z.string(),
-          modelID: z.string(),
-          auto: z.boolean().optional().default(false),
-        }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const body = c.req.valid("json")
-        const session = await Session.get(sessionID)
-        await SessionRevert.cleanup(session)
-        const msgs = await Session.messages({ sessionID })
-        let currentAgent = await Agent.defaultAgent()
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const info = msgs[i].info
-          if (info.role === "user") {
-            currentAgent = info.agent || (await Agent.defaultAgent())
-            break
+        validator(
+          "query",
+          z.object({
+            directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
+            roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
+            start: z.coerce
+              .number()
+              .optional()
+              .meta({ description: "Filter sessions updated on or after this timestamp (milliseconds since epoch)" }),
+            search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
+            limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),
+          }),
+        ),
+        async (c) => {
+          const query = c.req.valid("query")
+          const term = query.search?.toLowerCase()
+          const sessions: Session.Info[] = []
+          for await (const session of Session.list()) {
+            if (query.directory !== undefined && session.directory !== query.directory) continue
+            if (query.roots && session.parentID) continue
+            if (query.start !== undefined && session.time.updated < query.start) continue
+            if (term !== undefined && !session.title.toLowerCase().includes(term)) continue
+            sessions.push(session)
+            if (query.limit !== undefined && sessions.length >= query.limit) break
           }
-        }
-        await SessionCompaction.create({
-          sessionID,
-          agent: currentAgent,
-          model: {
-            providerID: body.providerID,
-            modelID: body.modelID,
+          return c.json(sessions)
+        },
+      )
+      .get(
+        "/status",
+        describeRoute({
+          summary: "Get session status",
+          description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
+          operationId: "session.status",
+          responses: {
+            200: {
+              description: "Get session status",
+              content: {
+                "application/json": {
+                  schema: resolver(z.record(z.string(), SessionStatus.Info)),
+                },
+              },
+            },
+            ...errors(400),
           },
-          auto: body.auto,
-        })
-        await SessionPrompt.loop({ sessionID })
-        return c.json(true)
-      },
-    )
-    .get(
-      "/:sessionID/message",
-      describeRoute({
-        summary: "Get session messages",
-        description: "Retrieve all messages in a session, including user prompts and AI responses.",
-        operationId: "session.messages",
-        responses: {
-          200: {
-            description: "List of messages",
-            content: {
-              "application/json": {
-                schema: resolver(MessageV2.WithParts.array()),
+        }),
+        async (c) => {
+          const result = SessionStatus.list()
+          return c.json(result)
+        },
+      )
+      .get(
+        "/:sessionID",
+        describeRoute({
+          summary: "Get session",
+          description: "Retrieve detailed information about a specific OpenCode session.",
+          tags: ["Session"],
+          operationId: "session.get",
+          responses: {
+            200: {
+              description: "Get session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: Session.get.schema,
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          log.info("SEARCH", { url: c.req.url })
+          const session = await Session.get(sessionID)
+          return c.json(session)
+        },
+      )
+      .get(
+        "/:sessionID/children",
+        describeRoute({
+          summary: "Get session children",
+          tags: ["Session"],
+          description: "Retrieve all child sessions that were forked from the specified parent session.",
+          operationId: "session.children",
+          responses: {
+            200: {
+              description: "List of children",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info.array()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: Session.children.schema,
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          const session = await Session.children(sessionID)
+          return c.json(session)
+        },
+      )
+      .get(
+        "/:sessionID/todo",
+        describeRoute({
+          summary: "Get session todos",
+          description: "Retrieve the todo list associated with a specific session, showing tasks and action items.",
+          operationId: "session.todo",
+          responses: {
+            200: {
+              description: "Todo list",
+              content: {
+                "application/json": {
+                  schema: resolver(Todo.Info.array()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          const todos = await Todo.get(sessionID)
+          return c.json(todos)
+        },
+      )
+      .post(
+        "/",
+        describeRoute({
+          summary: "Create session",
+          description: "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
+          operationId: "session.create",
+          responses: {
+            ...errors(400),
+            200: {
+              description: "Successfully created session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
               },
             },
           },
-          ...errors(400, 404),
+        }),
+        validator("json", Session.create.schema.optional()),
+        async (c) => {
+          const body = c.req.valid("json") ?? {}
+          const session = await Session.create(body)
+          return c.json(session)
         },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-        }),
-      ),
-      validator(
-        "query",
-        z.object({
-          limit: z.coerce.number().optional(),
-        }),
-      ),
-      async (c) => {
-        const query = c.req.valid("query")
-        const messages = await Session.messages({
-          sessionID: c.req.valid("param").sessionID,
-          limit: query.limit,
-        })
-        return c.json(messages)
-      },
-    )
-    .get(
-      "/:sessionID/message/:messageID",
-      describeRoute({
-        summary: "Get message",
-        description: "Retrieve a specific message from a session by its message ID.",
-        operationId: "session.message",
-        responses: {
-          200: {
-            description: "Message",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  z.object({
-                    info: MessageV2.Info,
-                    parts: MessageV2.Part.array(),
-                  }),
-                ),
+      )
+      .delete(
+        "/:sessionID",
+        describeRoute({
+          summary: "Delete session",
+          description: "Delete a session and permanently remove all associated data, including messages and history.",
+          operationId: "session.delete",
+          responses: {
+            200: {
+              description: "Successfully deleted session",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
               },
             },
+            ...errors(400, 404),
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-          messageID: z.string().meta({ description: "Message ID" }),
         }),
-      ),
-      async (c) => {
-        const params = c.req.valid("param")
-        const message = await MessageV2.get({
-          sessionID: params.sessionID,
-          messageID: params.messageID,
-        })
-        return c.json(message)
-      },
-    )
-    .delete(
-      "/:sessionID/message/:messageID/part/:partID",
-      describeRoute({
-        description: "Delete a part from a message",
-        operationId: "part.delete",
-        responses: {
-          200: {
-            description: "Successfully deleted part",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
+        validator(
+          "param",
+          z.object({
+            sessionID: Session.remove.schema,
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          await Session.remove(sessionID)
+          return c.json(true)
+        },
+      )
+      .patch(
+        "/:sessionID",
+        describeRoute({
+          summary: "Update session",
+          description: "Update properties of an existing session, such as title or other metadata.",
+          operationId: "session.update",
+          responses: {
+            200: {
+              description: "Successfully updated session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
               },
             },
+            ...errors(400, 404),
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-          messageID: z.string().meta({ description: "Message ID" }),
-          partID: z.string().meta({ description: "Part ID" }),
         }),
-      ),
-      async (c) => {
-        const params = c.req.valid("param")
-        await Session.removePart({
-          sessionID: params.sessionID,
-          messageID: params.messageID,
-          partID: params.partID,
-        })
-        return c.json(true)
-      },
-    )
-    .patch(
-      "/:sessionID/message/:messageID/part/:partID",
-      describeRoute({
-        description: "Update a part in a message",
-        operationId: "part.update",
-        responses: {
-          200: {
-            description: "Successfully updated part",
-            content: {
-              "application/json": {
-                schema: resolver(MessageV2.Part),
-              },
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+          }),
+        ),
+        validator(
+          "json",
+          z.object({
+            title: z.string().optional(),
+            time: z
+              .object({
+                archived: z.number().optional(),
+              })
+              .optional(),
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          const updates = c.req.valid("json")
+
+          const updatedSession = await Session.update(
+            sessionID,
+            (session) => {
+              if (updates.title !== undefined) {
+                session.title = updates.title
+              }
+              if (updates.time?.archived !== undefined) session.time.archived = updates.time.archived
             },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-          messageID: z.string().meta({ description: "Message ID" }),
-          partID: z.string().meta({ description: "Part ID" }),
-        }),
-      ),
-      validator("json", MessageV2.Part),
-      async (c) => {
-        const params = c.req.valid("param")
-        const body = c.req.valid("json")
-        if (body.id !== params.partID || body.messageID !== params.messageID || body.sessionID !== params.sessionID) {
-          throw new Error(
-            `Part mismatch: body.id='${body.id}' vs partID='${params.partID}', body.messageID='${body.messageID}' vs messageID='${params.messageID}', body.sessionID='${body.sessionID}' vs sessionID='${params.sessionID}'`,
+            { touch: false },
           )
-        }
-        const part = await Session.updatePart(body)
-        return c.json(part)
-      },
-    )
-    .post(
-      "/:sessionID/message",
-      describeRoute({
-        summary: "Send message",
-        description: "Create and send a new message to a session, streaming the AI response.",
-        operationId: "session.prompt",
-        responses: {
-          200: {
-            description: "Created message",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  z.object({
-                    info: MessageV2.Assistant,
-                    parts: MessageV2.Part.array(),
-                  }),
-                ),
+
+          return c.json(updatedSession)
+        },
+      )
+      .post(
+        "/:sessionID/init",
+        describeRoute({
+          summary: "Initialize session",
+          description:
+            "Analyze the current application and create an AGENTS.md file with project-specific agent configurations.",
+          operationId: "session.init",
+          responses: {
+            200: {
+              description: "200",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
               },
             },
+            ...errors(400, 404),
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
         }),
-      ),
-      validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
-      async (c) => {
-        c.status(200)
-        c.header("Content-Type", "application/json")
-        return stream(c, async (stream) => {
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator("json", Session.initialize.schema.omit({ sessionID: true })),
+        async (c) => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
-          stream.write(JSON.stringify(msg))
-        })
-      },
-    )
-    .post(
-      "/:sessionID/prompt_async",
-      describeRoute({
-        summary: "Send async message",
-        description:
-          "Create and send a new message to a session asynchronously, starting the session if needed and returning immediately.",
-        operationId: "session.prompt_async",
-        responses: {
-          204: {
-            description: "Prompt accepted",
-          },
-          ...errors(400, 404),
+          await Session.initialize({ ...body, sessionID })
+          return c.json(true)
         },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
+      )
+      .post(
+        "/:sessionID/fork",
+        describeRoute({
+          summary: "Fork session",
+          description: "Create a new session by forking an existing session at a specific message point.",
+          operationId: "session.fork",
+          responses: {
+            200: {
+              description: "200",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
+              },
+            },
+          },
         }),
-      ),
-      validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
-      async (c) => {
-        c.status(204)
-        c.header("Content-Type", "application/json")
-        return stream(c, async () => {
+        validator(
+          "param",
+          z.object({
+            sessionID: Session.fork.schema.shape.sessionID,
+          }),
+        ),
+        validator("json", Session.fork.schema.omit({ sessionID: true })),
+        async (c) => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
-        })
-      },
-    )
-    .post(
-      "/:sessionID/command",
-      describeRoute({
-        summary: "Send command",
-        description: "Send a new command to a session for execution by the AI assistant.",
-        operationId: "session.command",
-        responses: {
-          200: {
-            description: "Created message",
-            content: {
-              "application/json": {
-                schema: resolver(
-                  z.object({
-                    info: MessageV2.Assistant,
-                    parts: MessageV2.Part.array(),
-                  }),
-                ),
+          const result = await Session.fork({ ...body, sessionID })
+          return c.json(result)
+        },
+      )
+      .post(
+        "/:sessionID/abort",
+        describeRoute({
+          summary: "Abort session",
+          description: "Abort an active session and stop any ongoing AI processing or command execution.",
+          operationId: "session.abort",
+          responses: {
+            200: {
+              description: "Aborted session",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+          }),
+        ),
+        async (c) => {
+          SessionPrompt.cancel(c.req.valid("param").sessionID)
+          return c.json(true)
+        },
+      )
+      .post(
+        "/:sessionID/share",
+        describeRoute({
+          summary: "Share session",
+          description: "Create a shareable link for a session, allowing others to view the conversation.",
+          operationId: "session.share",
+          responses: {
+            200: {
+              description: "Successfully shared session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          await Session.share(sessionID)
+          const session = await Session.get(sessionID)
+          return c.json(session)
+        },
+      )
+      .get(
+        "/:sessionID/diff",
+        describeRoute({
+          summary: "Get message diff",
+          description: "Get the file changes (diff) that resulted from a specific user message in the session.",
+          operationId: "session.diff",
+          responses: {
+            200: {
+              description: "Successfully retrieved diff",
+              content: {
+                "application/json": {
+                  schema: resolver(Snapshot.FileDiff.array()),
+                },
               },
             },
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
         }),
-      ),
-      validator("json", SessionPrompt.CommandInput.omit({ sessionID: true })),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const body = c.req.valid("json")
-        const msg = await SessionPrompt.command({ ...body, sessionID })
-        return c.json(msg)
-      },
-    )
-    .post(
-      "/:sessionID/shell",
-      describeRoute({
-        summary: "Run shell command",
-        description: "Execute a shell command within the session context and return the AI's response.",
-        operationId: "session.shell",
-        responses: {
-          200: {
-            description: "Created message",
-            content: {
-              "application/json": {
-                schema: resolver(MessageV2.Assistant),
+        validator(
+          "param",
+          z.object({
+            sessionID: SessionSummary.diff.schema.shape.sessionID,
+          }),
+        ),
+        validator(
+          "query",
+          z.object({
+            messageID: SessionSummary.diff.schema.shape.messageID,
+          }),
+        ),
+        async (c) => {
+          const query = c.req.valid("query")
+          const params = c.req.valid("param")
+          const result = await SessionSummary.diff({
+            sessionID: params.sessionID,
+            messageID: query.messageID,
+          })
+          return c.json(result)
+        },
+      )
+      .delete(
+        "/:sessionID/share",
+        describeRoute({
+          summary: "Unshare session",
+          description: "Remove the shareable link for a session, making it private again.",
+          operationId: "session.unshare",
+          responses: {
+            200: {
+              description: "Successfully unshared session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
               },
             },
+            ...errors(400, 404),
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
         }),
-      ),
-      validator("json", SessionPrompt.ShellInput.omit({ sessionID: true })),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const body = c.req.valid("json")
-        const msg = await SessionPrompt.shell({ ...body, sessionID })
-        return c.json(msg)
-      },
-    )
-    .post(
-      "/:sessionID/revert",
-      describeRoute({
-        summary: "Revert message",
-        description: "Revert a specific message in a session, undoing its effects and restoring the previous state.",
-        operationId: "session.revert",
-        responses: {
-          200: {
-            description: "Updated session",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
+        validator(
+          "param",
+          z.object({
+            sessionID: Session.unshare.schema,
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          await Session.unshare(sessionID)
+          const session = await Session.get(sessionID)
+          return c.json(session)
+        },
+      )
+      .post(
+        "/:sessionID/summarize",
+        describeRoute({
+          summary: "Summarize session",
+          description: "Generate a concise summary of the session using AI compaction to preserve key information.",
+          operationId: "session.summarize",
+          responses: {
+            200: {
+              description: "Summarized session",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
               },
             },
+            ...errors(400, 404),
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string(),
         }),
-      ),
-      validator("json", SessionRevert.RevertInput.omit({ sessionID: true })),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        log.info("revert", c.req.valid("json"))
-        const session = await SessionRevert.revert({
-          sessionID,
-          ...c.req.valid("json"),
-        })
-        return c.json(session)
-      },
-    )
-    .post(
-      "/:sessionID/unrevert",
-      describeRoute({
-        summary: "Restore reverted messages",
-        description: "Restore all previously reverted messages in a session.",
-        operationId: "session.unrevert",
-        responses: {
-          200: {
-            description: "Updated session",
-            content: {
-              "application/json": {
-                schema: resolver(Session.Info),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator(
+          "json",
+          z.object({
+            providerID: z.string(),
+            modelID: z.string(),
+            auto: z.boolean().optional().default(false),
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          const body = c.req.valid("json")
+          const session = await Session.get(sessionID)
+          await SessionRevert.cleanup(session)
+          const msgs = await Session.messages({ sessionID })
+          let currentAgent = await Agent.defaultAgent()
+          for (let i = msgs.length - 1; i >= 0; i--) {
+            const info = msgs[i].info
+            if (info.role === "user") {
+              currentAgent = info.agent || (await Agent.defaultAgent())
+              break
+            }
+          }
+          await SessionCompaction.create({
+            sessionID,
+            agent: currentAgent,
+            model: {
+              providerID: body.providerID,
+              modelID: body.modelID,
+            },
+            auto: body.auto,
+          })
+          await SessionPrompt.loop({ sessionID })
+          return c.json(true)
+        },
+      )
+      .get(
+        "/:sessionID/message",
+        describeRoute({
+          summary: "Get session messages",
+          description: "Retrieve all messages in a session, including user prompts and AI responses.",
+          operationId: "session.messages",
+          responses: {
+            200: {
+              description: "List of messages",
+              content: {
+                "application/json": {
+                  schema: resolver(MessageV2.WithParts.array()),
+                },
               },
             },
+            ...errors(400, 404),
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string(),
         }),
-      ),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        const session = await SessionRevert.unrevert({ sessionID })
-        return c.json(session)
-      },
-    )
-    .post(
-      "/:sessionID/permissions/:permissionID",
-      describeRoute({
-        summary: "Respond to permission",
-        deprecated: true,
-        description: "Approve or deny a permission request from the AI assistant.",
-        operationId: "permission.respond",
-        responses: {
-          200: {
-            description: "Permission processed successfully",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator(
+          "query",
+          z.object({
+            limit: z.coerce.number().optional(),
+          }),
+        ),
+        async (c) => {
+          const query = c.req.valid("query")
+          const messages = await Session.messages({
+            sessionID: c.req.valid("param").sessionID,
+            limit: query.limit,
+          })
+          return c.json(messages)
+        },
+      )
+      .get(
+        "/:sessionID/message/:messageID",
+        describeRoute({
+          summary: "Get message",
+          description: "Retrieve a specific message from a session by its message ID.",
+          operationId: "session.message",
+          responses: {
+            200: {
+              description: "Message",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      info: MessageV2.Info,
+                      parts: MessageV2.Part.array(),
+                    }),
+                  ),
+                },
               },
             },
+            ...errors(400, 404),
           },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string(),
-          permissionID: z.string(),
         }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+            messageID: z.string().meta({ description: "Message ID" }),
+          }),
+        ),
+        async (c) => {
+          const params = c.req.valid("param")
+          const message = await MessageV2.get({
+            sessionID: params.sessionID,
+            messageID: params.messageID,
+          })
+          return c.json(message)
+        },
+      )
+      .delete(
+        "/:sessionID/message/:messageID/part/:partID",
+        describeRoute({
+          description: "Delete a part from a message",
+          operationId: "part.delete",
+          responses: {
+            200: {
+              description: "Successfully deleted part",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+            messageID: z.string().meta({ description: "Message ID" }),
+            partID: z.string().meta({ description: "Part ID" }),
+          }),
+        ),
+        async (c) => {
+          const params = c.req.valid("param")
+          await Session.removePart({
+            sessionID: params.sessionID,
+            messageID: params.messageID,
+            partID: params.partID,
+          })
+          return c.json(true)
+        },
+      )
+      .patch(
+        "/:sessionID/message/:messageID/part/:partID",
+        describeRoute({
+          description: "Update a part in a message",
+          operationId: "part.update",
+          responses: {
+            200: {
+              description: "Successfully updated part",
+              content: {
+                "application/json": {
+                  schema: resolver(MessageV2.Part),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+            messageID: z.string().meta({ description: "Message ID" }),
+            partID: z.string().meta({ description: "Part ID" }),
+          }),
+        ),
+        validator("json", MessageV2.Part),
+        async (c) => {
+          const params = c.req.valid("param")
+          const body = c.req.valid("json")
+          if (body.id !== params.partID || body.messageID !== params.messageID || body.sessionID !== params.sessionID) {
+            throw new Error(
+              `Part mismatch: body.id='${body.id}' vs partID='${params.partID}', body.messageID='${body.messageID}' vs messageID='${params.messageID}', body.sessionID='${body.sessionID}' vs sessionID='${params.sessionID}'`,
+            )
+          }
+          const part = await Session.updatePart(body)
+          return c.json(part)
+        },
+      )
+      .post(
+        "/:sessionID/message",
+        describeRoute({
+          summary: "Send message",
+          description: "Create and send a new message to a session, streaming the AI response.",
+          operationId: "session.prompt",
+          responses: {
+            200: {
+              description: "Created message",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      info: MessageV2.Assistant,
+                      parts: MessageV2.Part.array(),
+                    }),
+                  ),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
+        async (c) => {
+          c.status(200)
+          c.header("Content-Type", "application/json")
+          return stream(c, async (stream) => {
+            const sessionID = c.req.valid("param").sessionID
+            const body = c.req.valid("json")
+            const msg = await SessionPrompt.prompt({ ...body, sessionID })
+            stream.write(JSON.stringify(msg))
+          })
+        },
+      )
+      .post(
+        "/:sessionID/prompt_async",
+        describeRoute({
+          summary: "Send async message",
+          description:
+            "Create and send a new message to a session asynchronously, starting the session if needed and returning immediately.",
+          operationId: "session.prompt_async",
+          responses: {
+            204: {
+              description: "Prompt accepted",
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
+        async (c) => {
+          c.status(204)
+          c.header("Content-Type", "application/json")
+          return stream(c, async () => {
+            const sessionID = c.req.valid("param").sessionID
+            const body = c.req.valid("json")
+            SessionPrompt.prompt({ ...body, sessionID })
+          })
+        },
+      )
+      .post(
+        "/:sessionID/command",
+        describeRoute({
+          summary: "Send command",
+          description: "Send a new command to a session for execution by the AI assistant.",
+          operationId: "session.command",
+          responses: {
+            200: {
+              description: "Created message",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      info: MessageV2.Assistant,
+                      parts: MessageV2.Part.array(),
+                    }),
+                  ),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator("json", SessionPrompt.CommandInput.omit({ sessionID: true })),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          const body = c.req.valid("json")
+          const msg = await SessionPrompt.command({ ...body, sessionID })
+          return c.json(msg)
+        },
+      )
+      .post(
+        "/:sessionID/shell",
+        describeRoute({
+          summary: "Run shell command",
+          description: "Execute a shell command within the session context and return the AI's response.",
+          operationId: "session.shell",
+          responses: {
+            200: {
+              description: "Created message",
+              content: {
+                "application/json": {
+                  schema: resolver(MessageV2.Assistant),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator("json", SessionPrompt.ShellInput.omit({ sessionID: true })),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          const body = c.req.valid("json")
+          const msg = await SessionPrompt.shell({ ...body, sessionID })
+          return c.json(msg)
+        },
+      )
+      .post(
+        "/:sessionID/revert",
+        describeRoute({
+          summary: "Revert message",
+          description: "Revert a specific message in a session, undoing its effects and restoring the previous state.",
+          operationId: "session.revert",
+          responses: {
+            200: {
+              description: "Updated session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+          }),
+        ),
+        validator("json", SessionRevert.RevertInput.omit({ sessionID: true })),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          log.info("revert", c.req.valid("json"))
+          const session = await SessionRevert.revert({
+            sessionID,
+            ...c.req.valid("json"),
+          })
+          return c.json(session)
+        },
+      )
+      .post(
+        "/:sessionID/unrevert",
+        describeRoute({
+          summary: "Restore reverted messages",
+          description: "Restore all previously reverted messages in a session.",
+          operationId: "session.unrevert",
+          responses: {
+            200: {
+              description: "Updated session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          const session = await SessionRevert.unrevert({ sessionID })
+          return c.json(session)
+        },
+      )
+      .post(
+        "/:sessionID/permissions/:permissionID",
+        describeRoute({
+          summary: "Respond to permission",
+          deprecated: true,
+          description: "Approve or deny a permission request from the AI assistant.",
+          operationId: "permission.respond",
+          responses: {
+            200: {
+              description: "Permission processed successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+            permissionID: z.string(),
+          }),
+        ),
+        validator("json", z.object({ response: PermissionNext.Reply })),
+        async (c) => {
+          const params = c.req.valid("param")
+          PermissionNext.reply({
+            requestID: params.permissionID,
+            reply: c.req.valid("json").response,
+          })
+          return c.json(true)
+        },
+      )
+      // kilocode_change start
+      .post(
+        "/import-cloud",
+        describeRoute({
+          summary: "Import session from cloud",
+          description: "Download a cloud-synced session and write it to local storage.",
+          operationId: "session.importCloud",
+          responses: {
+            200: {
+              description: "Imported session info",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
+              },
+            },
+            ...errors(400, 401, 404),
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            sessionId: z.string().startsWith("ses_").length(30),
+          }),
+        ),
+        async (c) => {
+          const { sessionId } = c.req.valid("json")
+
+          const auth = await Auth.get("kilo")
+          if (!auth) return c.json({ error: "Not authenticated with Kilo" }, 401)
+
+          const token =
+            auth.type === "api"
+              ? auth.key
+              : auth.type === "oauth"
+                ? auth.access
+                : auth.type === "wellknown"
+                  ? auth.token
+                  : undefined
+          if (!token) return c.json({ error: "No valid token found" }, 401)
+
+          const ingestBase = process.env["KILO_SESSION_INGEST_URL"] ?? "https://ingest.kilosessions.ai"
+          const response = await fetch(`${ingestBase}/api/session/${sessionId}/export`, {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+
+          if (response.status === 404) return c.json({ error: "Session not found in cloud" }, 404)
+          if (!response.ok) {
+            const text = await response.text()
+            return c.json({ error: `Cloud export failed: ${response.status} ${text}` }, 500 as any)
+          }
+
+          const data = (await response.json()) as {
+            info: Session.Info
+            messages: Array<{
+              info: { id: string; sessionID: string; role: string; time: unknown }
+              parts: Array<{ id: string }>
+            }>
+          }
+
+          if (!data?.info?.id) return c.json({ error: "Invalid export data" }, 400)
+
+          const projectID = Instance.project.id
+          await Storage.write(["session", projectID, data.info.id], data.info)
+
+          for (const msg of data.messages ?? []) {
+            await Storage.write(["message", data.info.id, msg.info.id], msg.info)
+            for (const part of msg.parts ?? []) {
+              await Storage.write(["part", msg.info.id, part.id], part)
+            }
+          }
+
+          return c.json(data.info)
+        },
       ),
-      validator("json", z.object({ response: PermissionNext.Reply })),
-      async (c) => {
-        const params = c.req.valid("param")
-        PermissionNext.reply({
-          requestID: params.permissionID,
-          reply: c.req.valid("json").response,
-        })
-        return c.json(true)
-      },
-    ),
+  // kilocode_change end
 )

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -16,1004 +16,924 @@ import { Log } from "../../util/log"
 import { PermissionNext } from "@/permission/next"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
-import { Auth } from "../../auth" // kilocode_change
-import { Storage } from "../../storage/storage" // kilocode_change
-import { Instance } from "../../project/instance" // kilocode_change
 
 const log = Log.create({ service: "server" })
 
-export const SessionRoutes = lazy(
-  () =>
-    new Hono()
-      .get(
-        "/",
-        describeRoute({
-          summary: "List sessions",
-          description: "Get a list of all OpenCode sessions, sorted by most recently updated.",
-          operationId: "session.list",
-          responses: {
-            200: {
-              description: "List of sessions",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info.array()),
-                },
+export const SessionRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/",
+      describeRoute({
+        summary: "List sessions",
+        description: "Get a list of all OpenCode sessions, sorted by most recently updated.",
+        operationId: "session.list",
+        responses: {
+          200: {
+            description: "List of sessions",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info.array()),
               },
             },
           },
-        }),
-        validator(
-          "query",
-          z.object({
-            directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
-            roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
-            start: z.coerce
-              .number()
-              .optional()
-              .meta({ description: "Filter sessions updated on or after this timestamp (milliseconds since epoch)" }),
-            search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
-            limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),
-          }),
-        ),
-        async (c) => {
-          const query = c.req.valid("query")
-          const term = query.search?.toLowerCase()
-          const sessions: Session.Info[] = []
-          for await (const session of Session.list()) {
-            if (query.directory !== undefined && session.directory !== query.directory) continue
-            if (query.roots && session.parentID) continue
-            if (query.start !== undefined && session.time.updated < query.start) continue
-            if (term !== undefined && !session.title.toLowerCase().includes(term)) continue
-            sessions.push(session)
-            if (query.limit !== undefined && sessions.length >= query.limit) break
-          }
-          return c.json(sessions)
         },
-      )
-      .get(
-        "/status",
-        describeRoute({
-          summary: "Get session status",
-          description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
-          operationId: "session.status",
-          responses: {
-            200: {
-              description: "Get session status",
-              content: {
-                "application/json": {
-                  schema: resolver(z.record(z.string(), SessionStatus.Info)),
-                },
-              },
-            },
-            ...errors(400),
-          },
+      }),
+      validator(
+        "query",
+        z.object({
+          directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
+          roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
+          start: z.coerce
+            .number()
+            .optional()
+            .meta({ description: "Filter sessions updated on or after this timestamp (milliseconds since epoch)" }),
+          search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
+          limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),
         }),
-        async (c) => {
-          const result = SessionStatus.list()
-          return c.json(result)
-        },
-      )
-      .get(
-        "/:sessionID",
-        describeRoute({
-          summary: "Get session",
-          description: "Retrieve detailed information about a specific OpenCode session.",
-          tags: ["Session"],
-          operationId: "session.get",
-          responses: {
-            200: {
-              description: "Get session",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: Session.get.schema,
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          log.info("SEARCH", { url: c.req.url })
-          const session = await Session.get(sessionID)
-          return c.json(session)
-        },
-      )
-      .get(
-        "/:sessionID/children",
-        describeRoute({
-          summary: "Get session children",
-          tags: ["Session"],
-          description: "Retrieve all child sessions that were forked from the specified parent session.",
-          operationId: "session.children",
-          responses: {
-            200: {
-              description: "List of children",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info.array()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: Session.children.schema,
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const session = await Session.children(sessionID)
-          return c.json(session)
-        },
-      )
-      .get(
-        "/:sessionID/todo",
-        describeRoute({
-          summary: "Get session todos",
-          description: "Retrieve the todo list associated with a specific session, showing tasks and action items.",
-          operationId: "session.todo",
-          responses: {
-            200: {
-              description: "Todo list",
-              content: {
-                "application/json": {
-                  schema: resolver(Todo.Info.array()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const todos = await Todo.get(sessionID)
-          return c.json(todos)
-        },
-      )
-      .post(
-        "/",
-        describeRoute({
-          summary: "Create session",
-          description: "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
-          operationId: "session.create",
-          responses: {
-            ...errors(400),
-            200: {
-              description: "Successfully created session",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-          },
-        }),
-        validator("json", Session.create.schema.optional()),
-        async (c) => {
-          const body = c.req.valid("json") ?? {}
-          const session = await Session.create(body)
-          return c.json(session)
-        },
-      )
-      .delete(
-        "/:sessionID",
-        describeRoute({
-          summary: "Delete session",
-          description: "Delete a session and permanently remove all associated data, including messages and history.",
-          operationId: "session.delete",
-          responses: {
-            200: {
-              description: "Successfully deleted session",
-              content: {
-                "application/json": {
-                  schema: resolver(z.boolean()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: Session.remove.schema,
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          await Session.remove(sessionID)
-          return c.json(true)
-        },
-      )
-      .patch(
-        "/:sessionID",
-        describeRoute({
-          summary: "Update session",
-          description: "Update properties of an existing session, such as title or other metadata.",
-          operationId: "session.update",
-          responses: {
-            200: {
-              description: "Successfully updated session",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string(),
-          }),
-        ),
-        validator(
-          "json",
-          z.object({
-            title: z.string().optional(),
-            time: z
-              .object({
-                archived: z.number().optional(),
-              })
-              .optional(),
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const updates = c.req.valid("json")
-
-          const updatedSession = await Session.update(
-            sessionID,
-            (session) => {
-              if (updates.title !== undefined) {
-                session.title = updates.title
-              }
-              if (updates.time?.archived !== undefined) session.time.archived = updates.time.archived
-            },
-            { touch: false },
-          )
-
-          return c.json(updatedSession)
-        },
-      )
-      .post(
-        "/:sessionID/init",
-        describeRoute({
-          summary: "Initialize session",
-          description:
-            "Analyze the current application and create an AGENTS.md file with project-specific agent configurations.",
-          operationId: "session.init",
-          responses: {
-            200: {
-              description: "200",
-              content: {
-                "application/json": {
-                  schema: resolver(z.boolean()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        validator("json", Session.initialize.schema.omit({ sessionID: true })),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          await Session.initialize({ ...body, sessionID })
-          return c.json(true)
-        },
-      )
-      .post(
-        "/:sessionID/fork",
-        describeRoute({
-          summary: "Fork session",
-          description: "Create a new session by forking an existing session at a specific message point.",
-          operationId: "session.fork",
-          responses: {
-            200: {
-              description: "200",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: Session.fork.schema.shape.sessionID,
-          }),
-        ),
-        validator("json", Session.fork.schema.omit({ sessionID: true })),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const result = await Session.fork({ ...body, sessionID })
-          return c.json(result)
-        },
-      )
-      .post(
-        "/:sessionID/abort",
-        describeRoute({
-          summary: "Abort session",
-          description: "Abort an active session and stop any ongoing AI processing or command execution.",
-          operationId: "session.abort",
-          responses: {
-            200: {
-              description: "Aborted session",
-              content: {
-                "application/json": {
-                  schema: resolver(z.boolean()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string(),
-          }),
-        ),
-        async (c) => {
-          SessionPrompt.cancel(c.req.valid("param").sessionID)
-          return c.json(true)
-        },
-      )
-      .post(
-        "/:sessionID/share",
-        describeRoute({
-          summary: "Share session",
-          description: "Create a shareable link for a session, allowing others to view the conversation.",
-          operationId: "session.share",
-          responses: {
-            200: {
-              description: "Successfully shared session",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string(),
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          await Session.share(sessionID)
-          const session = await Session.get(sessionID)
-          return c.json(session)
-        },
-      )
-      .get(
-        "/:sessionID/diff",
-        describeRoute({
-          summary: "Get message diff",
-          description: "Get the file changes (diff) that resulted from a specific user message in the session.",
-          operationId: "session.diff",
-          responses: {
-            200: {
-              description: "Successfully retrieved diff",
-              content: {
-                "application/json": {
-                  schema: resolver(Snapshot.FileDiff.array()),
-                },
-              },
-            },
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: SessionSummary.diff.schema.shape.sessionID,
-          }),
-        ),
-        validator(
-          "query",
-          z.object({
-            messageID: SessionSummary.diff.schema.shape.messageID,
-          }),
-        ),
-        async (c) => {
-          const query = c.req.valid("query")
-          const params = c.req.valid("param")
-          const result = await SessionSummary.diff({
-            sessionID: params.sessionID,
-            messageID: query.messageID,
-          })
-          return c.json(result)
-        },
-      )
-      .delete(
-        "/:sessionID/share",
-        describeRoute({
-          summary: "Unshare session",
-          description: "Remove the shareable link for a session, making it private again.",
-          operationId: "session.unshare",
-          responses: {
-            200: {
-              description: "Successfully unshared session",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: Session.unshare.schema,
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          await Session.unshare(sessionID)
-          const session = await Session.get(sessionID)
-          return c.json(session)
-        },
-      )
-      .post(
-        "/:sessionID/summarize",
-        describeRoute({
-          summary: "Summarize session",
-          description: "Generate a concise summary of the session using AI compaction to preserve key information.",
-          operationId: "session.summarize",
-          responses: {
-            200: {
-              description: "Summarized session",
-              content: {
-                "application/json": {
-                  schema: resolver(z.boolean()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        validator(
-          "json",
-          z.object({
-            providerID: z.string(),
-            modelID: z.string(),
-            auto: z.boolean().optional().default(false),
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const session = await Session.get(sessionID)
-          await SessionRevert.cleanup(session)
-          const msgs = await Session.messages({ sessionID })
-          let currentAgent = await Agent.defaultAgent()
-          for (let i = msgs.length - 1; i >= 0; i--) {
-            const info = msgs[i].info
-            if (info.role === "user") {
-              currentAgent = info.agent || (await Agent.defaultAgent())
-              break
-            }
-          }
-          await SessionCompaction.create({
-            sessionID,
-            agent: currentAgent,
-            model: {
-              providerID: body.providerID,
-              modelID: body.modelID,
-            },
-            auto: body.auto,
-          })
-          await SessionPrompt.loop({ sessionID })
-          return c.json(true)
-        },
-      )
-      .get(
-        "/:sessionID/message",
-        describeRoute({
-          summary: "Get session messages",
-          description: "Retrieve all messages in a session, including user prompts and AI responses.",
-          operationId: "session.messages",
-          responses: {
-            200: {
-              description: "List of messages",
-              content: {
-                "application/json": {
-                  schema: resolver(MessageV2.WithParts.array()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        validator(
-          "query",
-          z.object({
-            limit: z.coerce.number().optional(),
-          }),
-        ),
-        async (c) => {
-          const query = c.req.valid("query")
-          const messages = await Session.messages({
-            sessionID: c.req.valid("param").sessionID,
-            limit: query.limit,
-          })
-          return c.json(messages)
-        },
-      )
-      .get(
-        "/:sessionID/message/:messageID",
-        describeRoute({
-          summary: "Get message",
-          description: "Retrieve a specific message from a session by its message ID.",
-          operationId: "session.message",
-          responses: {
-            200: {
-              description: "Message",
-              content: {
-                "application/json": {
-                  schema: resolver(
-                    z.object({
-                      info: MessageV2.Info,
-                      parts: MessageV2.Part.array(),
-                    }),
-                  ),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-            messageID: z.string().meta({ description: "Message ID" }),
-          }),
-        ),
-        async (c) => {
-          const params = c.req.valid("param")
-          const message = await MessageV2.get({
-            sessionID: params.sessionID,
-            messageID: params.messageID,
-          })
-          return c.json(message)
-        },
-      )
-      .delete(
-        "/:sessionID/message/:messageID/part/:partID",
-        describeRoute({
-          description: "Delete a part from a message",
-          operationId: "part.delete",
-          responses: {
-            200: {
-              description: "Successfully deleted part",
-              content: {
-                "application/json": {
-                  schema: resolver(z.boolean()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-            messageID: z.string().meta({ description: "Message ID" }),
-            partID: z.string().meta({ description: "Part ID" }),
-          }),
-        ),
-        async (c) => {
-          const params = c.req.valid("param")
-          await Session.removePart({
-            sessionID: params.sessionID,
-            messageID: params.messageID,
-            partID: params.partID,
-          })
-          return c.json(true)
-        },
-      )
-      .patch(
-        "/:sessionID/message/:messageID/part/:partID",
-        describeRoute({
-          description: "Update a part in a message",
-          operationId: "part.update",
-          responses: {
-            200: {
-              description: "Successfully updated part",
-              content: {
-                "application/json": {
-                  schema: resolver(MessageV2.Part),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-            messageID: z.string().meta({ description: "Message ID" }),
-            partID: z.string().meta({ description: "Part ID" }),
-          }),
-        ),
-        validator("json", MessageV2.Part),
-        async (c) => {
-          const params = c.req.valid("param")
-          const body = c.req.valid("json")
-          if (body.id !== params.partID || body.messageID !== params.messageID || body.sessionID !== params.sessionID) {
-            throw new Error(
-              `Part mismatch: body.id='${body.id}' vs partID='${params.partID}', body.messageID='${body.messageID}' vs messageID='${params.messageID}', body.sessionID='${body.sessionID}' vs sessionID='${params.sessionID}'`,
-            )
-          }
-          const part = await Session.updatePart(body)
-          return c.json(part)
-        },
-      )
-      .post(
-        "/:sessionID/message",
-        describeRoute({
-          summary: "Send message",
-          description: "Create and send a new message to a session, streaming the AI response.",
-          operationId: "session.prompt",
-          responses: {
-            200: {
-              description: "Created message",
-              content: {
-                "application/json": {
-                  schema: resolver(
-                    z.object({
-                      info: MessageV2.Assistant,
-                      parts: MessageV2.Part.array(),
-                    }),
-                  ),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
-        async (c) => {
-          c.status(200)
-          c.header("Content-Type", "application/json")
-          return stream(c, async (stream) => {
-            const sessionID = c.req.valid("param").sessionID
-            const body = c.req.valid("json")
-            const msg = await SessionPrompt.prompt({ ...body, sessionID })
-            stream.write(JSON.stringify(msg))
-          })
-        },
-      )
-      .post(
-        "/:sessionID/prompt_async",
-        describeRoute({
-          summary: "Send async message",
-          description:
-            "Create and send a new message to a session asynchronously, starting the session if needed and returning immediately.",
-          operationId: "session.prompt_async",
-          responses: {
-            204: {
-              description: "Prompt accepted",
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
-        async (c) => {
-          c.status(204)
-          c.header("Content-Type", "application/json")
-          return stream(c, async () => {
-            const sessionID = c.req.valid("param").sessionID
-            const body = c.req.valid("json")
-            SessionPrompt.prompt({ ...body, sessionID })
-          })
-        },
-      )
-      .post(
-        "/:sessionID/command",
-        describeRoute({
-          summary: "Send command",
-          description: "Send a new command to a session for execution by the AI assistant.",
-          operationId: "session.command",
-          responses: {
-            200: {
-              description: "Created message",
-              content: {
-                "application/json": {
-                  schema: resolver(
-                    z.object({
-                      info: MessageV2.Assistant,
-                      parts: MessageV2.Part.array(),
-                    }),
-                  ),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        validator("json", SessionPrompt.CommandInput.omit({ sessionID: true })),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const msg = await SessionPrompt.command({ ...body, sessionID })
-          return c.json(msg)
-        },
-      )
-      .post(
-        "/:sessionID/shell",
-        describeRoute({
-          summary: "Run shell command",
-          description: "Execute a shell command within the session context and return the AI's response.",
-          operationId: "session.shell",
-          responses: {
-            200: {
-              description: "Created message",
-              content: {
-                "application/json": {
-                  schema: resolver(MessageV2.Assistant),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string().meta({ description: "Session ID" }),
-          }),
-        ),
-        validator("json", SessionPrompt.ShellInput.omit({ sessionID: true })),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const msg = await SessionPrompt.shell({ ...body, sessionID })
-          return c.json(msg)
-        },
-      )
-      .post(
-        "/:sessionID/revert",
-        describeRoute({
-          summary: "Revert message",
-          description: "Revert a specific message in a session, undoing its effects and restoring the previous state.",
-          operationId: "session.revert",
-          responses: {
-            200: {
-              description: "Updated session",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string(),
-          }),
-        ),
-        validator("json", SessionRevert.RevertInput.omit({ sessionID: true })),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          log.info("revert", c.req.valid("json"))
-          const session = await SessionRevert.revert({
-            sessionID,
-            ...c.req.valid("json"),
-          })
-          return c.json(session)
-        },
-      )
-      .post(
-        "/:sessionID/unrevert",
-        describeRoute({
-          summary: "Restore reverted messages",
-          description: "Restore all previously reverted messages in a session.",
-          operationId: "session.unrevert",
-          responses: {
-            200: {
-              description: "Updated session",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string(),
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          const session = await SessionRevert.unrevert({ sessionID })
-          return c.json(session)
-        },
-      )
-      .post(
-        "/:sessionID/permissions/:permissionID",
-        describeRoute({
-          summary: "Respond to permission",
-          deprecated: true,
-          description: "Approve or deny a permission request from the AI assistant.",
-          operationId: "permission.respond",
-          responses: {
-            200: {
-              description: "Permission processed successfully",
-              content: {
-                "application/json": {
-                  schema: resolver(z.boolean()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: z.string(),
-            permissionID: z.string(),
-          }),
-        ),
-        validator("json", z.object({ response: PermissionNext.Reply })),
-        async (c) => {
-          const params = c.req.valid("param")
-          PermissionNext.reply({
-            requestID: params.permissionID,
-            reply: c.req.valid("json").response,
-          })
-          return c.json(true)
-        },
-      )
-      // kilocode_change start
-      .post(
-        "/import-cloud",
-        describeRoute({
-          summary: "Import session from cloud",
-          description: "Download a cloud-synced session and write it to local storage.",
-          operationId: "session.importCloud",
-          responses: {
-            200: {
-              description: "Imported session info",
-              content: {
-                "application/json": {
-                  schema: resolver(Session.Info),
-                },
-              },
-            },
-            ...errors(400, 401, 404),
-          },
-        }),
-        validator(
-          "json",
-          z.object({
-            sessionId: z.string().startsWith("ses_").length(30),
-          }),
-        ),
-        async (c) => {
-          const { sessionId } = c.req.valid("json")
-
-          const auth = await Auth.get("kilo")
-          if (!auth) return c.json({ error: "Not authenticated with Kilo" }, 401)
-
-          const token =
-            auth.type === "api"
-              ? auth.key
-              : auth.type === "oauth"
-                ? auth.access
-                : auth.type === "wellknown"
-                  ? auth.token
-                  : undefined
-          if (!token) return c.json({ error: "No valid token found" }, 401)
-
-          const ingestBase = process.env["KILO_SESSION_INGEST_URL"] ?? "https://ingest.kilosessions.ai"
-          const response = await fetch(`${ingestBase}/api/session/${sessionId}/export`, {
-            headers: { Authorization: `Bearer ${token}` },
-          })
-
-          if (response.status === 404) return c.json({ error: "Session not found in cloud" }, 404)
-          if (!response.ok) {
-            const text = await response.text()
-            return c.json({ error: `Cloud export failed: ${response.status} ${text}` }, 500 as any)
-          }
-
-          const data = (await response.json()) as {
-            info: Session.Info
-            messages: Array<{
-              info: { id: string; sessionID: string; role: string; time: unknown }
-              parts: Array<{ id: string }>
-            }>
-          }
-
-          if (!data?.info?.id) return c.json({ error: "Invalid export data" }, 400)
-
-          const projectID = Instance.project.id
-          await Storage.write(["session", projectID, data.info.id], data.info)
-
-          for (const msg of data.messages ?? []) {
-            await Storage.write(["message", data.info.id, msg.info.id], msg.info)
-            for (const part of msg.parts ?? []) {
-              await Storage.write(["part", msg.info.id, part.id], part)
-            }
-          }
-
-          return c.json(data.info)
-        },
       ),
-  // kilocode_change end
+      async (c) => {
+        const query = c.req.valid("query")
+        const term = query.search?.toLowerCase()
+        const sessions: Session.Info[] = []
+        for await (const session of Session.list()) {
+          if (query.directory !== undefined && session.directory !== query.directory) continue
+          if (query.roots && session.parentID) continue
+          if (query.start !== undefined && session.time.updated < query.start) continue
+          if (term !== undefined && !session.title.toLowerCase().includes(term)) continue
+          sessions.push(session)
+          if (query.limit !== undefined && sessions.length >= query.limit) break
+        }
+        return c.json(sessions)
+      },
+    )
+    .get(
+      "/status",
+      describeRoute({
+        summary: "Get session status",
+        description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
+        operationId: "session.status",
+        responses: {
+          200: {
+            description: "Get session status",
+            content: {
+              "application/json": {
+                schema: resolver(z.record(z.string(), SessionStatus.Info)),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      async (c) => {
+        const result = SessionStatus.list()
+        return c.json(result)
+      },
+    )
+    .get(
+      "/:sessionID",
+      describeRoute({
+        summary: "Get session",
+        description: "Retrieve detailed information about a specific OpenCode session.",
+        tags: ["Session"],
+        operationId: "session.get",
+        responses: {
+          200: {
+            description: "Get session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: Session.get.schema,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        log.info("SEARCH", { url: c.req.url })
+        const session = await Session.get(sessionID)
+        return c.json(session)
+      },
+    )
+    .get(
+      "/:sessionID/children",
+      describeRoute({
+        summary: "Get session children",
+        tags: ["Session"],
+        description: "Retrieve all child sessions that were forked from the specified parent session.",
+        operationId: "session.children",
+        responses: {
+          200: {
+            description: "List of children",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info.array()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: Session.children.schema,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const session = await Session.children(sessionID)
+        return c.json(session)
+      },
+    )
+    .get(
+      "/:sessionID/todo",
+      describeRoute({
+        summary: "Get session todos",
+        description: "Retrieve the todo list associated with a specific session, showing tasks and action items.",
+        operationId: "session.todo",
+        responses: {
+          200: {
+            description: "Todo list",
+            content: {
+              "application/json": {
+                schema: resolver(Todo.Info.array()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const todos = await Todo.get(sessionID)
+        return c.json(todos)
+      },
+    )
+    .post(
+      "/",
+      describeRoute({
+        summary: "Create session",
+        description: "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
+        operationId: "session.create",
+        responses: {
+          ...errors(400),
+          200: {
+            description: "Successfully created session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", Session.create.schema.optional()),
+      async (c) => {
+        const body = c.req.valid("json") ?? {}
+        const session = await Session.create(body)
+        return c.json(session)
+      },
+    )
+    .delete(
+      "/:sessionID",
+      describeRoute({
+        summary: "Delete session",
+        description: "Delete a session and permanently remove all associated data, including messages and history.",
+        operationId: "session.delete",
+        responses: {
+          200: {
+            description: "Successfully deleted session",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: Session.remove.schema,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await Session.remove(sessionID)
+        return c.json(true)
+      },
+    )
+    .patch(
+      "/:sessionID",
+      describeRoute({
+        summary: "Update session",
+        description: "Update properties of an existing session, such as title or other metadata.",
+        operationId: "session.update",
+        responses: {
+          200: {
+            description: "Successfully updated session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      validator(
+        "json",
+        z.object({
+          title: z.string().optional(),
+          time: z
+            .object({
+              archived: z.number().optional(),
+            })
+            .optional(),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const updates = c.req.valid("json")
+
+        const updatedSession = await Session.update(
+          sessionID,
+          (session) => {
+            if (updates.title !== undefined) {
+              session.title = updates.title
+            }
+            if (updates.time?.archived !== undefined) session.time.archived = updates.time.archived
+          },
+          { touch: false },
+        )
+
+        return c.json(updatedSession)
+      },
+    )
+    .post(
+      "/:sessionID/init",
+      describeRoute({
+        summary: "Initialize session",
+        description:
+          "Analyze the current application and create an AGENTS.md file with project-specific agent configurations.",
+        operationId: "session.init",
+        responses: {
+          200: {
+            description: "200",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator("json", Session.initialize.schema.omit({ sessionID: true })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        await Session.initialize({ ...body, sessionID })
+        return c.json(true)
+      },
+    )
+    .post(
+      "/:sessionID/fork",
+      describeRoute({
+        summary: "Fork session",
+        description: "Create a new session by forking an existing session at a specific message point.",
+        operationId: "session.fork",
+        responses: {
+          200: {
+            description: "200",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: Session.fork.schema.shape.sessionID,
+        }),
+      ),
+      validator("json", Session.fork.schema.omit({ sessionID: true })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const result = await Session.fork({ ...body, sessionID })
+        return c.json(result)
+      },
+    )
+    .post(
+      "/:sessionID/abort",
+      describeRoute({
+        summary: "Abort session",
+        description: "Abort an active session and stop any ongoing AI processing or command execution.",
+        operationId: "session.abort",
+        responses: {
+          200: {
+            description: "Aborted session",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      async (c) => {
+        SessionPrompt.cancel(c.req.valid("param").sessionID)
+        return c.json(true)
+      },
+    )
+    .post(
+      "/:sessionID/share",
+      describeRoute({
+        summary: "Share session",
+        description: "Create a shareable link for a session, allowing others to view the conversation.",
+        operationId: "session.share",
+        responses: {
+          200: {
+            description: "Successfully shared session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await Session.share(sessionID)
+        const session = await Session.get(sessionID)
+        return c.json(session)
+      },
+    )
+    .get(
+      "/:sessionID/diff",
+      describeRoute({
+        summary: "Get message diff",
+        description: "Get the file changes (diff) that resulted from a specific user message in the session.",
+        operationId: "session.diff",
+        responses: {
+          200: {
+            description: "Successfully retrieved diff",
+            content: {
+              "application/json": {
+                schema: resolver(Snapshot.FileDiff.array()),
+              },
+            },
+          },
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: SessionSummary.diff.schema.shape.sessionID,
+        }),
+      ),
+      validator(
+        "query",
+        z.object({
+          messageID: SessionSummary.diff.schema.shape.messageID,
+        }),
+      ),
+      async (c) => {
+        const query = c.req.valid("query")
+        const params = c.req.valid("param")
+        const result = await SessionSummary.diff({
+          sessionID: params.sessionID,
+          messageID: query.messageID,
+        })
+        return c.json(result)
+      },
+    )
+    .delete(
+      "/:sessionID/share",
+      describeRoute({
+        summary: "Unshare session",
+        description: "Remove the shareable link for a session, making it private again.",
+        operationId: "session.unshare",
+        responses: {
+          200: {
+            description: "Successfully unshared session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: Session.unshare.schema,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await Session.unshare(sessionID)
+        const session = await Session.get(sessionID)
+        return c.json(session)
+      },
+    )
+    .post(
+      "/:sessionID/summarize",
+      describeRoute({
+        summary: "Summarize session",
+        description: "Generate a concise summary of the session using AI compaction to preserve key information.",
+        operationId: "session.summarize",
+        responses: {
+          200: {
+            description: "Summarized session",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator(
+        "json",
+        z.object({
+          providerID: z.string(),
+          modelID: z.string(),
+          auto: z.boolean().optional().default(false),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const session = await Session.get(sessionID)
+        await SessionRevert.cleanup(session)
+        const msgs = await Session.messages({ sessionID })
+        let currentAgent = await Agent.defaultAgent()
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          const info = msgs[i].info
+          if (info.role === "user") {
+            currentAgent = info.agent || (await Agent.defaultAgent())
+            break
+          }
+        }
+        await SessionCompaction.create({
+          sessionID,
+          agent: currentAgent,
+          model: {
+            providerID: body.providerID,
+            modelID: body.modelID,
+          },
+          auto: body.auto,
+        })
+        await SessionPrompt.loop({ sessionID })
+        return c.json(true)
+      },
+    )
+    .get(
+      "/:sessionID/message",
+      describeRoute({
+        summary: "Get session messages",
+        description: "Retrieve all messages in a session, including user prompts and AI responses.",
+        operationId: "session.messages",
+        responses: {
+          200: {
+            description: "List of messages",
+            content: {
+              "application/json": {
+                schema: resolver(MessageV2.WithParts.array()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator(
+        "query",
+        z.object({
+          limit: z.coerce.number().optional(),
+        }),
+      ),
+      async (c) => {
+        const query = c.req.valid("query")
+        const messages = await Session.messages({
+          sessionID: c.req.valid("param").sessionID,
+          limit: query.limit,
+        })
+        return c.json(messages)
+      },
+    )
+    .get(
+      "/:sessionID/message/:messageID",
+      describeRoute({
+        summary: "Get message",
+        description: "Retrieve a specific message from a session by its message ID.",
+        operationId: "session.message",
+        responses: {
+          200: {
+            description: "Message",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    info: MessageV2.Info,
+                    parts: MessageV2.Part.array(),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+          messageID: z.string().meta({ description: "Message ID" }),
+        }),
+      ),
+      async (c) => {
+        const params = c.req.valid("param")
+        const message = await MessageV2.get({
+          sessionID: params.sessionID,
+          messageID: params.messageID,
+        })
+        return c.json(message)
+      },
+    )
+    .delete(
+      "/:sessionID/message/:messageID/part/:partID",
+      describeRoute({
+        description: "Delete a part from a message",
+        operationId: "part.delete",
+        responses: {
+          200: {
+            description: "Successfully deleted part",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+          messageID: z.string().meta({ description: "Message ID" }),
+          partID: z.string().meta({ description: "Part ID" }),
+        }),
+      ),
+      async (c) => {
+        const params = c.req.valid("param")
+        await Session.removePart({
+          sessionID: params.sessionID,
+          messageID: params.messageID,
+          partID: params.partID,
+        })
+        return c.json(true)
+      },
+    )
+    .patch(
+      "/:sessionID/message/:messageID/part/:partID",
+      describeRoute({
+        description: "Update a part in a message",
+        operationId: "part.update",
+        responses: {
+          200: {
+            description: "Successfully updated part",
+            content: {
+              "application/json": {
+                schema: resolver(MessageV2.Part),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+          messageID: z.string().meta({ description: "Message ID" }),
+          partID: z.string().meta({ description: "Part ID" }),
+        }),
+      ),
+      validator("json", MessageV2.Part),
+      async (c) => {
+        const params = c.req.valid("param")
+        const body = c.req.valid("json")
+        if (body.id !== params.partID || body.messageID !== params.messageID || body.sessionID !== params.sessionID) {
+          throw new Error(
+            `Part mismatch: body.id='${body.id}' vs partID='${params.partID}', body.messageID='${body.messageID}' vs messageID='${params.messageID}', body.sessionID='${body.sessionID}' vs sessionID='${params.sessionID}'`,
+          )
+        }
+        const part = await Session.updatePart(body)
+        return c.json(part)
+      },
+    )
+    .post(
+      "/:sessionID/message",
+      describeRoute({
+        summary: "Send message",
+        description: "Create and send a new message to a session, streaming the AI response.",
+        operationId: "session.prompt",
+        responses: {
+          200: {
+            description: "Created message",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    info: MessageV2.Assistant,
+                    parts: MessageV2.Part.array(),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
+      async (c) => {
+        c.status(200)
+        c.header("Content-Type", "application/json")
+        return stream(c, async (stream) => {
+          const sessionID = c.req.valid("param").sessionID
+          const body = c.req.valid("json")
+          const msg = await SessionPrompt.prompt({ ...body, sessionID })
+          stream.write(JSON.stringify(msg))
+        })
+      },
+    )
+    .post(
+      "/:sessionID/prompt_async",
+      describeRoute({
+        summary: "Send async message",
+        description:
+          "Create and send a new message to a session asynchronously, starting the session if needed and returning immediately.",
+        operationId: "session.prompt_async",
+        responses: {
+          204: {
+            description: "Prompt accepted",
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
+      async (c) => {
+        c.status(204)
+        c.header("Content-Type", "application/json")
+        return stream(c, async () => {
+          const sessionID = c.req.valid("param").sessionID
+          const body = c.req.valid("json")
+          SessionPrompt.prompt({ ...body, sessionID })
+        })
+      },
+    )
+    .post(
+      "/:sessionID/command",
+      describeRoute({
+        summary: "Send command",
+        description: "Send a new command to a session for execution by the AI assistant.",
+        operationId: "session.command",
+        responses: {
+          200: {
+            description: "Created message",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    info: MessageV2.Assistant,
+                    parts: MessageV2.Part.array(),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator("json", SessionPrompt.CommandInput.omit({ sessionID: true })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const msg = await SessionPrompt.command({ ...body, sessionID })
+        return c.json(msg)
+      },
+    )
+    .post(
+      "/:sessionID/shell",
+      describeRoute({
+        summary: "Run shell command",
+        description: "Execute a shell command within the session context and return the AI's response.",
+        operationId: "session.shell",
+        responses: {
+          200: {
+            description: "Created message",
+            content: {
+              "application/json": {
+                schema: resolver(MessageV2.Assistant),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator("json", SessionPrompt.ShellInput.omit({ sessionID: true })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const msg = await SessionPrompt.shell({ ...body, sessionID })
+        return c.json(msg)
+      },
+    )
+    .post(
+      "/:sessionID/revert",
+      describeRoute({
+        summary: "Revert message",
+        description: "Revert a specific message in a session, undoing its effects and restoring the previous state.",
+        operationId: "session.revert",
+        responses: {
+          200: {
+            description: "Updated session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      validator("json", SessionRevert.RevertInput.omit({ sessionID: true })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        log.info("revert", c.req.valid("json"))
+        const session = await SessionRevert.revert({
+          sessionID,
+          ...c.req.valid("json"),
+        })
+        return c.json(session)
+      },
+    )
+    .post(
+      "/:sessionID/unrevert",
+      describeRoute({
+        summary: "Restore reverted messages",
+        description: "Restore all previously reverted messages in a session.",
+        operationId: "session.unrevert",
+        responses: {
+          200: {
+            description: "Updated session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const session = await SessionRevert.unrevert({ sessionID })
+        return c.json(session)
+      },
+    )
+    .post(
+      "/:sessionID/permissions/:permissionID",
+      describeRoute({
+        summary: "Respond to permission",
+        deprecated: true,
+        description: "Approve or deny a permission request from the AI assistant.",
+        operationId: "permission.respond",
+        responses: {
+          200: {
+            description: "Permission processed successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+          permissionID: z.string(),
+        }),
+      ),
+      validator("json", z.object({ response: PermissionNext.Reply })),
+      async (c) => {
+        const params = c.req.valid("param")
+        PermissionNext.reply({
+          requestID: params.permissionID,
+          reply: c.req.valid("json").response,
+        })
+        return c.json(true)
+      },
+    ),
 )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -248,6 +248,8 @@ export namespace Server {
             errors,
             Auth,
             z,
+            Storage, // kilocode_change
+            Instance, // kilocode_change
           }),
         )
         // kilocode_change end

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -43,6 +43,8 @@ import type {
   GlobalEventResponses,
   GlobalHealthResponses,
   InstanceDisposeResponses,
+  KiloCloudSessionImportErrors,
+  KiloCloudSessionImportResponses,
   KiloCloudSessionsListErrors,
   KiloCloudSessionsListResponses,
   KiloFimErrors,
@@ -123,8 +125,6 @@ import type {
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
-  SessionImportCloudErrors,
-  SessionImportCloudResponses,
   SessionInitErrors,
   SessionInitResponses,
   SessionListResponses,
@@ -1787,41 +1787,6 @@ export class Session extends HeyApiClient {
       ...params,
     })
   }
-
-  /**
-   * Import session from cloud
-   *
-   * Download a cloud-synced session and write it to local storage.
-   */
-  public importCloud<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      sessionId?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "body", key: "sessionId" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<SessionImportCloudResponses, SessionImportCloudErrors, ThrowOnError>({
-      url: "/session/import-cloud",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
 }
 
 export class Part extends HeyApiClient {
@@ -2328,10 +2293,56 @@ export class Sessions extends HeyApiClient {
   }
 }
 
+export class Session2 extends HeyApiClient {
+  /**
+   * Import session from cloud
+   *
+   * Download a cloud-synced session and write it to local storage.
+   */
+  public import<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      sessionId?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "sessionId" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KiloCloudSessionImportResponses,
+      KiloCloudSessionImportErrors,
+      ThrowOnError
+    >({
+      url: "/kilo/cloud/session/import",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class Cloud extends HeyApiClient {
   private _sessions?: Sessions
   get sessions(): Sessions {
     return (this._sessions ??= new Sessions({ client: this.client }))
+  }
+
+  private _session?: Session2
+  get session(): Session2 {
+    return (this._session ??= new Session2({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3892,39 +3892,6 @@ export type PermissionRespondResponses = {
 
 export type PermissionRespondResponse = PermissionRespondResponses[keyof PermissionRespondResponses]
 
-export type SessionImportCloudData = {
-  body?: {
-    sessionId: string
-  }
-  path?: never
-  query?: {
-    directory?: string
-  }
-  url: "/session/import-cloud"
-}
-
-export type SessionImportCloudErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionImportCloudError = SessionImportCloudErrors[keyof SessionImportCloudErrors]
-
-export type SessionImportCloudResponses = {
-  /**
-   * Imported session info
-   */
-  200: Session
-}
-
-export type SessionImportCloudResponse = SessionImportCloudResponses[keyof SessionImportCloudResponses]
-
 export type PermissionReplyData = {
   body?: {
     reply: "once" | "always" | "reject"
@@ -4367,6 +4334,37 @@ export type KiloCloudSessionsListResponses = {
 }
 
 export type KiloCloudSessionsListResponse = KiloCloudSessionsListResponses[keyof KiloCloudSessionsListResponses]
+
+export type KiloCloudSessionImportData = {
+  body?: {
+    sessionId: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/kilo/cloud/session/import"
+}
+
+export type KiloCloudSessionImportErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type KiloCloudSessionImportError = KiloCloudSessionImportErrors[keyof KiloCloudSessionImportErrors]
+
+export type KiloCloudSessionImportResponses = {
+  /**
+   * Imported session info
+   */
+  200: unknown
+}
 
 export type KiloProfileData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3892,6 +3892,39 @@ export type PermissionRespondResponses = {
 
 export type PermissionRespondResponse = PermissionRespondResponses[keyof PermissionRespondResponses]
 
+export type SessionImportCloudData = {
+  body?: {
+    sessionId: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/session/import-cloud"
+}
+
+export type SessionImportCloudErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionImportCloudError = SessionImportCloudErrors[keyof SessionImportCloudErrors]
+
+export type SessionImportCloudResponses = {
+  /**
+   * Imported session info
+   */
+  200: Session
+}
+
+export type SessionImportCloudResponse = SessionImportCloudResponses[keyof SessionImportCloudResponses]
+
 export type PermissionReplyData = {
   body?: {
     reply: "once" | "always" | "reject"
@@ -4299,6 +4332,41 @@ export type CommitMessageGenerateResponses = {
 }
 
 export type CommitMessageGenerateResponse = CommitMessageGenerateResponses[keyof CommitMessageGenerateResponses]
+
+export type KiloCloudSessionsListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/kilo/cloud/sessions"
+}
+
+export type KiloCloudSessionsListErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KiloCloudSessionsListError = KiloCloudSessionsListErrors[keyof KiloCloudSessionsListErrors]
+
+export type KiloCloudSessionsListResponses = {
+  /**
+   * Cloud sessions list
+   */
+  200: {
+    sessions: Array<{
+      session_id: string
+      title: string | null
+      created_at: string
+      updated_at: string
+    }>
+    nextCursor: string | null
+  }
+}
+
+export type KiloCloudSessionsListResponse = KiloCloudSessionsListResponses[keyof KiloCloudSessionsListResponses]
 
 export type KiloProfileData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3303,6 +3303,78 @@
         ]
       }
     },
+    "/session/import-cloud": {
+      "post": {
+        "operationId": "session.importCloud",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Import session from cloud",
+        "description": "Download a cloud-synced session and write it to local storage.",
+        "responses": {
+          "200": {
+            "description": "Imported session info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 30,
+                    "maxLength": 30,
+                    "pattern": "^ses_.*"
+                  }
+                },
+                "required": ["sessionId"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.session.importCloud({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/permission/{requestID}/reply": {
       "post": {
         "operationId": "permission.reply",
@@ -4195,6 +4267,91 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.commitMessage.generate({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilo/cloud/sessions": {
+      "get": {
+        "operationId": "kilo.cloud.sessions.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List cloud sessions",
+        "description": "Fetch the list of sessions synced to the Kilo cloud for the current user",
+        "responses": {
+          "200": {
+            "description": "Cloud sessions list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "session_id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["session_id", "title", "created_at", "updated_at"]
+                      }
+                    },
+                    "nextCursor": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["sessions", "nextCursor"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.kilo.cloud.sessions.list({\n  ...\n})"
           }
         ]
       }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3303,78 +3303,6 @@
         ]
       }
     },
-    "/session/import-cloud": {
-      "post": {
-        "operationId": "session.importCloud",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Import session from cloud",
-        "description": "Download a cloud-synced session and write it to local storage.",
-        "responses": {
-          "200": {
-            "description": "Imported session info",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Session"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "sessionId": {
-                    "type": "string",
-                    "minLength": 30,
-                    "maxLength": 30,
-                    "pattern": "^ses_.*"
-                  }
-                },
-                "required": ["sessionId"]
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.session.importCloud({\n  ...\n})"
-          }
-        ]
-      }
-    },
     "/permission/{requestID}/reply": {
       "post": {
         "operationId": "permission.reply",
@@ -4352,6 +4280,76 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.kilo.cloud.sessions.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilo/cloud/session/import": {
+      "post": {
+        "operationId": "kilo.cloud.session.import",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Import session from cloud",
+        "description": "Download a cloud-synced session and write it to local storage.",
+        "responses": {
+          "200": {
+            "description": "Imported session info",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 30,
+                    "maxLength": 30,
+                    "pattern": "^ses_.*"
+                  }
+                },
+                "required": ["sessionId"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@kilocode/sdk\n\nconst client = createOpencodeClient()\nawait client.kilo.cloud.session.import({\n  ...\n})"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Implements [#168](https://github.com/Kilo-Org/kilocode/issues/6066) — cloud session browsing and import in the VS Code extension.

### What's added

**1. Cloud Sessions panel (new toolbar button)**
- New `$(cloud)` icon button in the sidebar toolbar (between marketplace and history)
- Opens a new `CloudSessionList` view that lists all sessions synced to Kilo cloud, grouped by date (today / yesterday / this week / this month / older)
- Clicking a session calls the new `POST /session/import-cloud` endpoint which fetches the full session from `ingest.kilosessions.ai/api/session/:id/export` and writes it to local storage — then navigates directly to it (same behavior as clicking a local session in history)
- Shows login-required state when not authenticated, spinner while importing

**2. Import from Cloud — on welcome page**
- New "Import from Cloud" link in the empty/welcome state (below recent sessions)
- Click reveals an inline text input with OK / Cancel
- Accepts either a bare session ID (`ses_...30 chars`) or a URL (`https://app.kilo.ai/sessions/ses_...`)
- Parses/validates, then triggers the same import flow as (1)

**3. Platform field**
- Already done: `server-manager.ts` sets `KILO_PLATFORM=vscode`, picked up by `kilo-sessions.ts`. No change needed.

### Backend changes (opencode + kilo-gateway)

| Route | What |
|---|---|
| `GET /kilo/cloud/sessions` | New gateway route — proxies to `api.kilo.ai/api/trpc/cliSessionsV2.list` with the user's Bearer token. Supports `cursor` + `limit` pagination. |
| `POST /session/import-cloud` | New session route — fetches from `ingest.kilosessions.ai/api/session/:id/export`, writes session/messages/parts to local `Storage`, returns `Session.Info`. |

SDK regenerated after route changes.

### Files changed

- `packages/kilo-gateway/src/server/routes.ts` — new `GET /cloud/sessions` route
- `packages/opencode/src/server/routes/session.ts` — new `POST /session/import-cloud` route
- `packages/kilo-vscode/package.json` — new command + menu entry
- `packages/kilo-vscode/src/extension.ts` — register command
- `packages/kilo-vscode/src/KiloProvider.ts` — handlers for `loadCloudSessions` + `importCloudSession`
- `packages/kilo-vscode/src/services/cli-backend/` — new types + HTTP client methods
- `packages/kilo-vscode/webview-ui/src/` — new message types, context state, `CloudSessionList` component, `App.tsx` routing, `MessageList.tsx` import UI, i18n keys
- `packages/sdk/` — regenerated