### PR TITLE
feat(agent): add agent-scoped MCP tool filtering via mcpToolPrefixes config

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -47,6 +47,14 @@ export namespace Agent {
       prompt: z.string().optional(),
       options: z.record(z.string(), z.any()),
       steps: z.number().int().positive().optional(),
+      // kilocode_change: agent-scoped MCP tool filtering (#555)
+      mcpToolPrefixes: z
+        .array(z.string().min(1))
+        .optional()
+        .describe(
+          "List of MCP tool key prefixes this agent can access. When set, only MCP tools whose key matches one of these prefixes (boundary-safe) are visible to the agent. When unset, all MCP tools are available.",
+        ),
+      // end kilocode_change
     })
     .meta({
       ref: "Agent",
@@ -316,6 +324,7 @@ export namespace Agent {
       item.hidden = value.hidden ?? item.hidden
       item.name = value.name ?? item.name
       item.steps = value.steps ?? item.steps
+      item.mcpToolPrefixes = value.mcpToolPrefixes ?? item.mcpToolPrefixes // kilocode_change (#555)
       item.options = mergeDeep(item.options, value.options ?? {})
       item.permission = PermissionNext.merge(item.permission, PermissionNext.fromConfig(value.permission ?? {}))
     }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -789,6 +789,14 @@ export namespace Config {
         .describe("Maximum number of agentic iterations before forcing text-only response"),
       maxSteps: z.number().int().positive().optional().describe("@deprecated Use 'steps' field instead."),
       permission: Permission.optional(),
+      // kilocode_change: agent-scoped MCP tool filtering (#555)
+      mcpToolPrefixes: z
+        .array(z.string().min(1))
+        .optional()
+        .describe(
+          "List of MCP tool key prefixes this agent can access. Boundary-safe: prefix 'foo' matches 'foo_bar' but not 'foobar'. When unset, all MCP tools are available. Example: ['governor_serper', 'governor_context7'] to restrict to specific backend servers within a multiplexer.",
+        ),
+      // end kilocode_change
     })
     .catchall(z.any())
     .transform((agent, ctx) => {
@@ -809,6 +817,7 @@ export namespace Config {
         "permission",
         "disable",
         "tools",
+        "mcpToolPrefixes", // kilocode_change (#555)
       ])
 
       // Extract unknown properties into options

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -844,7 +844,20 @@ export namespace SessionPrompt {
       })
     }
 
+    // kilocode_change: agent-scoped MCP tool filtering (#555)
+    const mcpToolPrefixes = input.agent.mcpToolPrefixes
+    const sanitizedPrefixes = mcpToolPrefixes?.map((p) => p.replace(/[^a-zA-Z0-9_-]/g, "_"))
     for (const [key, item] of Object.entries(await MCP.tools())) {
+      // Boundary-safe prefix matching: 'foo' matches 'foo' and 'foo_bar' but not 'foobar'
+      if (
+        sanitizedPrefixes &&
+        sanitizedPrefixes.length > 0 &&
+        !sanitizedPrefixes.some((prefix) => key === prefix || key.startsWith(prefix + "_"))
+      ) {
+        continue
+      }
+      // end kilocode_change
+
       const execute = item.execute
       if (!execute) continue
 


### PR DESCRIPTION
Fixes #555

## Context

When using MCP multiplexers (e.g., a single MCP server that aggregates tools from many backends), all agents currently see the full set of MCP tools. This creates problems for specialized agent topologies:

- **Token overhead**: A multiplexer can expose 200+ tools; agents that only need 5-10 pay the full context cost on every turn.
- **Model confusion**: More tools = more opportunities for the model to pick the wrong one, especially for focused subagents (reviewer, explorer).
- **No specialization**: You can't give an "ops" subagent access to Google Workspace + calendar tools while keeping a "code" subagent lean with just codebase search.

This feature adds optional per-agent MCP tool filtering via a `mcpToolPrefixes` config property, enabling agent topologies where each agent only sees the MCP tools it needs.

## Implementation

**31 lines across 3 files**, fully backward compatible:

### 1. `packages/opencode/src/config/config.ts`
- Added `mcpToolPrefixes: z.array(z.string().min(1)).optional()` to the `Config.Agent` schema
- Added `"mcpToolPrefixes"` to `knownKeys` so it's not treated as a provider option
- All changes wrapped with `// kilocode_change` markers

### 2. `packages/opencode/src/agent/agent.ts`
- Added `mcpToolPrefixes` to the `Agent.Info` Zod schema with descriptive `.describe()`
- Added config passthrough: `item.mcpToolPrefixes = value.mcpToolPrefixes ?? item.mcpToolPrefixes`

### 3. `packages/opencode/src/session/prompt.ts`
- Added boundary-safe prefix filtering in `resolveTools()`
- Prefixes are sanitized using the same regex as MCP tool keys (`/[^a-zA-Z0-9_-]/g`)
- Matching: `key === prefix || key.startsWith(prefix + "_")` — prevents overmatch (e.g., prefix `foo` matches `foo_bar` but **not** `foobar`)

### Design decisions

- **Boundary-safe prefix matching** — not raw `startsWith()`. Prevents prefix collision between similarly-named servers.
- **Prefix sanitization** — config values are sanitized with the same regex used for MCP tool key construction, ensuring consistent matching regardless of special characters.
- **`z.string().min(1)`** — empty strings rejected at schema level, preventing silent allow-all via `"".startsWith("")`.
- **No filtering when unset** — fully backward compatible. Existing configs are unaffected.
- **No new dependencies** — uses only existing Zod schemas and standard JS methods.
- **`// kilocode_change` markers** on all modifications for upstream merge tracking.

### Example config

```json
{
  "agent": {
    "code": {
      "model": "anthropic/claude-sonnet-4-20250514",
      "mcpToolPrefixes": ["governor_codebase_rag", "governor_context7"]
    },
    "reviewer": {
      "mode": "subagent",
      "model": "openai/o3",
      "mcpToolPrefixes": ["governor_codebase_rag", "governor_supabase"]
    }
  }
}
```

## Screenshots

N/A — config-only change, no UI impact.

## How to Test

1. Configure an MCP server that exposes multiple tools (or a multiplexer with many backends)
2. Add `mcpToolPrefixes` to one agent in your config:
   ```json
   {
     "agent": {
       "code": {
         "mcpToolPrefixes": ["your_server_prefix"]
       }
     }
   }
   ```
3. Start a session with that agent
4. Verify only tools matching the prefix(es) appear in the agent's tool list
5. Verify boundary safety: prefix `foo` should NOT match `foobar_tool`
6. Remove `mcpToolPrefixes` from config → verify all tools appear again (backward compat)
7. Test `mcpToolPrefixes: []` → should behave same as unset (all tools visible)

## Get in Touch

Discord: `marlian` — happy to discuss design decisions or iterate on the approach.