### PR TITLE
feat(vscode): add back button to ProfileView

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -171,6 +171,7 @@ const AppContent: Component = () => {
             profileData={server.profileData()}
             deviceAuth={server.deviceAuth()}
             onLogin={server.startLogin}
+            onBack={() => setCurrentView("newTask")}
           />
         </Match>
         <Match when={currentView() === "settings"}>

--- a/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
@@ -1,6 +1,7 @@
 import { Component, Show, createSignal, createMemo, createEffect, onMount } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Card } from "@kilocode/kilo-ui/card"
+import { Icon } from "@kilocode/kilo-ui/icon"
 import { Select } from "@kilocode/kilo-ui/select"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useVSCode } from "../context/vscode"
@@ -14,6 +15,7 @@ export interface ProfileViewProps {
   profileData: ProfileData | null | undefined
   deviceAuth: DeviceAuthState
   onLogin: () => void
+  onBack?: () => void
 }
 
 const formatBalance = (amount: number): string => {
@@ -97,26 +99,24 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
   }
 
   return (
-    <div style={{ padding: "16px" }}>
-      <h2
-        style={{
-          "font-size": "16px",
-          "font-weight": "600",
-          "margin-top": "0",
-          "margin-bottom": "12px",
-          color: "var(--vscode-foreground)",
-        }}
-      >
-        {language.t("profile.title")}
-      </h2>
-
+    <div style={{ display: "flex", "flex-direction": "column", height: "100%" }}>
       <div
         style={{
-          height: "1px",
-          background: "var(--vscode-panel-border)",
-          "margin-bottom": "16px",
+          padding: "12px 16px",
+          "border-bottom": "1px solid var(--border-weak-base)",
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
         }}
-      />
+      >
+        <Tooltip value={language.t("common.goBack")} placement="bottom">
+          <Button variant="ghost" size="small" onClick={() => props.onBack?.()}>
+            <Icon name="arrow-left" />
+          </Button>
+        </Tooltip>
+        <h2 style={{ "font-size": "16px", "font-weight": "600", margin: 0 }}>{language.t("profile.title")}</h2>
+      </div>
+      <div style={{ padding: "16px" }}>
 
       <Show
         when={props.profileData}
@@ -265,6 +265,7 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
           </div>
         )}
       </Show>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #568

## Context

The Profile view had no way to navigate back to the chat interface. Unlike the Settings view which has a back button in its header, the Profile view was missing this navigation, leaving users stuck on the page.

## Implementation

Added an onBack optional prop to ProfileViewProps in ProfileView.tsx. Replaced the existing plain \<h2> title + divider header with a flex header matching the Settings view style — an arrow-left icon button wrapped in a Tooltip, followed by the page title. In App.tsx, passed onBack={() => setCurrentView("newTask")} to the ProfileView component.

No refactoring was needed. The change mirrors the existing pattern used by Settings.tsx exactly.

## Screenshots

| before | after |
| ------ | ----- |
|<img width="809" height="1420" alt="image" src="https://github.com/user-attachments/assets/68c27f3e-f891-4bbf-822b-675772c57361" />|<img width="1013" height="1390" alt="image" src="https://github.com/user-attachments/assets/2b5e5ba1-6247-4304-91c8-bb1d881abfdd" />|

## How to Test

1. Open the Kilo VSCode extension sidebar
2. Click the Profile icon to navigate to the Profile view
3. Verify a ← back button appears in the top-left of the header
4. Click the back button — you should return to the chat (new task) view
5. Confirm the Settings view back button still works as before

## Get in Touch