### PR TITLE
fix(mcp): persist toggle state to config file

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -549,6 +549,7 @@ export namespace MCP {
       }
       s.clients[name] = result.mcpClient
     }
+    await Config.update({ mcp: { [name]: { enabled: true } } })
   }
 
   export async function disconnect(name: string) {
@@ -561,6 +562,7 @@ export namespace MCP {
       delete s.clients[name]
     }
     s.status[name] = { status: "disabled" }
+    await Config.update({ mcp: { [name]: { enabled: false } } })
   }
 
   export async function tools() {


### PR DESCRIPTION
## Summary

- Persist MCP server enabled/disabled state to config file when using `connect()`/`disconnect()` functions
- Uses `Config.update()` with partial MCP config (`{ enabled: true/false }`) to avoid overwriting other settings
- 2 lines added — one in `connect()`, one in `disconnect()`

Closes Kilo-Org/kilocode#6292

## Test plan

- [ ] Toggle an MCP server off via the TUI/CLI
- [ ] Restart the application
- [ ] Verify the MCP server remains disabled after restart
- [ ] Toggle it back on and restart — verify it stays enabled
- [ ] Verify the config file (`config.json`) contains `"enabled": false/true` for the toggled MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)