### PR TITLE
fix(vscode): add back button to profile view header

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -171,6 +171,7 @@ const AppContent: Component = () => {
             profileData={server.profileData()}
             deviceAuth={server.deviceAuth()}
             onLogin={server.startLogin}
+            onBack={() => setCurrentView("newTask")}
           />
         </Match>
         <Match when={currentView() === "settings"}>

--- a/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
@@ -1,6 +1,7 @@
 import { Component, Show, createSignal, createMemo, createEffect, onMount } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Card } from "@kilocode/kilo-ui/card"
+import { Icon } from "@kilocode/kilo-ui/icon"
 import { Select } from "@kilocode/kilo-ui/select"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useVSCode } from "../context/vscode"
@@ -14,6 +15,7 @@ export interface ProfileViewProps {
   profileData: ProfileData | null | undefined
   deviceAuth: DeviceAuthState
   onLogin: () => void
+  onBack?: () => void
 }
 
 const formatBalance = (amount: number): string => {
@@ -97,27 +99,24 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
   }
 
   return (
-    <div style={{ padding: "16px" }}>
-      <h2
-        style={{
-          "font-size": "16px",
-          "font-weight": "600",
-          "margin-top": "0",
-          "margin-bottom": "12px",
-          color: "var(--vscode-foreground)",
-        }}
-      >
-        {language.t("profile.title")}
-      </h2>
-
+    <div style={{ display: "flex", "flex-direction": "column", height: "100%" }}>
       <div
         style={{
-          height: "1px",
-          background: "var(--vscode-panel-border)",
-          "margin-bottom": "16px",
+          padding: "12px 16px",
+          "border-bottom": "1px solid var(--border-weak-base)",
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
         }}
-      />
-
+      >
+        <Tooltip value={language.t("common.goBack")} placement="bottom">
+          <Button variant="ghost" size="small" onClick={() => props.onBack?.()}>
+            <Icon name="arrow-left" />
+          </Button>
+        </Tooltip>
+        <h2 style={{ "font-size": "16px", "font-weight": "600", margin: 0 }}>{language.t("profile.title")}</h2>
+      </div>
+      <div style={{ padding: "16px" }}>
       <Show
         when={props.profileData}
         fallback={
@@ -265,6 +264,7 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
           </div>
         )}
       </Show>
+      </div>
     </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/ProfileView.tsx
@@ -117,43 +117,43 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
         <h2 style={{ "font-size": "16px", "font-weight": "600", margin: 0 }}>{language.t("profile.title")}</h2>
       </div>
       <div style={{ padding: "16px" }}>
-      <Show
-        when={props.profileData}
-        fallback={
-          <div style={{ display: "flex", "flex-direction": "column", gap: "12px" }}>
-            <Show
-              when={props.deviceAuth.status !== "idle"}
-              fallback={
-                <>
-                  <p
-                    style={{
-                      "font-size": "13px",
-                      color: "var(--vscode-descriptionForeground)",
-                      margin: "0 0 8px 0",
-                    }}
-                  >
-                    {language.t("profile.notLoggedIn")}
-                  </p>
-                  <Button variant="primary" onClick={handleLogin}>
-                    {language.t("profile.action.login")}
-                  </Button>
-                </>
-              }
-            >
-              <DeviceAuthCard
-                status={props.deviceAuth.status}
-                code={props.deviceAuth.code}
-                verificationUrl={props.deviceAuth.verificationUrl}
-                expiresIn={props.deviceAuth.expiresIn}
-                error={props.deviceAuth.error}
-                onCancel={handleCancelLogin}
-                onRetry={handleLogin}
-              />
-            </Show>
-          </div>
-        }
-      >
-        {(data) => (
+        <Show
+          when={props.profileData}
+          fallback={
+            <div style={{ display: "flex", "flex-direction": "column", gap: "12px" }}>
+              <Show
+                when={props.deviceAuth.status !== "idle"}
+                fallback={
+                  <>
+                    <p
+                      style={{
+                        "font-size": "13px",
+                        color: "var(--vscode-descriptionForeground)",
+                        margin: "0 0 8px 0",
+                      }}
+                    >
+                      {language.t("profile.notLoggedIn")}
+                    </p>
+                    <Button variant="primary" onClick={handleLogin}>
+                      {language.t("profile.action.login")}
+                    </Button>
+                  </>
+                }
+              >
+                <DeviceAuthCard
+                  status={props.deviceAuth.status}
+                  code={props.deviceAuth.code}
+                  verificationUrl={props.deviceAuth.verificationUrl}
+                  expiresIn={props.deviceAuth.expiresIn}
+                  error={props.deviceAuth.error}
+                  onCancel={handleCancelLogin}
+                  onRetry={handleLogin}
+                />
+              </Show>
+            </div>
+          }
+        >
+          {(data) => (
           <div style={{ display: "flex", "flex-direction": "column", gap: "12px" }}>
             {/* User header */}
             <Card>
@@ -263,7 +263,7 @@ const ProfileView: Component<ProfileViewProps> = (props) => {
             </div>
           </div>
         )}
-      </Show>
+        </Show>
       </div>
     </div>
   )


### PR DESCRIPTION
## Linked Issue\nCloses Kilo-Org/kilo#568\n\n## Summary\n- add a back button to the Profile view header using the same UX pattern as Settings\n- wire Profile view back action to return users to the chat view\n- keep existing profile content unchanged\n\n## Testing\n- unable to run package checks in this environment (bun not installed)