### PR TITLE
feat: allow custom tools to send stop flag in metadata

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -36,6 +36,7 @@ export namespace SessionProcessor {
     let attempt = 0
     let needsCompaction = false
     let stepStart = 0 // kilocode_change
+    let shouldStopAfterTool = false
 
     const result = {
       get message() {
@@ -189,6 +190,10 @@ export namespace SessionProcessor {
                         attachments: value.output.attachments,
                       },
                     })
+
+                    if (value.output.metadata?.stop === true) {
+                      shouldStopAfterTool = true
+                    }
 
                     delete toolcalls[value.toolCallId]
                   }
@@ -358,6 +363,7 @@ export namespace SessionProcessor {
                   continue
               }
               if (needsCompaction) break
+              if (shouldStopAfterTool) break
             }
           } catch (e: any) {
             log.error("process", {
@@ -424,6 +430,7 @@ export namespace SessionProcessor {
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"
+          if (shouldStopAfterTool) return "stop"
           return "continue"
         }
       },

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -78,13 +78,14 @@ export namespace ToolRegistry {
               metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
             }
           }
-          const res = result as { title?: string; output: string; metadata?: { [key: string]: any } }
-          const out = await Truncate.output(res.output, {}, initCtx?.agent)
+          if (typeof result !== "object" || result === null || !("output" in result))
+            throw new Error(`Tool ${id} returned unexpected value: ${typeof result}`)
+          const out = await Truncate.output(result.output, {}, initCtx?.agent)
           return {
-            title: res.title ?? id,
-            output: out.truncated ? out.content : res.output,
+            title: result.title ?? id,
+            output: out.truncated ? out.content : result.output,
             metadata: {
-              ...(res.metadata ?? {}),
+              ...(result.metadata ?? {}),
               truncated: out.truncated,
               outputPath: out.truncated ? out.outputPath : undefined,
             },

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -70,11 +70,24 @@ export namespace ToolRegistry {
             worktree: Instance.worktree,
           } as unknown as PluginToolContext
           const result = await def.execute(args as any, pluginCtx)
-          const out = await Truncate.output(result, {}, initCtx?.agent)
+          if (typeof result === "string") {
+            const out = await Truncate.output(result, {}, initCtx?.agent)
+            return {
+              title: id,
+              output: out.truncated ? out.content : result,
+              metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
+            }
+          }
+          const res = result as { title?: string; output: string; metadata?: { [key: string]: any } }
+          const out = await Truncate.output(res.output, {}, initCtx?.agent)
           return {
-            title: "",
-            output: out.truncated ? out.content : result,
-            metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
+            title: res.title ?? id,
+            output: out.truncated ? out.content : res.output,
+            metadata: {
+              ...(res.metadata ?? {}),
+              truncated: out.truncated,
+              outputPath: out.truncated ? out.outputPath : undefined,
+            },
           }
         },
       }),

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -26,10 +26,12 @@ type AskInput = {
   metadata: { [key: string]: any }
 }
 
+export type ToolResult = string | { title?: string; output: string; metadata?: Record<string, any> }
+
 export function tool<Args extends z.ZodRawShape>(input: {
   description: string
   args: Args
-  execute(args: z.infer<z.ZodObject<Args>>, context: ToolContext): Promise<string>
+  execute(args: z.infer<z.ZodObject<Args>>, context: ToolContext): Promise<ToolResult>
 }) {
   return input
 }


### PR DESCRIPTION
Fixes https://github.com/Kilo-Org/kilocode/issues/6289

## Context

Allow tools to stop the agent loop via metadata.

Example tool that needs this feature: https://github.com/pschiel/kilo-config/blob/master/tool/speak.ts
(TTS speaker summary as final assistant action, must stop the agent loop)

## Implementation

- Tools can now return a structured result `{ title?, output, metadata? }` in addition to a plain string.
- When a tool sets `metadata.stop = true`, the session processor halts after that tool completes instead of triggering another LLM turn.
