### PR TITLE
feat(cli): add optional cwd argument to serve

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -14,14 +14,16 @@ export const ServeCommand = cmd({
     }),
   describe: "starts a headless kilo server", // kilocode_change
   handler: async (args) => {
-    const baseCwd = process.env.PWD ?? process.cwd()
-    const cwd = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
-    try {
-      process.chdir(cwd)
-    } catch {
-      console.error(`Failed to change directory to ${cwd}`)
-      process.exitCode = 1
-      return
+    if (args.project) {
+      const cwd = path.resolve(args.project)
+      try {
+        process.chdir(cwd)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "unknown error"
+        console.error(`Failed to change directory to ${cwd}: ${message}`)
+        process.exitCode = 1
+        return
+      }
     }
 
     if (!Flag.KILO_SERVER_PASSWORD) {

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -3,12 +3,27 @@ import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 import { Instance } from "../../project/instance" // kilocode_change
+import path from "path"
 
 export const ServeCommand = cmd({
-  command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  command: "serve [project]",
+  builder: (yargs) =>
+    withNetworkOptions(yargs).positional("project", {
+      type: "string",
+      describe: "path to start kilo server in", // kilocode_change
+    }),
   describe: "starts a headless kilo server", // kilocode_change
   handler: async (args) => {
+    const baseCwd = process.env.PWD ?? process.cwd()
+    const cwd = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
+    try {
+      process.chdir(cwd)
+    } catch {
+      console.error(`Failed to change directory to ${cwd}`)
+      process.exitCode = 1
+      return
+    }
+
     if (!Flag.KILO_SERVER_PASSWORD) {
       console.log("Warning: KILO_SERVER_PASSWORD is not set; server is unsecured.")
     }


### PR DESCRIPTION
## Summary
- add an optional positional project path to kilo serve
- resolve relative paths from current shell working directory
- change into the target directory before booting the server, with clear error handling when the path is invalid

Fixes Kilo-Org/kilocode#6330