### PR TITLE
feat(mcp): persist MCP enabled state to config file

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -549,6 +549,10 @@ export namespace MCP {
       }
       s.clients[name] = result.mcpClient
     }
+
+    // kilocode_change start - Persist enabled: true to config
+    await Config.persistMcpToggle(name, true)
+    // kilocode_change end
   }
 
   export async function disconnect(name: string) {
@@ -561,6 +565,10 @@ export namespace MCP {
       delete s.clients[name]
     }
     s.status[name] = { status: "disabled" }
+
+    // kilocode_change start - Persist enabled: false to config
+    await Config.persistMcpToggle(name, false)
+    // kilocode_change end
   }
 
   export async function tools() {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -550,8 +550,12 @@ export namespace MCP {
       s.clients[name] = result.mcpClient
     }
 
-    // kilocode_change start - Persist enabled: true to config
-    await Config.persistMcpToggle(name, true)
+    // kilocode_change start - Persist enabled: true to config only if connection succeeded
+    if (result.status.status === "connected") {
+      await Config.persistMcpToggle(name, true).catch((error) => {
+        log.error("Failed to persist MCP enabled state to config", { name, error })
+      })
+    }
     // kilocode_change end
   }
 
@@ -567,7 +571,9 @@ export namespace MCP {
     s.status[name] = { status: "disabled" }
 
     // kilocode_change start - Persist enabled: false to config
-    await Config.persistMcpToggle(name, false)
+    await Config.persistMcpToggle(name, false).catch((error) => {
+      log.error("Failed to persist MCP disabled state to config", { name, error })
+    })
     // kilocode_change end
   }
 


### PR DESCRIPTION
Add `persistMcpToggle` function to persist MCP server enabled/disabled state to the configuration file. This ensures MCP server states are preserved across application restarts.
Closes Kilo-Org/kilocode#6292

## Context

When toggling MCP servers via the CLI/TUI (through the connect/disconnect endpoints introduced in PR #4509), the enabled/disabled state was only stored in memory and lost after restarting the application. This was an oversight where the runtime toggle feature (added Dec 2025) was never integrated with the persistent `enabled` config field (introduced June 2025).
The `enabled` field was designed to control startup behavior, but could only be modified by manually editing the config file. Users expected toggles to persist but they didn't.

## Implementation

1. **Added `Config.persistMcpToggle(name, enabled)` function** in `packages/opencode/src/config/config.ts`:
   - Resolves the correct config path (supports project-local `.opencode/opencode.json` and global `~/.config/kilo/opencode.json`)
   - Uses `jsonc-parser` to modify the config while preserving comments and formatting
   - Writes the updated config back to disk
2. **Updated `MCP.connect()`** in `packages/opencode/src/mcp/index.ts`:
   - Calls `Config.persistMcpToggle(name, true)` after successfully connecting
   - Ensures enabled state persists to config
3. **Updated `MCP.disconnect()`** in `packages/opencode/src/mcp/index.ts`:
   - Calls `Config.persistMcpToggle(name, false)` after disconnecting
   - Ensures disabled state persists to config
  
The fix bridges two separate features that were never properly integrated:
- June 2025 (PR Kilo-Org/kilo#513): Static `enabled` field for manual config editing
- December 2025 (PR #4509): Runtime toggle endpoints

## How to Test

1. Start the CLI or TUI
2. Open MCP dialog (TUI: press `Ctrl+X`, select "Toggle MCPs")
3. Toggle an MCP server (press Space on a server to enable/disable)
4. Restart the CLI/TUI application
5. Verify: The MCP server retains its enabled/disabled state from step 3
**Alternative test via CLI:**
# Connect an MCP server
curl -X POST http://localhost:4096/mcp/my-server/connect
# Check it's enabled in config
cat ~/.config/kilo/opencode.json | grep -A 3 "my-server"
# Restart application
# Verify server is still connected on startup

## Get in Touch

861519093852012544