### PR TITLE
fix(tui): keep prompt border continuous in compact terminals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -807,7 +807,7 @@ export function Prompt(props: PromptProps) {
           customBorderChars={{
             ...EmptyBorder,
             vertical: "┃",
-            bottomLeft: "┃", // kilocode_change
+            bottomLeft: "┃",
           }}
         >
           <box
@@ -1038,7 +1038,7 @@ export function Prompt(props: PromptProps) {
           borderColor={highlight()}
           customBorderChars={{
             ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "┃" : " ", // kilocode_change
+            vertical: theme.backgroundElement.a !== 0 ? "┃" : " ",
           }}
         >
           <box

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -807,7 +807,7 @@ export function Prompt(props: PromptProps) {
           customBorderChars={{
             ...EmptyBorder,
             vertical: "┃",
-            bottomLeft: "╹",
+            bottomLeft: "┃", // kilocode_change
           }}
         >
           <box
@@ -1038,7 +1038,7 @@ export function Prompt(props: PromptProps) {
           borderColor={highlight()}
           customBorderChars={{
             ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
+            vertical: theme.backgroundElement.a !== 0 ? "┃" : " ", // kilocode_change
           }}
         >
           <box


### PR DESCRIPTION
## Linked Issue\nCloses Kilo-Org/kilocode#6309\n\n## Summary\n- use a continuous vertical border glyph at the prompt bottom-left corner\n- align the 1-row separator segment with the same border glyph when background elements are enabled\n- prevent the visual split seen in small terminal sizes\n\n## Testing\n- not run (visual TUI rendering fix)