### PR TITLE
docs: migrate Memory Bank docs to AGENTS.md guidance

### DIFF
--- a/packages/kilo-docs/lib/nav/customize.ts
+++ b/packages/kilo-docs/lib/nav/customize.ts
@@ -38,6 +38,10 @@ export const CustomizeNav: NavSection[] = [
         children: "Context Condensing",
       },
       {
+        href: "/customize/context/memory-bank",
+        children: "Memory Bank (Deprecated)",
+      },
+      {
         href: "/customize/context/kilocodeignore",
         children: ".kilocodeignore",
       },

--- a/packages/kilo-docs/pages/customize/agents-md.md
+++ b/packages/kilo-docs/pages/customize/agents-md.md
@@ -16,8 +16,9 @@ Legacy Memory Bank status indicators such as `[Memory Bank: Active]` and `[Memor
 
 If you'd like to migrate your memory bank content to AGENTS.md:
 
-1. Examine the contents in `.kilocode/rules/memory-bank/`
+1. Examine legacy content in `.kilocode/rules/memory-bank/` or `.kilocode/memory-bank/`
 2. Move that content into your project's `AGENTS.md` file (or ask Kilo to do it for you)
+3. Use the [Memory Bank migration guide](/docs/customize/context/memory-bank) for a step-by-step checklist
    {% /callout %}
 
 ## What is AGENTS.md?

--- a/packages/kilo-docs/pages/customize/context/context-condensing.md
+++ b/packages/kilo-docs/pages/customize/context/context-condensing.md
@@ -74,7 +74,7 @@ You can configure context condensing thresholds and behavior on a per-profile ba
 ### Maintaining Context Quality
 
 - **Be specific in your initial task**: A clear task description helps create better summaries
-- **Use AGENTS.md**: Combine with [AGENTS.md](/docs/customize/agents-md) for persistent project context that doesn't need to be condensed
+- **Use AGENTS.md for durable context**: Keep stable project instructions in [agents.md](/docs/customize/agents-md) so they do not depend on session history
 - **Review the summary**: After condensing, the summary is visible in your chat history
 
 ## Troubleshooting
@@ -97,6 +97,7 @@ If the condensed summary doesn't capture important details:
 
 ## Related Features
 
-- [AGENTS.md](/docs/customize/agents-md) - Persistent context storage across sessions
+- [Memory Bank (Deprecated)](/docs/customize/context/memory-bank) - Migration guide for legacy Memory Bank content
+- [agents.md](/docs/customize/agents-md) - Recommended place for durable, cross-tool project instructions
 - [Large Projects](/docs/customize/context/large-projects) - Managing context for large codebases
 - [Codebase Indexing](/docs/customize/context/codebase-indexing) - Efficient code search and retrieval

--- a/packages/kilo-docs/pages/customize/context/memory-bank.md
+++ b/packages/kilo-docs/pages/customize/context/memory-bank.md
@@ -1,0 +1,51 @@
+---
+title: "Memory Bank (Deprecated)"
+description: "Migrate legacy Memory Bank content to AGENTS.md"
+---
+
+# Memory Bank (Deprecated)
+
+Memory Bank has been deprecated in Kilo Code in favor of `AGENTS.md`.
+
+If you already have Memory Bank content, it may still work in some clients, but `AGENTS.md` is now the recommended and portable source of truth.
+
+## Why Migrate to AGENTS.md
+
+- Works across tools (Kilo Code, Cursor, Windsurf, and other `AGENTS.md`-compatible tools)
+- Lives at project root and is easy to version with your code
+- Replaces legacy Memory Bank status behavior that is not guaranteed in all clients/modes
+
+## Migration Steps
+
+1. Locate your existing Memory Bank notes in one of these legacy locations:
+   - `.kilocode/rules/memory-bank/`
+   - `.kilocode/memory-bank/`
+2. Create or open `AGENTS.md` in your project root.
+3. Copy the rules and project context you still want into clearly named sections in `AGENTS.md`.
+4. Keep mode-specific rules in `.kilocode/rules/` when needed, and put cross-tool guidance in `AGENTS.md`.
+5. Remove or archive old Memory Bank files after validating the new behavior.
+
+## Suggested AGENTS.md Structure
+
+```markdown
+# Project Overview
+- What this repo does
+
+## Coding Standards
+- Language/style conventions
+
+## Architecture
+- Key boundaries and patterns
+
+## Testing
+- Required commands and coverage expectations
+
+## Constraints
+- Security, performance, and deployment requirements
+```
+
+## Related Docs
+
+- [agents.md](/docs/customize/agents-md)
+- [Custom Rules](/docs/customize/custom-rules)
+- [Migrating from Cursor or Windsurf](/docs/getting-started/migrating)

--- a/packages/kilo-docs/pages/customize/index.md
+++ b/packages/kilo-docs/pages/customize/index.md
@@ -27,7 +27,7 @@ Help Kilo understand your codebase better:
 
 - [**Codebase Indexing**](/docs/customize/context/codebase-indexing) - Build a semantic index of your code for better context awareness
 - [**Context Condensing**](/docs/customize/context/context-condensing) - Summarize older context to stay within limits
-- [**AGENTS.md**](/docs/customize/agents-md) - Store project context, decisions, and important information
+- [**Memory Bank (Deprecated)**](/docs/customize/context/memory-bank) - Migrate legacy memory notes to `AGENTS.md`
 - [**Large Projects**](/docs/customize/context/large-projects) - Best practices for working with monorepos and large codebases
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- add a dedicated Memory Bank (Deprecated) docs page with migration steps to AGENTS.md
- wire the page into Customize nav so the legacy link resolves
- update customization overview and context condensing docs to point users toward AGENTS.md-first guidance
- update gents.md page with explicit legacy Memory Bank paths and migration-guide link

## Why
Issue Kilo-Org/kilocode#6091 asks for Memory Bank migration guidance now that Memory Bank is deprecated.

Closes Kilo-Org/kilocode#6091