### PR TITLE
fix(vscode): add back button to ProfileView

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -171,6 +171,7 @@ const AppContent: Component = () => {
             profileData={server.profileData()}
             deviceAuth={server.deviceAuth()}
             onLogin={server.startLogin}
+            onBack={() => setCurrentView("newTask")}
           />
         </Match>
         <Match when={currentView() === "settings"}>

--- a/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
@@ -1,6 +1,7 @@
 import { Component, Show, createSignal, createMemo, createEffect, onMount } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Card } from "@kilocode/kilo-ui/card"
+import { Icon } from "@kilocode/kilo-ui/icon"
 import { Select } from "@kilocode/kilo-ui/select"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useVSCode } from "../context/vscode"
@@ -14,6 +15,7 @@ export interface ProfileViewProps {
   profileData: ProfileData | null | undefined
   deviceAuth: DeviceAuthState
   onLogin: () => void
+  onBack?: () => void
 }
 
 const formatBalance = (amount: number): string => {
@@ -97,26 +99,26 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
   }
 
   return (
-    <div style={{ padding: "16px" }}>
-      <h2
-        style={{
-          "font-size": "16px",
-          "font-weight": "600",
-          "margin-top": "0",
-          "margin-bottom": "12px",
-          color: "var(--vscode-foreground)",
-        }}
-      >
-        {language.t("profile.title")}
-      </h2>
-
+    <div style={{ display: "flex", "flex-direction": "column", height: "100%" }}>
+      {/* Header with back button */}
       <div
         style={{
-          height: "1px",
-          background: "var(--vscode-panel-border)",
-          "margin-bottom": "16px",
+          padding: "12px 16px",
+          "border-bottom": "1px solid var(--border-weak-base)",
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
         }}
-      />
+      >
+        <Tooltip value={language.t("common.goBack")} placement="bottom">
+          <Button variant="ghost" size="small" onClick={() => props.onBack?.()}>
+            <Icon name="arrow-left" />
+          </Button>
+        </Tooltip>
+        <h2 style={{ "font-size": "16px", "font-weight": "600", margin: 0 }}>{language.t("profile.title")}</h2>
+      </div>
+
+      <div style={{ padding: "16px", flex: 1, overflow: "auto" }}>
 
       <Show
         when={props.profileData}
@@ -265,6 +267,7 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
           </div>
         )}
       </Show>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Add a back button header to `ProfileView` matching the existing `Settings` component pattern
- Wire up `onBack` callback in `App.tsx` to navigate back to the chat view (`"newTask"`)
- The `onBack` prop is optional to maintain backward compatibility

Closes #568

## Test plan

- [ ] Open ProfileView in the VSCode extension
- [ ] Verify the back button appears in the header
- [ ] Click the back button and verify navigation returns to the chat view
- [ ] Verify Settings back button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)