### PR TITLE
fix(tui): terminate cleanly when terminal closes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -128,11 +128,18 @@ export const TuiThreadCommand = cmd({
         await client.call("reload", undefined)
       })
       // kilocode_change start - graceful shutdown on external signals
+      let shuttingDown = false
       const shutdown = async () => {
+        if (shuttingDown) return
+        shuttingDown = true
         await client.call("shutdown", undefined).catch(() => {})
       }
-      process.on("SIGHUP", shutdown)
-      process.on("SIGTERM", shutdown)
+      process.once("SIGHUP", shutdown)
+      process.once("SIGTERM", shutdown)
+      process.once("SIGINT", shutdown)
+      process.once("disconnect", shutdown)
+      process.stdin.once("end", shutdown)
+      process.stdin.once("close", shutdown)
       // kilocode_change end
 
       const prompt = await iife(async () => {


### PR DESCRIPTION
## Summary
- add one-shot shutdown hooks for SIGINT/SIGHUP/SIGTERM and parent disconnect
- trigger shutdown when stdin closes/ends (common when VS Code terminal is closed)
- guard shutdown to run only once and avoid duplicate RPC calls

Fixes Kilo-Org/kilocode#6324