### PR TITLE
fix(tui/win32): clear queued mouse input on Ctrl+C exit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -121,6 +121,8 @@ export function win32InstallCtrlCGuard() {
       stdin.setRawMode = original
     }
 
+    // Drop any queued mouse/key events before restoring normal input mode.
+    k32!.symbols.FlushConsoleInputBuffer(handle)
     k32!.symbols.SetConsoleMode(handle, initial)
     unhook = undefined
   }


### PR DESCRIPTION
## Summary
- flush Windows console input buffer when the Ctrl+C guard unhooks
- ensure queued mouse events do not spill into the terminal after Kilo exits
- preserve existing console mode restoration behavior

Fixes Kilo-Org/kilocode#6328