### PR TITLE
Fix navigation issue with sidenav

### DIFF
--- a/packages/kilo-docs/pages/_app.tsx
+++ b/packages/kilo-docs/pages/_app.tsx
@@ -73,7 +73,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
     posthog.capture("$pageview")
   }, [])
 
-  // Close mobile menu on route change and track pageviews
+  // Close mobile menu on route change, track pageviews, and reset scroll position
   useEffect(() => {
     const handleRouteChange = () => {
       setIsMobileMenuOpen(false)
@@ -81,6 +81,11 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
 
     const handleRouteComplete = () => {
       posthog.capture("$pageview")
+      // Reset scroll position of the main content container on navigation
+      const mainContent = document.querySelector(".main-content")
+      if (mainContent) {
+        mainContent.scrollTop = 0
+      }
     }
 
     router.events.on("routeChangeStart", handleRouteChange)
@@ -175,7 +180,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
               <div className="article-content flex column mt-5">
                 <Component {...pageProps} />
               </div>
-              <div className="right-sidebar">
+              <div className="right-sidebar" key={router.asPath}>
                 {markdoc && <CopyPageButton />}
                 <TableOfContents toc={toc} />
               </div>


### PR DESCRIPTION
Sometimes in navigating with anchors and then moving between pages, the side nav does not reset properly and ends up having headers from different pages. This adds keys as well as a scroll reset between navigation events

Example of the problem:

<img width="2914" height="1120" alt="CleanShot 2026-02-21 at 06 49 19@2x" src="https://github.com/user-attachments/assets/b31e9d3a-1b9c-43ba-b45b-581ebc56d542" />
