### PR TITLE
fix(locale): prevent titlecase crash on missing session values

### DIFF
--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -1,5 +1,6 @@
 export namespace Locale {
-  export function titlecase(str: string) {
+  export function titlecase(str?: string | null) {
+    if (!str) return ""
     return str.replace(/\b\w/g, (c) => c.toUpperCase())
   }
 


### PR DESCRIPTION
## Summary
- make Locale.titlecase safely handle undefined and 
ull values
- return an empty string for missing input instead of throwing at eplace
- prevent session loading/rendering crashes caused by legacy or incomplete message fields

Fixes Kilo-Org/kilocode#6319