### PR TITLE
fix(tui): keep prompt left border continuous in small terminals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -807,7 +807,7 @@ export function Prompt(props: PromptProps) {
           customBorderChars={{
             ...EmptyBorder,
             vertical: "┃",
-            bottomLeft: "╹",
+            bottomLeft: "┃", // kilocode_change
           }}
         >
           <box
@@ -1038,7 +1038,7 @@ export function Prompt(props: PromptProps) {
           borderColor={highlight()}
           customBorderChars={{
             ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
+            vertical: theme.backgroundElement.a !== 0 ? "┃" : " ", // kilocode_change
           }}
         >
           <box


### PR DESCRIPTION
## Summary
- update prompt border glyphs to avoid the segmented left bar in height-constrained terminals
- use a full-height vertical glyph for both the prompt border end cap and the 1-line separator border

## Why
Issue Kilo-Org/kilocode#6309 reports that the vertical bar near the input field appears split in small terminal windows (for example 80x24).

This change keeps the left border visually continuous regardless of terminal height.

Closes Kilo-Org/kilocode#6309