### PR TITLE
fix: use taskkill on Windows to ensure LSP server process is killed p…

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -240,7 +240,13 @@ export namespace LSPClient {
         l.info("shutting down")
         connection.end()
         connection.dispose()
-        input.server.process.kill()
+        const pid = input.server.process.pid
+        if (process.platform === "win32" && pid) {
+          // On Windows, kill() is unreliable — use taskkill /F /T to force-kill the entire process tree
+          Bun.spawnSync(["taskkill", "/F", "/T", "/PID", String(pid)], { stderr: "pipe", stdout: "pipe" })
+        } else {
+          input.server.process.kill()
+        }
         l.info("shutdown")
       },
     }


### PR DESCRIPTION
Fixes https://github.com/Kilo-Org/kilocode/issues/6287


## Summary

On Windows, after LSP usage (e.g. biome) and exiting Kilo CLI, the LSP server processes don't get killed and survive as zombies.

This will cause Kilo to hang on the next startup, unless the entire terminal is restarted or the processes killed manually.

## Problem

`ChildProcess.kill()` sends `SIGTERM`, which Windows processes ignore (see https://nodejs.org/api/child_process.html#subprocesskillsignal).

Additionally, biome lsp-proxy spawns its own child processes, so even if the parent was killed, the children remained as zombies.

## Tested

1. `client.ts` was calling `input.server.process.kill()` (which sends `SIGTERM`)
2. After exiting Kilo, biome.exe processes were still visible in Task Manager
3. The log showed shutdown complete - so the code ran, but the processes survived
4. Switching to `taskkill /F /T /PID` - `biome.exe` processes were gone from Task Manager after exit

## Proposed fix

On Windows, replace `process.kill()` in `LSPClient.shutdown()` with `taskkill /F /T /PID <pid>`:
- `/F` - force kill (equivalent of `SIGKILL`)
- `/T` - terminate the entire process tree, not just the parent
 
This ensures all LSP subprocess children are cleaned up on exit, preventing zombie processes that block the next startup.
