### PR TITLE
docs: add issue template compliance guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,10 +72,126 @@ kilo web             # Start server + open web interface
 
 ### Pull Request Expectations
 
-- **Issue First Policy:** All PRs must reference an existing issue.
-- **UI Changes:** Include screenshots or videos (before/after).
-- **Logic Changes:** Explain how you verified it works.
-- **PR Titles:** Follow conventional commit standards (`feat:`, `fix:`, `docs:`, etc.).
+- All PRs must reference an existing issue.
+- UI changes must include screenshots or videos (before/after).
+- Logic changes must explain how the change was verified.
+- PR titles must follow conventional commit style (`feat:`, `fix:`, `docs:`, etc.).
+
+## Issue First Policy
+
+Every pull request must be tied to an existing issue. Include the issue number in the PR body using one of these keywords so GitHub auto-links it:
+
+- `Fixes #123`
+- `Closes #123`
+- `Resolves #123`
+
+If no issue exists yet, create one first.
+
+## PR Titles
+
+Use a conventional commit prefix in PR titles:
+
+- `feat:` for a new feature
+- `fix:` for a bug fix
+- `docs:` for documentation-only changes
+- `refactor:` for code restructuring without behavior change
+- `test:` for tests
+- `chore:` for maintenance tasks
+
+Examples:
+
+- `fix: add back button to profile view`
+- `docs: add release asset selection guide`
+
+## Issue Template Compliance (CLI and API)
+
+GitHub Issue Forms enforce required fields in the web UI, but `gh issue create` and API-created issues can bypass that form validation. The compliance bot checks for required structure and may auto-close non-compliant issues after about 2 hours.
+
+When creating issues from CLI/API, include the required headings and content exactly as below.
+
+### Bug Report Required Fields
+
+Required:
+
+- `### Description` with a clear problem statement
+
+Recommended (helps triage faster):
+
+- `### Plugins`
+- `### Kilo version`
+- `### Steps to reproduce`
+- `### Screenshot and/or share link`
+- `### Operating System`
+- `### Terminal`
+
+CLI example:
+
+```bash
+cat > bug-issue.md <<'EOF'
+### Description
+The profile page has no back button, so users cannot return to chat.
+
+### Plugins
+None
+
+### Kilo version
+1.0.25
+
+### Steps to reproduce
+1. Open Kilo
+2. Open Profile
+3. Observe no back button
+
+### Screenshot and/or share link
+N/A
+
+### Operating System
+Windows 11
+
+### Terminal
+Windows Terminal
+EOF
+
+gh issue create --repo Kilo-Org/kilo --title "[BUG] Profile page missing back button" --body-file bug-issue.md
+```
+
+### Feature Request Required Fields
+
+Required:
+
+- `### Feature hasn't been suggested before.` with the verification checkbox line
+- `### Describe the enhancement you want to request`
+
+CLI example:
+
+```bash
+cat > feature-issue.md <<'EOF'
+### Feature hasn't been suggested before.
+- [x] I have verified this feature I'm about to request hasn't been suggested before.
+
+### Describe the enhancement you want to request
+Add release asset naming guidance to the README for new users.
+EOF
+
+gh issue create --repo Kilo-Org/kilo --title "[FEATURE]: Clarify release asset naming in README" --body-file feature-issue.md
+```
+
+### Question Required Fields
+
+Required:
+
+- `### Question`
+
+CLI example:
+
+```bash
+cat > question-issue.md <<'EOF'
+### Question
+Is there a recommended way to run Kilo in CI with non-interactive approvals?
+EOF
+
+gh issue create --repo Kilo-Org/kilo --title "Question: CI mode recommendations" --body-file question-issue.md
+```
 
 ### Style Preferences
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Examples:
 
 ## Issue Template Compliance (CLI and API)
 
-GitHub Issue Forms enforce required fields in the web UI, but `gh issue create` and API-created issues can bypass that form validation. The compliance bot checks for required structure and may auto-close non-compliant issues after about 2 hours.
+GitHub Issue Forms enforce required fields in the web UI, but `gh issue create` and issues created through the API can bypass that form validation. The compliance bot checks for required structure and may auto-close non-compliant issues after about 2 hours.
 
 When creating issues from CLI/API, include the required headings and content exactly as below.
 


### PR DESCRIPTION
## Summary\n- document required fields for issue templates when using CLI/API\n- add missing CONTRIBUTING anchors for Issue First Policy and PR Titles\n- include compliant gh CLI issue creation examples for bug reports, feature requests, and questions\n\n## Testing\n- docs-only change\n\nFixes Kilo-Org/kilocode#6290