### PR TITLE
fix: use kilo.exe as binary name on win32

### DIFF
--- a/packages/kilo-vscode/script/local-bin.ts
+++ b/packages/kilo-vscode/script/local-bin.ts
@@ -22,7 +22,8 @@ const packagesDir = join(kiloVscodeDir, "..")
 const opencodeDir = join(packagesDir, "opencode")
 
 const targetBinDir = join(kiloVscodeDir, "bin")
-const targetBinPath = join(targetBinDir, "kilo")
+const binName = process.platform === "win32" ? "kilo.exe" : "kilo"
+const targetBinPath = join(targetBinDir, binName)
 
 function log(msg: string) {
   console.log(`[local-bin] ${msg}`)
@@ -44,7 +45,7 @@ async function findKiloBinaryInOpencodeDist(): Promise<string | null> {
 
   // Prefer the binary matching the current platform (e.g. cli-darwin-arm64)
   const tag = platformTag()
-  const preferred = join(distDir, `@kilocode`, tag, "bin", "kilo")
+  const preferred = join(distDir, `@kilocode`, tag, "bin", binName)
   try {
     statSync(preferred)
     return preferred
@@ -52,7 +53,7 @@ async function findKiloBinaryInOpencodeDist(): Promise<string | null> {
     // fall through to generic search
   }
 
-  // Fallback: find any dist/**/bin/kilo
+  // Fallback: find any dist/**/bin/kilo or kilo.exe
   const queue = [distDir]
   while (queue.length) {
     const dir = queue.pop()
@@ -71,7 +72,7 @@ async function findKiloBinaryInOpencodeDist(): Promise<string | null> {
         queue.push(p)
         continue
       }
-      if (e.isFile() && e.name === "kilo" && basename(dirname(p)) === "bin") {
+      if (e.isFile() && (e.name === "kilo" || e.name === "kilo.exe") && basename(dirname(p)) === "bin") {
         return p
       }
     }

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -129,7 +129,8 @@ export class ServerManager {
 
   private getCliPath(): string {
     // Always use the bundled binary from the extension directory
-    const cliPath = path.join(this.context.extensionPath, "bin", "kilo")
+    const binName = process.platform === "win32" ? "kilo.exe" : "kilo" // kilocode_change
+    const cliPath = path.join(this.context.extensionPath, "bin", binName)
     console.log("[Kilo New] ServerManager: 📦 Using CLI path:", cliPath)
     return cliPath
   }


### PR DESCRIPTION
Fixes https://github.com/Kilo-Org/kilo/issues/583

## Context

Adds win32 platform checks so the correct binary (`kilo.exe` vs `kilo`) is used

Issues see https://github.com/Kilo-Org/kilo/issues/583

## Test

After applying patch and
```bash
cd packages/kilo-vscode
bun run package
npx @vscode/vsce package --no-dependencies
code --install-extension kilo-code-*.vsix
```
CLI spawns and functionality is available