### PR TITLE
fix: show full path in read/list tool permission dialogs

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -188,13 +188,13 @@ export function getToolInfo(tool: string, input: any = {}): ToolInfo {
       return {
         icon: "glasses",
         title: i18n.t("ui.tool.read"),
-        subtitle: input.filePath ? getFilename(input.filePath) : undefined,
+        subtitle: input.filePath, // kilocode_change
       }
     case "list":
       return {
         icon: "bullet-list",
         title: i18n.t("ui.tool.list"),
-        subtitle: input.path ? getFilename(input.path) : undefined,
+        subtitle: input.path, // kilocode_change
       }
     case "glob":
       return {
@@ -759,6 +759,9 @@ ToolRegistry.register({
       if (!value || !Array.isArray(value)) return []
       return value.filter((p): p is string => typeof p === "string")
     })
+    // kilocode_change start
+    const subtitle = () => relativizeProjectPaths(props.input.filePath ?? "", data.directory)
+    // kilocode_change end
     return (
       <>
         <BasicTool
@@ -766,7 +769,7 @@ ToolRegistry.register({
           icon="glasses"
           trigger={{
             title: i18n.t("ui.tool.read"),
-            subtitle: props.input.filePath ? getFilename(props.input.filePath) : "",
+            subtitle: subtitle(), // kilocode_change
             args,
           }}
           // kilocode_change start
@@ -797,13 +800,13 @@ ToolRegistry.register({
 ToolRegistry.register({
   name: "list",
   render(props) {
+    const data = useData()
     const i18n = useI18n()
+    // kilocode_change start
+    const subtitle = () => relativizeProjectPaths(props.input.path ?? "", data.directory)
+    // kilocode_change end
     return (
-      <BasicTool
-        {...props}
-        icon="bullet-list"
-        trigger={{ title: i18n.t("ui.tool.list"), subtitle: getDirectory(props.input.path || "/") }}
-      >
+      <BasicTool {...props} icon="bullet-list" trigger={{ title: i18n.t("ui.tool.list"), subtitle: subtitle() }}>
         <Show when={props.output}>
           {(output) => (
             <div data-component="tool-output" data-scrollable>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -188,13 +188,13 @@ export function getToolInfo(tool: string, input: any = {}): ToolInfo {
       return {
         icon: "glasses",
         title: i18n.t("ui.tool.read"),
-        subtitle: input.filePath, // kilocode_change
+        subtitle: input.filePath ? getFilename(input.filePath) : undefined,
       }
     case "list":
       return {
         icon: "bullet-list",
         title: i18n.t("ui.tool.list"),
-        subtitle: input.path, // kilocode_change
+        subtitle: input.path ? getFilename(input.path) : undefined,
       }
     case "glob":
       return {


### PR DESCRIPTION
## Context

Fixes Kilo-Org/kilocode#6092. After the streamlining of approval boxes into inline tool-part permission prompts, the read and list tools only showed the filename (e.g. `text.txt`) instead of the full path. This made it impossible to tell where a file was located, especially for files outside the workspace.

## Implementation

Changed the `read` and `list` tool renderers in `packages/ui/src/components/message-part.tsx` to use `relativizeProjectPaths()` instead of `getFilename()` for the subtitle:

- **Project files** show a relative path (e.g. `src/components/foo.tsx`) since the project directory prefix is stripped
- **External files** show the full absolute path (e.g. `/var/home/thomasbrugman/text.txt`) since there's no project prefix to strip

Also updated `getToolInfo()` (used in task child tool summaries) to show the full path instead of just the filename for `read` and `list` entries.

The change is minimal — only the subtitle computation changes, keeping the clean single-line `{title, subtitle}` trigger format.

## Screenshots

**Before** — only the filename is shown, no context about where the file lives:

<img width="984" height="271" alt="image" src="https://github.com/user-attachments/assets/5cb6d8bc-2524-44b9-9231-94d551b642f8" />

**After** — the full path is shown for files outside the workspace:

<img width="690" height="301" alt="Schermafdruk van 2026-02-22 12-03-46" src="https://github.com/user-attachments/assets/18cda47e-24a8-4568-9638-17f1c6b19f2d" />

## How to Test

1. Start a session and ask the agent to read a file **outside** the workspace (e.g. a file in your home directory)
2. When the permission dialog appears, verify the full path is shown in the tool part subtitle
3. Also verify that files **inside** the project still show relative paths (e.g. `src/foo.ts` not the full absolute path)

## Get in Touch

thomas07374