### PR TITLE
feat: add shell to system prompt environment

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -10,6 +10,7 @@ import PROMPT_GEMINI from "./prompt/gemini.txt"
 import PROMPT_CODEX from "./prompt/codex_header.txt"
 import PROMPT_TRINITY from "./prompt/trinity.txt"
 import type { Provider } from "@/provider/provider"
+import { Shell } from "@/shell/shell"
 
 // kilocode_change start
 import SOUL from "../kilocode/soul.txt"
@@ -46,6 +47,7 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
+        `  Shell: ${Shell.acceptable()}`,
         `  Today's date: ${new Date().toDateString()}`,
         `</env>`,
         `<directories>`,


### PR DESCRIPTION
## Context

This patch adds info about the shell being used, in the environment part of the system prompt.

It should help preventing agents trying to run wrong commands (especially on Windows bash vs. cmd/powershell).

Should fix https://github.com/Kilo-Org/kilocode/issues/6307
