### PR TITLE
feat(vscode): add ArrowUp/ArrowDown message history navigation to chat input

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -17,6 +17,7 @@ import { ThinkingSelector } from "./ThinkingSelector"
 import { useFileMention } from "../../hooks/useFileMention"
 import { useImageAttachments } from "../../hooks/useImageAttachments"
 import { fileName, dirName, buildHighlightSegments } from "./prompt-input-utils"
+import { addHistory, navigate, reset, canNavigate } from "./history"
 
 const AUTOCOMPLETE_DEBOUNCE_MS = 500
 const MIN_TEXT_LENGTH = 3
@@ -179,6 +180,22 @@ export const PromptInput: Component = () => {
       return
     }
 
+    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+      if (e.altKey || e.ctrlKey || e.metaKey) return
+      if (!textareaRef) return
+      if (textareaRef.selectionStart !== textareaRef.selectionEnd) return
+      const dir = e.key === "ArrowUp" ? ("up" as const) : ("down" as const)
+      if (!canNavigate(dir, textareaRef)) return
+      const result = navigate(dir, text())
+      if (result === null) return
+      setText(result.text)
+      textareaRef.value = result.text
+      textareaRef.setSelectionRange(result.text.length, result.text.length)
+      adjustHeight()
+      e.preventDefault()
+      return
+    }
+
     if ((e.key === "Tab" || e.key === "ArrowRight") && ghostText()) {
       e.preventDefault()
       acceptSuggestion()
@@ -217,6 +234,8 @@ export const PromptInput: Component = () => {
 
     session.sendMessage(message, sel?.providerID, sel?.modelID, attachments)
 
+    addHistory(message)
+    reset()
     requestCounter++
     setText("")
     setGhostText("")

--- a/packages/kilo-vscode/webview-ui/src/components/chat/history.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/history.ts
@@ -1,0 +1,48 @@
+const entries: string[] = []
+let idx = -1
+let draft = ""
+
+export function addHistory(text: string) {
+  const trimmed = text.trim()
+  if (!trimmed) return
+  if (entries[0] === trimmed) return
+  entries.unshift(trimmed)
+  if (entries.length > 100) entries.pop()
+}
+
+export function navigate(direction: "up" | "down", current: string): { text: string } | null {
+  if (direction === "up") {
+    if (entries.length === 0) return null
+    if (idx === -1) {
+      draft = current
+      idx = 0
+      return { text: entries[0] }
+    }
+    if (idx < entries.length - 1) {
+      idx++
+      return { text: entries[idx] }
+    }
+    return null
+  }
+  if (idx === -1) return null
+  if (idx > 0) {
+    idx--
+    return { text: entries[idx] }
+  }
+  const saved = draft
+  idx = -1
+  draft = ""
+  return { text: saved }
+}
+
+export function reset() {
+  idx = -1
+  draft = ""
+}
+
+export function canNavigate(direction: "up" | "down", textarea: HTMLTextAreaElement): boolean {
+  const cursor = textarea.selectionStart ?? textarea.value.length
+  if (!textarea.value.includes("\n")) return true
+  if (direction === "up") return !textarea.value.slice(0, cursor).includes("\n")
+  return !textarea.value.slice(cursor).includes("\n")
+}


### PR DESCRIPTION
Fixes Kilo-Org/kilocode#6072 

## Context

Add support for pressing ArrowUp/ArrowDown to navigate through previously sent messages in the VS Code extension's chat input. This is a standard UX pattern (like terminal/shell history) that lets users quickly resend or edit previous messages.

## Implementation

Added a new `history.ts` utility module alongside the existing `PromptInput.tsx` component:

- **`history.ts`** — Pure functions for string-based message history management:
  - `addHistory(text)` — prepends sent messages, deduplicates consecutive identical entries, caps at 100
  - `navigate(direction, current)` — navigates up/down through history; saves current draft on first "up", restores on "down" past newest
  - `reset()` — resets navigation index (called after sending)
  - `canNavigate(direction, textarea)` — multiline-aware: ArrowUp only when cursor is on first line, ArrowDown only on last line

- **`PromptInput.tsx`** — Three targeted modifications:
  1. Import history functions
  2. ArrowUp/ArrowDown handler in `handleKeyDown()` (after mention-dropdown check, before Tab/Enter)
  3. Call `addHistory()` and `reset()` in `handleSend()` after sending

The approach mirrors the existing history system in `packages/app/` but simplified for plain-string textarea input rather than rich `Prompt` parts. History is stored in-memory at the module level (like the existing per-session `drafts` Map).

## Screenshots

N/A — keyboard interaction feature (no visual changes)

## How to Test

1. Open Kilo Code in VS Code
2. Send a few messages in the chat (e.g., "hello", "fix the bug", "explain this code")
3. With the input empty, press **ArrowUp** — should recall "explain this code"
4. Press **ArrowUp** again — should recall "fix the bug"
5. Press **ArrowDown** — should go back to "explain this code"
6. Press **ArrowDown** again — should restore the empty input (or whatever you were typing before pressing up)
7. Type a multiline message (Shift+Enter for newlines), then with cursor on middle line press ArrowUp — should NOT navigate history (only triggers on first/last line)

## Get in Touch

thomas07374