### PR TITLE
feat(opencode): add SIGHUP signal handler for graceful shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ logs/
 
 # Telemetry ID
 telemetry-id
+.cocoindex_code

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -42,6 +42,11 @@ if (!process.env[ENV_FEATURE]) {
 import { Global } from "./global"
 import { Config } from "./config/config"
 import { Auth } from "./auth"
+
+process.on("SIGHUP", async () => {
+  await Instance.disposeAll()
+  process.exit(0)
+})
 // kilocode_change end
 
 process.on("unhandledRejection", (e) => {


### PR DESCRIPTION
Add SIGHUP signal handler to exit process cleanly, update .gitignore to exclude cocoindex code artifacts

## Context

Added a SIGHUP signal handler to enable graceful process shutdown when the terminal is closed, updated .gitignore to exclude cocoindex code index artifacts from version control.

Closes Kilo-Org/kilocode#6324 

## Implementation

**SIGHUP Signal Handler**
- Added `process.on("SIGHUP", () => process.exit(0))` in `packages/opencode/src/index.ts`
- Ensures clean process termination when the terminal session ends or the process receives a SIGHUP signal
- Prevents zombie processes or hanging connections
**.gitignore Update**
- Added `.cocoindex_code` to exclude cocoindex semantic index artifacts
- Prevents committing large binary index files to the repository

## Screenshots

| before | after |
| ------ | ----- |
| N/A - no UI changes | N/A - no UI changes |

## How to Test

**Test SIGHUP Handler:**
1. Start Kilo CLI: `bun run dev`
2. Send SIGHUP signal to the process: `kill -HUP <pid>` (find pid with `ps aux | grep bun`)
3. Verify the process exits cleanly (no errors, zombie processes)
4. Alternatively, close the terminal window and confirm the process terminates

## Get in Touch

861519093852012544
